### PR TITLE
Add GNSSLeapSecond type to ptime package

### DIFF
--- a/internal/ptime/ptime.go
+++ b/internal/ptime/ptime.go
@@ -374,3 +374,135 @@ func Picoseconds(ps int32) time.Duration {
 	}
 	return time.Duration(((ps + 500) / 1000))
 }
+
+
+
+
+// convertLeapSecond resolves a GNSS-encoded leap second into a concrete ptime.LeapSecond.
+// Arguments:
+//   now:                 current time in TAI (as determined from GNSS)
+//   epoch:               time of the GNSS epoch (from which GNSS week and day numbers count)
+//   leapSecondsAtEpoch:  (TAI − GNSS) at that epoch in whole seconds (GPS=19, GAL=19, BDS=33)
+//   wn:                  low 8 bits of the GNSS week number of the leap-second event (as broadcast)
+//   dn:                  day number with Sunday=0 … Saturday=6  (subtract 1 from GPS, Galileo but not BeiDou before calling)
+//   deltaBefore:         leap seconds since GNSS epoch BEFORE the event (as broadcast)
+//   deltaAfter:          leap seconds since GNSS epoch AFTER the event (as broadcast)
+//
+// Policy:
+//   • If deltaBefore == deltaAfter → no pending leap second (past reference):
+//       - Reconstruct the date by walking *backwards* in 256-week steps and pick the
+//         first legal end-of-quarter date ≤ now (error on ambiguity or none found).
+//       - Determine UTCOffBefore/After without trusting broadcast sign:
+//           · If the date == 2016-12-31 → use LeapSecond2016UTCOffBefore/After constants.
+//           · Else compare the broadcast “after” (TAI−UTC after event) to 37:
+//               >37 ⇒ assume past +1: before = after − 1
+//               <37 ⇒ assume past −1: before = after + 1
+//               =37 ⇒ assume past +1: before = 36, after = 37
+//   • If deltaBefore != deltaAfter → pending leap second (future):
+//       - Walk *forwards* in 256-week steps to the first legal date ≥ now that is within
+//         a 6-month announcement horizon; error if none / ambiguous.
+//       - UTCOffBefore/After are taken from leapSecondsAtEpoch + delta{Before,After}.
+
+func convertLeapSecond(
+	now Time,
+	epoch time.Time,
+	leapSecondsAtEpoch int16,
+	wn uint8,
+	dn uint8,
+	deltaBefore int8,
+	deltaAfter int8,
+) (LeapSecond, error) {
+	isLastDayOfQuarter := func(t time.Time) bool {
+		return t.AddDate(0, 0, 1).Day() == 1 && (t.Month()%3) == 0
+	}
+	dateOf := func(week int) time.Time {
+		return epoch.AddDate(0, 0, week*7+int(dn))
+	}
+
+	// Future iff offsets differ.
+	future := deltaBefore != deltaAfter
+
+	// Convert now (TAI) → UTC using the *current* offset for ordering.
+	var currUTCOff int16
+	if future {
+		currUTCOff = leapSecondsAtEpoch + int16(deltaBefore)
+	} else {
+		currUTCOff = leapSecondsAtEpoch + int16(deltaAfter)
+	}
+	nowUTC := time.Unix(int64(now)/1e9-int64(currUTCOff), int64(now)%1e9).UTC()
+
+	// Compute a base full week near now by splicing 8 LSBs.
+	weeksSinceEpoch := int(nowUTC.Sub(epoch) / (7 * 24 * time.Hour))
+	baseWeek := (weeksSinceEpoch &^ 0xFF) | int(wn)
+
+	// Alias search with ambiguity detection (like ubxleap.go’s simple stepping).
+	search := func(startWeek, step, limit int, accept func(time.Time) bool) (time.Time, error) {
+		found := time.Time{}
+		for i := 0; i < limit; i++ {
+			w := startWeek + i*step
+			if w < 0 {
+				continue
+			}
+			d := dateOf(w)
+			if accept(d) {
+				if found.IsZero() {
+					found = d
+				} else {
+					return time.Time{}, fmt.Errorf("ambiguous leap-second alias: %v and %v", found, d)
+				}
+			}
+		}
+		if found.IsZero() {
+			return time.Time{}, fmt.Errorf("no valid leap-second alias found")
+		}
+		return found, nil
+	}
+
+	const weekStride = 256
+	const maxAliases = 5
+	const announceHorizon = 183 * 24 * time.Hour // ~6 months
+
+	var chosen time.Time
+	var err error
+	if !future {
+		// Past reference: first legal date ≤ now, walking backwards.
+		chosen, err = search(baseWeek, -weekStride, maxAliases, func(d time.Time) bool {
+			return !d.After(nowUTC) && isLastDayOfQuarter(d)
+		})
+	} else {
+		// Future event: first legal date ≥ now within 6 months, walking forwards.
+		chosen, err = search(baseWeek, +weekStride, maxAliases, func(d time.Time) bool {
+			return !d.Before(nowUTC) && isLastDayOfQuarter(d) && d.Sub(nowUTC) <= announceHorizon
+		})
+	}
+	if err != nil {
+		return LeapSecond{}, fmt.Errorf("convertLeapSecond: %w (wn=%d dn=%d future=%v)", err, wn, dn, future)
+	}
+
+	// Offsets:
+	after := leapSecondsAtEpoch + int16(deltaAfter)
+	before := leapSecondsAtEpoch + int16(deltaBefore)
+
+	if !future {
+		// Past reference: derive the sign robustly.
+		if chosen.Equal(leapSecond2016Date) {
+			before = LeapSecond2016UTCOffBefore
+			after = LeapSecond2016UTCOffAfter
+		} else {
+			switch {
+			case after > 37:
+				// Past +1 event.
+				before = after - 1
+			case after < 37:
+				// Past −1 event.
+				before = after + 1
+			default:
+				// Equal to the known post-2016 value: assume a +1 past leap like 2016.
+				before = 36
+				after = 37
+			}
+		}
+	}
+
+	return LeapSecondOnDate(chosen, before, after), nil
+}

--- a/internal/ptime/ptime.go
+++ b/internal/ptime/ptime.go
@@ -381,8 +381,8 @@ func Picoseconds(ps int32) time.Duration {
 type GNSSLeapSecond struct {
 	WNLSF    uint8 // low 8 bits of GNSS week number of future leap second
 	DN       uint8 // day number in native GNSS format: GPS/Galileo 1-based (Sun=1), BeiDou 0-based (Sun=0)
-	DeltaLS  int8  // leap seconds since GNSS epoch BEFORE the event (as broadcast)
-	DeltaLSF int8  // leap seconds since GNSS epoch AFTER the event (as broadcast)
+	DeltaLS  int8  // leap seconds since GNSS epoch BEFORE the occurrence of the leap second
+	DeltaLSF int8  // leap seconds since GNSS epoch AFTER the occurrence of the leap second
 }
 
 // GPSLeapSecond converts GPS leap second data to a LeapSecond.
@@ -404,121 +404,98 @@ func BeiDouLeapSecond(g GNSSLeapSecond, now Time) (LeapSecond, error) {
 }
 
 // gnssLeapSecond converts a GNSS-encoded leap second to a LeapSecond.
-// Arguments:
-//   g: GNSS leap second data
-//   now: current time in TAI (as determined from GNSS)
-//   epoch: time of the GNSS epoch (from which GNSS week and day numbers count)
-//   epochLeapSeconds: (TAI − GNSS) at that epoch in whole seconds (GPS=19, GAL=19, BDS=33)
-//   dnBase: day numbering base (0 for BeiDou, 1 for GPS/Galileo)
 //
-// Policy:
-//   • If g.DeltaLS == g.DeltaLSF → no pending leap second (past reference):
-//       - Reconstruct the date by walking *backwards* in 256-week steps and pick the
-//         first legal end-of-quarter date ≤ now (error on ambiguity or none found).
-//       - Determine UTCOffBefore/After without trusting broadcast sign:
-//           · If the date == 2016-12-31 → use LeapSecond2016UTCOffBefore/After constants.
-//           · Else compare the broadcast "after" (TAI−UTC after event) to 37:
-//               >37 ⇒ assume past +1: before = after − 1
-//               <37 ⇒ assume past −1: before = after + 1
-//               =37 ⇒ assume past +1: before = 36, after = 37
-//   • If g.DeltaLS != g.DeltaLSF → pending leap second (future):
-//       - Walk *forwards* in 256-week steps to the first legal date ≥ now that is within
-//         a 6-month announcement horizon; error if none / ambiguous.
-//       - UTCOffBefore/After are taken from leapSecondsAtEpoch + g.Delta{LS,LSF}.
+//	g: GNSS-encoded leap second
+//	now: current time in TAI (as determined from GNSS)
+//	epoch: time of the GNSS epoch (from which GNSS week and day numbers count)
+//	epochLeapSeconds: (TAI − GNSS) at that epoch in whole seconds (GPS=19, GAL=19, BDS=33)
+//	dnBase: day numbering base (0 for BeiDou, 1 for GPS/Galileo)
 func gnssLeapSecond(g GNSSLeapSecond, now Time, epoch time.Time, epochLeapSeconds int16, dnBase uint8) (LeapSecond, error) {
 	dayOfWeek := int(g.DN) - int(dnBase)
+	isPast := g.DeltaLS == g.DeltaLSF
 
-	dateOf := func(week int) time.Time {
-		// Convert DN from native format to 0-based (subtract dnBase to normalize)
-		return epoch.AddDate(0, 0, week*7+dayOfWeek)
-	}
+	// Find candidate leap seconds using forward search from epoch
+	week := int(g.WNLSF)
+	var candidates []LeapSecond
+	maxTime := now.Add(6 * 30 * 24 * time.Hour) // now + 6 months (IERS horizon)
 
-	// Future iff offsets differ.
-	future := g.DeltaLS != g.DeltaLSF
+	for {
+		date := epoch.AddDate(0, 0, week*7+dayOfWeek)
 
-	// Convert now (TAI) → UTC using the *current* offset for ordering.
-	var currUTCOff int16
-	if future {
-		currUTCOff = epochLeapSeconds + int16(g.DeltaLS)
-	} else {
-		currUTCOff = epochLeapSeconds + int16(g.DeltaLSF)
-	}
-	nowUTC := time.Unix(int64(now)/1e9-int64(currUTCOff), int64(now)%1e9).UTC()
-
-	// Compute a base full week near now by splicing 8 LSBs.
-	weeksSinceEpoch := int(nowUTC.Sub(epoch) / (7 * 24 * time.Hour))
-	baseWeek := (weeksSinceEpoch &^ 0xFF) | int(g.WNLSF)
-
-	// Alias search with ambiguity detection (like ubxleap.go’s simple stepping).
-	search := func(startWeek, step, limit int, accept func(time.Time) bool) (time.Time, error) {
-		found := time.Time{}
-		for i := 0; i < limit; i++ {
-			w := startWeek + i*step
-			if w < 0 {
-				continue
-			}
-			d := dateOf(w)
-			if accept(d) {
-				if found.IsZero() {
-					found = d
-				} else {
-					return time.Time{}, fmt.Errorf("ambiguous leap-second alias: %v and %v", found, d)
-				}
-			}
+		// Stop if we've gone too far in the future (check date first to avoid unnecessary work)
+		if Unix(date.Unix(), 0) > maxTime {
+			break
 		}
-		if found.IsZero() {
-			return time.Time{}, fmt.Errorf("no valid leap-second alias found")
+
+		// Skip dates before 2016
+		if date.Before(leapSecond2016Date) {
+			week += 256
+			continue
 		}
-		return found, nil
-	}
 
-	const weekStride = 256
-	const maxAliases = 5
-	const announceHorizon = 183 * 24 * time.Hour // ~6 months
+		// Must be a valid quarter-end date
+		if !isLastDayOfQuarter(date) {
+			week += 256
+			continue
+		}
 
-	var chosen time.Time
-	var err error
-	if !future {
-		// Past reference: first legal date ≤ now, walking backwards.
-		chosen, err = search(baseWeek, -weekStride, maxAliases, func(d time.Time) bool {
-			return !d.After(nowUTC) && isLastDayOfQuarter(d)
-		})
-	} else {
-		// Future event: first legal date ≥ now within 6 months, walking forwards.
-		chosen, err = search(baseWeek, +weekStride, maxAliases, func(d time.Time) bool {
-			return !d.Before(nowUTC) && isLastDayOfQuarter(d) && d.Sub(nowUTC) <= announceHorizon
-		})
-	}
-	if err != nil {
-		return LeapSecond{}, fmt.Errorf("convertLeapSecond: %w (wn=%d dn=%d future=%v)", err, g.WNLSF, g.DN, future)
-	}
+		// Create candidate leap second
+		candidate := LeapSecondOnDate(date, epochLeapSeconds+int16(g.DeltaLS), epochLeapSeconds+int16(g.DeltaLSF))
 
-	// Offsets:
-	after := epochLeapSeconds + int16(g.DeltaLSF)
-	before := epochLeapSeconds + int16(g.DeltaLS)
-
-	if !future {
-		// Past reference: derive the sign robustly.
-		if chosen.Equal(leapSecond2016Date) {
-			before = LeapSecond2016UTCOffBefore
-			after = LeapSecond2016UTCOffAfter
+		// Check if candidate is appropriate for past/future with slack for edge cases
+		const slack = 24 * time.Hour
+		if isPast {
+			if candidate.OffChangeTime <= now.Add(slack) {
+				candidates = append(candidates, candidate)
+			}
 		} else {
-			switch {
-			case after > 37:
-				// Past +1 event.
-				before = after - 1
-			case after < 37:
-				// Past −1 event.
-				before = after + 1
-			default:
-				// Equal to the known post-2016 value: assume a +1 past leap like 2016.
-				before = 36
-				after = 37
+			if candidate.OffChangeTime >= now.Add(-slack) {
+				candidates = append(candidates, candidate)
 			}
 		}
+
+		week += 256
 	}
 
-	return LeapSecondOnDate(chosen, before, after), nil
+	// Check for ambiguity or no candidates
+	if len(candidates) == 0 {
+		return LeapSecond{}, fmt.Errorf("no valid leap second date found for WNLSF=%d DN=%d", g.WNLSF, g.DN)
+	}
+	if len(candidates) > 1 {
+		return LeapSecond{}, fmt.Errorf("ambiguous leap second dates: %v", candidates)
+	}
+
+	ls := candidates[0]
+
+	if isPast {
+		ls.UTCOffBefore = guessPastLeapSecondOffset(ls.OffChangeTime, ls.UTCOffAfter)
+	}
+
+	return ls, nil
+}
+
+// guessPastLeapSecondOffset guesses the before UTC offset for a past leap second
+// when only the after offset is known (DeltaLS == DeltaLSF).
+// leapTime is the Time when the leap second offset change occurs (OffChangeTime).
+func guessPastLeapSecondOffset(leapTime Time, after int16) int16 {
+	leapSecond2016 := LeapSecond2016()
+	if leapTime == leapSecond2016.OffChangeTime {
+		// Known reference point
+		return LeapSecond2016UTCOffBefore
+	}
+
+	// For other past leap seconds, derive based on after offset
+	if after > leapSecond2016.UTCOffAfter {
+		// Assume positive leap second (all historical ones have been)
+		return after - 1
+	} else if after < leapSecond2016.UTCOffAfter {
+		// Would indicate negative leap second (theoretically possible but never happened)
+		return after + 1
+	} else { // after == 37
+		// Could be 2016 or could have returned to 37 via negative leap
+		// Assume 2016 behavior (positive leap second)
+		return leapSecond2016.UTCOffBefore
+	}
 }
 
 func isLastDayOfQuarter(t time.Time) bool {

--- a/internal/ptime/ptime.go
+++ b/internal/ptime/ptime.go
@@ -375,65 +375,79 @@ func Picoseconds(ps int32) time.Duration {
 	return time.Duration(((ps + 500) / 1000))
 }
 
+// GNSSLeapSecond is information about a future leap second in a form similar to what is broadcast by GNSS systems.
+// GPS, Galileo, and BeiDou all use similar formats.
+// Day numbering uses each GNSS's native format: GPS/Galileo use 1-based (Sunday=1), BeiDou uses 0-based (Sunday=0).
+type GNSSLeapSecond struct {
+	WNLSF    uint8 // low 8 bits of GNSS week number of future leap second
+	DN       uint8 // day number in native GNSS format: GPS/Galileo 1-based (Sun=1), BeiDou 0-based (Sun=0)
+	DeltaLS  int8  // leap seconds since GNSS epoch BEFORE the event (as broadcast)
+	DeltaLSF int8  // leap seconds since GNSS epoch AFTER the event (as broadcast)
+}
 
+// GPSLeapSecond converts GPS leap second data to a LeapSecond.
+// The day number (DN) in g should be 1-based as broadcast by GPS (Sunday=1).
+func GPSLeapSecond(g GNSSLeapSecond, now Time) (LeapSecond, error) {
+	return gnssLeapSecond(g, now, epochGPS, TAIMinusGPS, 1)
+}
 
+// GalileoLeapSecond converts Galileo leap second data to a LeapSecond.
+// The day number (DN) in g should be 1-based as broadcast by Galileo (Sunday=1).
+func GalileoLeapSecond(g GNSSLeapSecond, now Time) (LeapSecond, error) {
+	return gnssLeapSecond(g, now, epochGalileo, TAIMinusGalileo, 1)
+}
 
-// convertLeapSecond resolves a GNSS-encoded leap second into a concrete ptime.LeapSecond.
+// BeiDouLeapSecond converts BeiDou leap second data to a LeapSecond.
+// The day number (DN) in g should be 0-based as broadcast by BeiDou (Sunday=0).
+func BeiDouLeapSecond(g GNSSLeapSecond, now Time) (LeapSecond, error) {
+	return gnssLeapSecond(g, now, epochBeiDou, TAIMinusBeiDou, 0)
+}
+
+// gnssLeapSecond converts a GNSS-encoded leap second to a LeapSecond.
 // Arguments:
-//   now:                 current time in TAI (as determined from GNSS)
-//   epoch:               time of the GNSS epoch (from which GNSS week and day numbers count)
-//   leapSecondsAtEpoch:  (TAI − GNSS) at that epoch in whole seconds (GPS=19, GAL=19, BDS=33)
-//   wn:                  low 8 bits of the GNSS week number of the leap-second event (as broadcast)
-//   dn:                  day number with Sunday=0 … Saturday=6  (subtract 1 from GPS, Galileo but not BeiDou before calling)
-//   deltaBefore:         leap seconds since GNSS epoch BEFORE the event (as broadcast)
-//   deltaAfter:          leap seconds since GNSS epoch AFTER the event (as broadcast)
+//   g: GNSS leap second data
+//   now: current time in TAI (as determined from GNSS)
+//   epoch: time of the GNSS epoch (from which GNSS week and day numbers count)
+//   epochLeapSeconds: (TAI − GNSS) at that epoch in whole seconds (GPS=19, GAL=19, BDS=33)
+//   dnBase: day numbering base (0 for BeiDou, 1 for GPS/Galileo)
 //
 // Policy:
-//   • If deltaBefore == deltaAfter → no pending leap second (past reference):
+//   • If g.DeltaLS == g.DeltaLSF → no pending leap second (past reference):
 //       - Reconstruct the date by walking *backwards* in 256-week steps and pick the
 //         first legal end-of-quarter date ≤ now (error on ambiguity or none found).
 //       - Determine UTCOffBefore/After without trusting broadcast sign:
 //           · If the date == 2016-12-31 → use LeapSecond2016UTCOffBefore/After constants.
-//           · Else compare the broadcast “after” (TAI−UTC after event) to 37:
+//           · Else compare the broadcast "after" (TAI−UTC after event) to 37:
 //               >37 ⇒ assume past +1: before = after − 1
 //               <37 ⇒ assume past −1: before = after + 1
 //               =37 ⇒ assume past +1: before = 36, after = 37
-//   • If deltaBefore != deltaAfter → pending leap second (future):
+//   • If g.DeltaLS != g.DeltaLSF → pending leap second (future):
 //       - Walk *forwards* in 256-week steps to the first legal date ≥ now that is within
 //         a 6-month announcement horizon; error if none / ambiguous.
-//       - UTCOffBefore/After are taken from leapSecondsAtEpoch + delta{Before,After}.
+//       - UTCOffBefore/After are taken from leapSecondsAtEpoch + g.Delta{LS,LSF}.
+func gnssLeapSecond(g GNSSLeapSecond, now Time, epoch time.Time, epochLeapSeconds int16, dnBase uint8) (LeapSecond, error) {
+	dayOfWeek := int(g.DN) - int(dnBase)
 
-func convertLeapSecond(
-	now Time,
-	epoch time.Time,
-	leapSecondsAtEpoch int16,
-	wn uint8,
-	dn uint8,
-	deltaBefore int8,
-	deltaAfter int8,
-) (LeapSecond, error) {
-	isLastDayOfQuarter := func(t time.Time) bool {
-		return t.AddDate(0, 0, 1).Day() == 1 && (t.Month()%3) == 0
-	}
 	dateOf := func(week int) time.Time {
-		return epoch.AddDate(0, 0, week*7+int(dn))
+		// Convert DN from native format to 0-based (subtract dnBase to normalize)
+		return epoch.AddDate(0, 0, week*7+dayOfWeek)
 	}
 
 	// Future iff offsets differ.
-	future := deltaBefore != deltaAfter
+	future := g.DeltaLS != g.DeltaLSF
 
 	// Convert now (TAI) → UTC using the *current* offset for ordering.
 	var currUTCOff int16
 	if future {
-		currUTCOff = leapSecondsAtEpoch + int16(deltaBefore)
+		currUTCOff = epochLeapSeconds + int16(g.DeltaLS)
 	} else {
-		currUTCOff = leapSecondsAtEpoch + int16(deltaAfter)
+		currUTCOff = epochLeapSeconds + int16(g.DeltaLSF)
 	}
 	nowUTC := time.Unix(int64(now)/1e9-int64(currUTCOff), int64(now)%1e9).UTC()
 
 	// Compute a base full week near now by splicing 8 LSBs.
 	weeksSinceEpoch := int(nowUTC.Sub(epoch) / (7 * 24 * time.Hour))
-	baseWeek := (weeksSinceEpoch &^ 0xFF) | int(wn)
+	baseWeek := (weeksSinceEpoch &^ 0xFF) | int(g.WNLSF)
 
 	// Alias search with ambiguity detection (like ubxleap.go’s simple stepping).
 	search := func(startWeek, step, limit int, accept func(time.Time) bool) (time.Time, error) {
@@ -476,12 +490,12 @@ func convertLeapSecond(
 		})
 	}
 	if err != nil {
-		return LeapSecond{}, fmt.Errorf("convertLeapSecond: %w (wn=%d dn=%d future=%v)", err, wn, dn, future)
+		return LeapSecond{}, fmt.Errorf("convertLeapSecond: %w (wn=%d dn=%d future=%v)", err, g.WNLSF, g.DN, future)
 	}
 
 	// Offsets:
-	after := leapSecondsAtEpoch + int16(deltaAfter)
-	before := leapSecondsAtEpoch + int16(deltaBefore)
+	after := epochLeapSeconds + int16(g.DeltaLSF)
+	before := epochLeapSeconds + int16(g.DeltaLS)
 
 	if !future {
 		// Past reference: derive the sign robustly.
@@ -505,4 +519,8 @@ func convertLeapSecond(
 	}
 
 	return LeapSecondOnDate(chosen, before, after), nil
+}
+
+func isLastDayOfQuarter(t time.Time) bool {
+	return t.AddDate(0, 0, 1).Day() == 1 && (t.Month()%3) == 0
 }

--- a/internal/ptime/ptime_test.go
+++ b/internal/ptime/ptime_test.go
@@ -222,14 +222,13 @@ func TestGPSLeapSecond(t *testing.T) {
 
 	const sixMonths = 183 * 24 * time.Hour
 	futureDate := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
-	lastLeapSecond := LeapSecond2016()
 
 	testCases := []leapSecondTestCase{
 		{
 			name:   "GPS past (receiver showed WNLSF=2441, DN=7)",
 			now:    pastNowTAI,
 			gnss:   GNSSLeapSecond{WNLSF: 2441 % 256, DN: 7, DeltaLS: 18, DeltaLSF: 18}, // 137, Saturday (1-based)
-			expect: lastLeapSecond,
+			expect: LeapSecond2016(),
 		},
 		{
 			name:   "GPS future within horizon",
@@ -256,14 +255,13 @@ func TestGalileoLeapSecond(t *testing.T) {
 
 	const sixMonths = 183 * 24 * time.Hour
 	futureDate := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
-	lastLeapSecond := LeapSecond2016()
 
 	testCases := []leapSecondTestCase{
 		{
 			name:   "Galileo past (receiver showed WnLSF=1417, Dn=7)",
 			now:    pastNowTAI,
 			gnss:   GNSSLeapSecond{WNLSF: 1417 % 256, DN: 7, DeltaLS: 18, DeltaLSF: 18}, // 137, Saturday (1-based)
-			expect: lastLeapSecond,
+			expect: LeapSecond2016(),
 		},
 		{
 			name:   "Galileo future within horizon",

--- a/internal/ptime/ptime_test.go
+++ b/internal/ptime/ptime_test.go
@@ -200,98 +200,143 @@ func TestMJD(t *testing.T) {
 
 func TestGPSUTC(t *testing.T) {
 	expected := UTC(2025, 5, 27, 3, 38, 53, 0)
-	ut := GPSUTC(2368,185933*time.Second)
+	ut := GPSUTC(2368, 185933*time.Second)
 	if expected != ut {
 		t.Errorf("GPSUTC(2368, 185933) = %v, want %v", ut, expected)
 	}
 }
 
-func TestConvertLeapSecond_PastCases(t *testing.T) {
+type leapSecondTestCase struct {
+	name      string
+	now       Time
+	gnss      GNSSLeapSecond
+	expect    LeapSecond
+	expectErr bool
+}
+
+func TestGPSLeapSecond(t *testing.T) {
 	// Helper: construct a TAI Time from a UTC instant given current TAI−UTC.
-	nowUTC := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // comfortably after 2016-12-31
-	nowTAI := Unix(nowUTC.Unix()+37, 0)                   // all three systems have 37s (TAI−UTC) since 2017
+	pastNowUTC := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // comfortably after 2016-12-31
+	pastNowTAI := Unix(pastNowUTC.Unix()+37, 0)               // all three systems have 37s (TAI−UTC) since 2017
+	nowTAI := func(utc time.Time) Time { return Unix(utc.Unix()+37, 0) }
 
-	wantDate := time.Date(2016, time.December, 31, 0, 0, 0, 0, time.UTC)
+	const sixMonths = 183 * 24 * time.Hour
+	futureDate := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
+	lastLeapSecond := LeapSecond2016()
 
-	tests := []struct {
-		name            string
-		now             Time
-		epoch           time.Time
-		leapSecondsAtEp int16
-		wn              uint8
-		dn              uint8
-		deltaBefore     int8
-		deltaAfter      int8
-		wantDate        time.Time
-		wantBefore      int16
-		wantAfter       int16
-	}{
+	testCases := []leapSecondTestCase{
 		{
-			name:            "GPS past (receiver showed WNLSF=2441, DN=7)",
-			now:             nowTAI,
-			epoch:           epochGPS,
-			leapSecondsAtEp: TAIMinusGPS,
-			wn:              uint8(2441 % 256), // 137
-			dn:              6,                 // Saturday
-			deltaBefore:     18,
-			deltaAfter:      18,
-			wantDate:        wantDate,
-			wantBefore:      TAIMinusGPS + 17,
-			wantAfter:       TAIMinusGPS + 18,
+			name:   "GPS past (receiver showed WNLSF=2441, DN=7)",
+			now:    pastNowTAI,
+			gnss:   GNSSLeapSecond{WNLSF: 2441 % 256, DN: 7, DeltaLS: 18, DeltaLSF: 18}, // 137, Saturday (1-based)
+			expect: lastLeapSecond,
 		},
 		{
-			name:            "Galileo past (receiver showed WnLSF=1417, Dn=7)",
-			now:             nowTAI,
-			epoch:           epochGalileo,
-			leapSecondsAtEp: TAIMinusGalileo,
-			wn:              uint8(1417 % 256), // 137
-			dn:              6,                 // Saturday
-			deltaBefore:     18,
-			deltaAfter:      18,
-			wantDate:        wantDate,
-			wantBefore:      TAIMinusGalileo + 17,
-			wantAfter:       TAIMinusGalileo + 18,
+			name:   "GPS future within horizon",
+			now:    nowTAI(futureDate.Add(-179 * 24 * time.Hour)),
+			gnss:   GNSSLeapSecond{WNLSF: 147, DN: 5, DeltaLS: 18, DeltaLSF: 19}, // Thursday (1-based: 5)
+			expect: LeapSecondOnDate(futureDate, TAIMinusGPS+18, TAIMinusGPS+19),
 		},
 		{
-			name:            "BeiDou-3 past (receiver showed WnLSF=61, Dn=6, ΔtLS=4, ΔtLSF=4)",
-			now:             nowTAI,
-			epoch:           epochBeiDou,
-			leapSecondsAtEp: TAIMinusBeiDou,
-			wn:              61,
-			dn:              6,
-			deltaBefore:     4,
-			deltaAfter:      4,
-			wantDate:        wantDate,
-			wantBefore:      TAIMinusBeiDou + 3,
-			wantAfter:       TAIMinusBeiDou + 4,
-		},
-		{
-			name:            "BeiDou-2 past (receiver showed WnLSF=1085, Dn=6, ΔtLS=4, ΔtLSF=4)",
-			now:             nowTAI,
-			epoch:           epochBeiDou,
-			leapSecondsAtEp: TAIMinusBeiDou,
-			wn:              uint8(1085 % 256), // 61
-			dn:              6,
-			deltaBefore:     4,
-			deltaAfter:      4,
-			wantDate:        wantDate,
-			wantBefore:      TAIMinusBeiDou + 3,
-			wantAfter:       TAIMinusBeiDou + 4,
+			name:      "GPS future beyond horizon → error",
+			now:       nowTAI(futureDate.Add(-(sixMonths + 10*24*time.Hour))),
+			gnss:      GNSSLeapSecond{WNLSF: 147, DN: 5, DeltaLS: 18, DeltaLSF: 19},
+			expectErr: true,
 		},
 	}
 
-	for _, tt := range tests {
+	runLeapSecondTests(t, testCases, GPSLeapSecond)
+}
+
+func TestGalileoLeapSecond(t *testing.T) {
+	// Helper: construct a TAI Time from a UTC instant given current TAI−UTC.
+	pastNowUTC := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	pastNowTAI := Unix(pastNowUTC.Unix()+37, 0)
+	nowTAI := func(utc time.Time) Time { return Unix(utc.Unix()+37, 0) }
+
+	const sixMonths = 183 * 24 * time.Hour
+	futureDate := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
+	lastLeapSecond := LeapSecond2016()
+
+	testCases := []leapSecondTestCase{
+		{
+			name:   "Galileo past (receiver showed WnLSF=1417, Dn=7)",
+			now:    pastNowTAI,
+			gnss:   GNSSLeapSecond{WNLSF: 1417 % 256, DN: 7, DeltaLS: 18, DeltaLSF: 18}, // 137, Saturday (1-based)
+			expect: lastLeapSecond,
+		},
+		{
+			name:   "Galileo future within horizon",
+			now:    nowTAI(futureDate.Add(-170 * 24 * time.Hour)),
+			gnss:   GNSSLeapSecond{WNLSF: 147, DN: 5, DeltaLS: 18, DeltaLSF: 19}, // Thursday (1-based: 5)
+			expect: LeapSecondOnDate(futureDate, TAIMinusGalileo+18, TAIMinusGalileo+19),
+		},
+		{
+			name:      "Galileo future beyond horizon → error",
+			now:       nowTAI(futureDate.Add(-(sixMonths + 1*time.Hour))),
+			gnss:      GNSSLeapSecond{WNLSF: 147, DN: 5, DeltaLS: 18, DeltaLSF: 19},
+			expectErr: true,
+		},
+	}
+
+	runLeapSecondTests(t, testCases, GalileoLeapSecond)
+}
+
+func TestBeiDouLeapSecond(t *testing.T) {
+	// Helper: construct a TAI Time from a UTC instant given current TAI−UTC.
+	pastNowUTC := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	pastNowTAI := Unix(pastNowUTC.Unix()+37, 0)
+	nowTAI := func(utc time.Time) Time { return Unix(utc.Unix()+37, 0) }
+
+	const sixMonths = 183 * 24 * time.Hour
+	futureDate := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
+	lastLeapSecond := LeapSecond2016()
+
+	testCases := []leapSecondTestCase{
+		{
+			name:   "BeiDou-3 past (receiver showed WnLSF=61, Dn=6, ΔtLS=4, ΔtLSF=4)",
+			now:    pastNowTAI,
+			gnss:   GNSSLeapSecond{WNLSF: 61, DN: 6, DeltaLS: 4, DeltaLSF: 4}, // Saturday (0-based)
+			expect: lastLeapSecond,
+		},
+		{
+			name:   "BeiDou-2 past (receiver showed WnLSF=1085, Dn=6, ΔtLS=4, ΔtLSF=4)",
+			now:    pastNowTAI,
+			gnss:   GNSSLeapSecond{WNLSF: 1085 % 256, DN: 6, DeltaLS: 4, DeltaLSF: 4}, // 61, Saturday (0-based)
+			expect: lastLeapSecond,
+		},
+		{
+			name:   "BeiDou-3 future within horizon",
+			now:    nowTAI(futureDate.Add(-150 * 24 * time.Hour)),
+			gnss:   GNSSLeapSecond{WNLSF: 71, DN: 4, DeltaLS: 4, DeltaLSF: 5}, // Thursday (0-based: 4)
+			expect: LeapSecondOnDate(futureDate, TAIMinusBeiDou+4, TAIMinusBeiDou+5),
+		},
+		{
+			name:      "BeiDou-3 future beyond horizon → error",
+			now:       nowTAI(futureDate.Add(-(sixMonths + 24*time.Hour))),
+			gnss:      GNSSLeapSecond{WNLSF: 71, DN: 4, DeltaLS: 4, DeltaLSF: 5},
+			expectErr: true,
+		},
+	}
+
+	runLeapSecondTests(t, testCases, BeiDouLeapSecond)
+}
+
+func runLeapSecondTests(t *testing.T, testCases []leapSecondTestCase, testFunc func(GNSSLeapSecond, Time) (LeapSecond, error)) {
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ls, err := convertLeapSecond(tt.now, tt.epoch, tt.leapSecondsAtEp, tt.wn, tt.dn, tt.deltaBefore, tt.deltaAfter)
+			ls, err := testFunc(tt.gnss, tt.now)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
 			if err != nil {
-				t.Fatalf("convertLeapSecond error: %v", err)
+				t.Fatalf("leap second conversion error: %v", err)
 			}
-			if got := ls.Date(); !got.Equal(tt.wantDate) {
-				t.Errorf("Date() = %v, want %v", got, tt.wantDate)
-			}
-			if ls.UTCOffBefore != tt.wantBefore || ls.UTCOffAfter != tt.wantAfter {
-				t.Errorf("UTC offsets = before:%d after:%d, want before:%d after:%d",
-					ls.UTCOffBefore, ls.UTCOffAfter, tt.wantBefore, tt.wantAfter)
+			if ls != tt.expect {
+				t.Errorf("got %+v, expect %+v", ls, tt.expect)
 			}
 		})
 	}

--- a/internal/ptime/ptime_test.go
+++ b/internal/ptime/ptime_test.go
@@ -205,3 +205,94 @@ func TestGPSUTC(t *testing.T) {
 		t.Errorf("GPSUTC(2368, 185933) = %v, want %v", ut, expected)
 	}
 }
+
+func TestConvertLeapSecond_PastCases(t *testing.T) {
+	// Helper: construct a TAI Time from a UTC instant given current TAI−UTC.
+	nowUTC := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // comfortably after 2016-12-31
+	nowTAI := Unix(nowUTC.Unix()+37, 0)                   // all three systems have 37s (TAI−UTC) since 2017
+
+	wantDate := time.Date(2016, time.December, 31, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		now             Time
+		epoch           time.Time
+		leapSecondsAtEp int16
+		wn              uint8
+		dn              uint8
+		deltaBefore     int8
+		deltaAfter      int8
+		wantDate        time.Time
+		wantBefore      int16
+		wantAfter       int16
+	}{
+		{
+			name:            "GPS past (receiver showed WNLSF=2441, DN=7)",
+			now:             nowTAI,
+			epoch:           epochGPS,
+			leapSecondsAtEp: TAIMinusGPS,
+			wn:              uint8(2441 % 256), // 137
+			dn:              6,                 // Saturday
+			deltaBefore:     18,
+			deltaAfter:      18,
+			wantDate:        wantDate,
+			wantBefore:      TAIMinusGPS + 17,
+			wantAfter:       TAIMinusGPS + 18,
+		},
+		{
+			name:            "Galileo past (receiver showed WnLSF=1417, Dn=7)",
+			now:             nowTAI,
+			epoch:           epochGalileo,
+			leapSecondsAtEp: TAIMinusGalileo,
+			wn:              uint8(1417 % 256), // 137
+			dn:              6,                 // Saturday
+			deltaBefore:     18,
+			deltaAfter:      18,
+			wantDate:        wantDate,
+			wantBefore:      TAIMinusGalileo + 17,
+			wantAfter:       TAIMinusGalileo + 18,
+		},
+		{
+			name:            "BeiDou-3 past (receiver showed WnLSF=61, Dn=6, ΔtLS=4, ΔtLSF=4)",
+			now:             nowTAI,
+			epoch:           epochBeiDou,
+			leapSecondsAtEp: TAIMinusBeiDou,
+			wn:              61,
+			dn:              6,
+			deltaBefore:     4,
+			deltaAfter:      4,
+			wantDate:        wantDate,
+			wantBefore:      TAIMinusBeiDou + 3,
+			wantAfter:       TAIMinusBeiDou + 4,
+		},
+		{
+			name:            "BeiDou-2 past (receiver showed WnLSF=1085, Dn=6, ΔtLS=4, ΔtLSF=4)",
+			now:             nowTAI,
+			epoch:           epochBeiDou,
+			leapSecondsAtEp: TAIMinusBeiDou,
+			wn:              uint8(1085 % 256), // 61
+			dn:              6,
+			deltaBefore:     4,
+			deltaAfter:      4,
+			wantDate:        wantDate,
+			wantBefore:      TAIMinusBeiDou + 3,
+			wantAfter:       TAIMinusBeiDou + 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls, err := convertLeapSecond(tt.now, tt.epoch, tt.leapSecondsAtEp, tt.wn, tt.dn, tt.deltaBefore, tt.deltaAfter)
+			if err != nil {
+				t.Fatalf("convertLeapSecond error: %v", err)
+			}
+			if got := ls.Date(); !got.Equal(tt.wantDate) {
+				t.Errorf("Date() = %v, want %v", got, tt.wantDate)
+			}
+			if ls.UTCOffBefore != tt.wantBefore || ls.UTCOffAfter != tt.wantAfter {
+				t.Errorf("UTC offsets = before:%d after:%d, want before:%d after:%d",
+					ls.UTCOffBefore, ls.UTCOffAfter, tt.wantBefore, tt.wantAfter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This supports converting the representation of a leap second as transmitted by GPS, Galileo or BeiDou into our leap second representation.