### PR TITLE
Make gpscfg receiver detection protocol-agnostic

### DIFF
--- a/internal/gpscfg/gpscfg.go
+++ b/internal/gpscfg/gpscfg.go
@@ -7,14 +7,13 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/jclark/satpulse/internal/gpsio"
 	"github.com/jclark/satpulse/internal/gpsprot"
 	"github.com/jclark/satpulse/internal/nmea"
-	"github.com/jclark/satpulse/internal/rtcm"
 	"github.com/jclark/satpulse/internal/scan"
-	"github.com/jclark/satpulse/internal/ubx"
 	"golang.org/x/exp/maps"
 )
 
@@ -189,8 +188,8 @@ func (mh *msgHandler) detect(ctx context.Context) error {
 		var msg string
 		if mh.bad.framingErrs > 0 {
 			msg = "framing errors reading GPS output (wrong speed?)"
-		} else if mh.msgCount[rtcm.Tag] > 0 {
-			msg = "only RTCM messages detected from GPS"
+		} else if nativeOnly := mh.nativeOnlyTags(); len(nativeOnly) > 0 {
+			msg = fmt.Sprintf("only messages with these protocols detected: %s", strings.Join(nativeOnly, ", "))
 		} else if mh.bad.invalidBytes+mh.bad.corruptMsgs == 0 {
 			msg = "no output detected from GPS"
 		} else if mh.bad.corruptMsgs > 0 {
@@ -198,7 +197,7 @@ func (mh *msgHandler) detect(ctx context.Context) error {
 		} else {
 			msg = "cannot parse GPS output"
 		}
-		lg.Debug("not receiving data from GPS correctly", "bad", mh.bad, "rtcmMsgCount", mh.msgCount[rtcm.Tag])
+		lg.Debug("not receiving data from GPS correctly", "bad", mh.bad, "nativeOnlyTags", mh.nativeOnlyTags())
 		return errors.New(msg)
 	}
 	lg.Info("detected a GPS")
@@ -405,7 +404,25 @@ loop:
 }
 
 func (mh *msgHandler) suitableMessageCount() int {
-	return mh.msgCount[ubx.Tag] + mh.msgCount[nmea.Tag]
+	count := 0
+	for tag, msgCount := range mh.msgCount {
+		if pp, ok := mh.packetProcs[tag]; ok && !pp.NativeOnly() {
+			count += msgCount
+		}
+	}
+	return count
+}
+
+func (mh *msgHandler) nativeOnlyTags() []string {
+	var tags []string
+	for tag, msgCount := range mh.msgCount {
+		if msgCount > 0 {
+			if pp, ok := mh.packetProcs[tag]; ok && pp.NativeOnly() {
+				tags = append(tags, string(tag))
+			}
+		}
+	}
+	return tags
 }
 
 func (mh *msgHandler) totalMsgCount() int {

--- a/internal/gpscfg/gpscfg_test.go
+++ b/internal/gpscfg/gpscfg_test.go
@@ -1,0 +1,38 @@
+package gpscfg
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/jclark/satpulse/internal/gpsprot"
+	"github.com/jclark/satpulse/internal/gpsreg"
+	"github.com/jclark/satpulse/internal/nmea"
+	"github.com/jclark/satpulse/internal/rtcm"
+	"github.com/jclark/satpulse/internal/ubx"
+)
+
+func TestNativeOnlyDetection(t *testing.T) {
+	// Create msgHandler with real packet processors
+	mh := msgHandler{
+		lg:          slog.Default(),
+		packetProcs: gpsreg.CreatePacketProcessors(nil),
+		msgCount:    make(map[gpsprot.Tag]int),
+	}
+
+	// Simulate receiving messages from different protocols
+	mh.msgCount[ubx.Tag] = 5
+	mh.msgCount[nmea.Tag] = 3
+	mh.msgCount[rtcm.Tag] = 7
+
+	// Test suitableMessageCount - should only count non-native-only protocols
+	suitable := mh.suitableMessageCount()
+	if suitable != 8 {
+		t.Errorf("suitableMessageCount() = %d, want 8", suitable)
+	}
+
+	// Test nativeOnlyTags - should only return RTCM
+	nativeOnly := mh.nativeOnlyTags()
+	if len(nativeOnly) != 1 || nativeOnly[0] != "RTCM" {
+		t.Errorf("nativeOnlyTags() = %v, want [RTCM]", nativeOnly)
+	}
+}

--- a/internal/gpsprot/packet.go
+++ b/internal/gpsprot/packet.go
@@ -88,6 +88,12 @@ type PacketProcessor interface {
 	// CreatePacketExchanger creates a PacketExchanger if configuration is supported
 	// Returns nil if configuration is not supported
 	CreatePacketExchanger() PacketExchanger
+
+	// NativeOnly returns true if this processor only generates native messages
+	// and never produces protocol-agnostic messages like TimeMsg or SatellitesMsg.
+	// This is typically true for protocols that provide correction data rather
+	// than positioning solutions (e.g., RTCM).
+	NativeOnly() bool
 }
 
 // DefaultPacketProcessor provides default implementations of PacketProcessor methods
@@ -123,6 +129,11 @@ func (p *DefaultPacketProcessor) GetNativeMsgHandler() NativeMsgHandler {
 // CreatePacketExchanger returns nil by default as most protocols don't support configuration
 func (p *DefaultPacketProcessor) CreatePacketExchanger() PacketExchanger {
 	return nil
+}
+
+// NativeOnly returns false by default since most protocols provide timing/positioning
+func (p *DefaultPacketProcessor) NativeOnly() bool {
+	return false
 }
 
 type NMEAPacketProcessor interface {

--- a/internal/rtcm/rtcm.go
+++ b/internal/rtcm/rtcm.go
@@ -171,6 +171,11 @@ func (p *PacketProcessor) ProcessPacket(data string, tRead time.Time) (string, e
 	return msgID, nil
 }
 
+// NativeOnly returns true since RTCM only provides correction data
+func (p *PacketProcessor) NativeOnly() bool {
+	return true
+}
+
 // ParseMessage parses a packet into an RTCM Message
 func ParseMessage(packet string) *Message {
 	return &Message{


### PR DESCRIPTION
Fixes #137

This PR makes the GPS receiver detection phase protocol-agnostic by allowing protocols to self-declare whether they only provide native messages (correction data) vs protocol-agnostic messages (positioning/timing).

## Changes

- Added `NativeOnly()` method to the `PacketProcessor` interface
- Default implementation returns `false` (most protocols provide timing/positioning)
- RTCM overrides to return `true` (only provides correction data)
- Updated `gpscfg` to use this method instead of hardcoding protocol tags
- Error messages now show specific protocols detected: "only messages with these protocols detected: RTCM"

## Testing

Added test in `internal/gpscfg/gpscfg_test.go` that verifies:
- Suitable message count only includes non-native-only protocols
- Native-only tags correctly identifies RTCM when present

## Benefits

- No hardcoded protocol knowledge in gpscfg
- New protocols (like Unicore) work automatically
- Clear semantic distinction between correction data and positioning protocols