### PR TITLE
Expose sync mode via dedicated observer signal

### DIFF
--- a/time/app/daemon/http.go
+++ b/time/app/daemon/http.go
@@ -96,7 +96,7 @@ func startHTTP(ctx context.Context, lg *slog.Logger, wg *sync.WaitGroup, cfg []H
 		// Only register GUI routes if enabled for this endpoint
 		if cfg[i].gui() {
 			mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
-				sseHandleRequest(ctx, lg, w, r, b, sseObs.InitEvent())
+				sseHandleRequest(ctx, lg, w, r, b, sseObs.InitEvents())
 			})
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 				fileServer.ServeHTTP(w, r)
@@ -138,22 +138,28 @@ func startHTTP(ctx context.Context, lg *slog.Logger, wg *sync.WaitGroup, cfg []H
 	return nil
 }
 
-func sseHandleRequest(ctx context.Context, lg *slog.Logger, w http.ResponseWriter, r *http.Request, b *bcast.Bcast[sse.Event], initEvent sse.Event) {
+func sseHandleRequest(ctx context.Context, lg *slog.Logger, w http.ResponseWriter, r *http.Request, b *bcast.Bcast[sse.Event], initEvents []sse.Event) {
 	defer lg.Debug("about to exit HTTP SSE request handler")
 	lg.Debug("starting to handle HTTP SSE request")
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	flusher := w.(http.Flusher)
-	if !initEvent.IsZero() {
-		_, err := w.Write(([]byte)(initEvent.Format()))
-		if err != nil {
+	// Subscribe before writing the init events: any broadcast events that
+	// fire in the small window between init delivery and the loop below
+	// will then be queued for us, rather than lost.
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+	for _, ev := range initEvents {
+		if ev.IsZero() {
+			continue
+		}
+		if _, err := w.Write(([]byte)(ev.Format())); err != nil {
 			lg.Error("error writing HTTP response", "err", err)
 			return
 		}
 	}
-	ch := b.Subscribe()
-	defer b.Unsubscribe(ch)
+	flusher.Flush()
 
 	for {
 		select {

--- a/time/app/daemon/http.go
+++ b/time/app/daemon/http.go
@@ -96,7 +96,7 @@ func startHTTP(ctx context.Context, lg *slog.Logger, wg *sync.WaitGroup, cfg []H
 		// Only register GUI routes if enabled for this endpoint
 		if cfg[i].gui() {
 			mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
-				sseHandleRequest(ctx, lg, w, r, b, sseObs.InitEvents())
+				sseHandleRequest(ctx, lg, w, r, b, sseObs)
 			})
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 				fileServer.ServeHTTP(w, r)
@@ -138,19 +138,20 @@ func startHTTP(ctx context.Context, lg *slog.Logger, wg *sync.WaitGroup, cfg []H
 	return nil
 }
 
-func sseHandleRequest(ctx context.Context, lg *slog.Logger, w http.ResponseWriter, r *http.Request, b *bcast.Bcast[sse.Event], initEvents []sse.Event) {
+func sseHandleRequest(ctx context.Context, lg *slog.Logger, w http.ResponseWriter, r *http.Request, b *bcast.Bcast[sse.Event], sseObs *sseobs.SSEObserver) {
 	defer lg.Debug("about to exit HTTP SSE request handler")
 	lg.Debug("starting to handle HTTP SSE request")
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	flusher := w.(http.Flusher)
-	// Subscribe before writing the init events: any broadcast events that
-	// fire in the small window between init delivery and the loop below
-	// will then be queued for us, rather than lost.
+	// Subscribe before snapshotting the init events: any broadcast event
+	// that fires after Subscribe will be queued for us, so a mode change
+	// racing with our connect cannot be lost between snapshot and live
+	// delivery.
 	ch := b.Subscribe()
 	defer b.Unsubscribe(ch)
-	for _, ev := range initEvents {
+	for _, ev := range sseObs.InitEvents() {
 		if ev.IsZero() {
 			continue
 		}

--- a/time/internal/gpsevent/event_log_replay.go
+++ b/time/internal/gpsevent/event_log_replay.go
@@ -42,7 +42,7 @@ func (m *mockClock) AdjTime(d time.Duration) (phctime.Era, error) {
 	return phctime.Era(1), nil
 }
 
-// replaySampler implements phcsync.Sampler to collect samples during replay
+// replaySampler implements phcsync.Observer to collect samples during replay
 type replaySampler struct {
 	ref    ptime.Time
 	ls     ptime.LeapSecond
@@ -66,6 +66,8 @@ func (rs *replaySampler) Sample(data phcsync.Sample) {
 	rs.ref = data.Ref
 	rs.count++
 }
+
+func (rs *replaySampler) ModeChanged(_, _ phcsync.Mode) {}
 
 func (rs *replaySampler) logDateTime(ref ptime.Time) string {
 	// Round because the reference time may have had a pulse offset applied

--- a/time/internal/gpsevent/replay_test.go
+++ b/time/internal/gpsevent/replay_test.go
@@ -68,7 +68,7 @@ func (m *mockClock) AdjTime(d time.Duration) (phctime.Era, error) {
 	return phctime.Era(1), nil
 }
 
-// replaySampler implements phcsync.Sampler for testing
+// replaySampler implements phcsync.Observer for testing
 type replaySampler struct {
 	t           *testing.T
 	ref         ptime.Time
@@ -85,3 +85,5 @@ func (s *replaySampler) Sample(data phcsync.Sample) {
 	s.ref = data.Ref
 	s.sampleCount++
 }
+
+func (s *replaySampler) ModeChanged(_, _ phcsync.Mode) {}

--- a/time/internal/logobs/clocklog.go
+++ b/time/internal/logobs/clocklog.go
@@ -38,7 +38,7 @@ func NewClockLogObserver(lg *slog.Logger, path string, ls ptime.LeapSecond) (*Cl
 	return o, nil
 }
 
-// Sample implements phcsync.Sampler - logs clock data samples
+// Sample implements phcsync.Observer - logs clock data samples
 func (o *ClockLogObserver) Sample(data phcsync.Sample) {
 	// Don't log missing samples
 	if data.Kind == phcsync.SampleMissing {

--- a/time/internal/logobs/statslog.go
+++ b/time/internal/logobs/statslog.go
@@ -27,7 +27,7 @@ func NewStatsLogObserver(lg *slog.Logger, interval int) *StatsLogObserver {
 	}
 }
 
-// Sample implements phcsync.Sampler
+// Sample implements phcsync.Observer
 func (o *StatsLogObserver) Sample(data phcsync.Sample) {
 	if o.interval <= 0 {
 		return

--- a/time/internal/obs/observer.go
+++ b/time/internal/obs/observer.go
@@ -10,7 +10,7 @@ import (
 
 // Observer provides unified observability interface
 type Observer interface {
-	phcsync.Sampler
+	phcsync.Observer
 	gpsprot.MsgHandler
 
 	// Tick delivers a filled TimeMsg (TAI+UTC populated, rounded to ms)
@@ -54,11 +54,20 @@ func NewMultiObserver(observers ...Observer) *MultiObserver {
 	}
 }
 
-// Sample implements phcsync.Sampler by type-asserting handlers to Sampler
+// Sample implements phcsync.Observer by type-asserting handlers to Observer
 func (m *MultiObserver) Sample(data phcsync.Sample) {
 	for h := range m.Handlers() {
-		if sampler, ok := h.(phcsync.Sampler); ok {
-			sampler.Sample(data)
+		if o, ok := h.(phcsync.Observer); ok {
+			o.Sample(data)
+		}
+	}
+}
+
+// ModeChanged implements phcsync.Observer by type-asserting handlers to Observer
+func (m *MultiObserver) ModeChanged(oldMode, newMode phcsync.Mode) {
+	for h := range m.Handlers() {
+		if o, ok := h.(phcsync.Observer); ok {
+			o.ModeChanged(oldMode, newMode)
 		}
 	}
 }
@@ -113,8 +122,11 @@ type DefaultObserver struct {
 	gpsprot.DefaultHandler
 }
 
-// Sample implements phcsync.Sampler as a no-op
+// Sample implements phcsync.Observer as a no-op
 func (o *DefaultObserver) Sample(data phcsync.Sample) {}
+
+// ModeChanged implements phcsync.Observer as a no-op
+func (o *DefaultObserver) ModeChanged(_, _ phcsync.Mode) {}
 
 // Tick implements Observer as a no-op
 func (o *DefaultObserver) Tick(_ *gpsprot.TimeMsg, _ time.Time) {}

--- a/time/internal/obs/observer_test.go
+++ b/time/internal/obs/observer_test.go
@@ -24,6 +24,8 @@ func (m *mockObserver) Sample(data phcsync.Sample) {
 	m.sampleCount++
 }
 
+func (m *mockObserver) ModeChanged(_, _ phcsync.Mode) {}
+
 func (m *mockObserver) Tick(_ *gpsprot.TimeMsg, _ time.Time) {
 	m.tickCount++
 }

--- a/time/internal/phcsync/controller.go
+++ b/time/internal/phcsync/controller.go
@@ -125,7 +125,7 @@ func (m Mode) InSync() bool {
 type Controller struct {
 	clock         Clock
 	timeMsgBuffer TimeMsgBuffer
-	sampler       Sampler
+	observer      Observer
 	gm            *ptpgm.Grandmaster
 	cfg           Config
 	leapSecond    ptime.LeapSecond
@@ -171,7 +171,7 @@ type sampleProcessor interface {
 // The Config must be validated before calling this function.
 func NewController(
 	clock Clock,
-	sampler Sampler,
+	observer Observer,
 	gm *ptpgm.Grandmaster,
 	cfg Config,
 	leapSecond ptime.LeapSecond,
@@ -187,7 +187,7 @@ func NewController(
 	}
 	c := &Controller{
 		clock:      clock,
-		sampler:    sampler,
+		observer:   observer,
 		gm:         gm,
 		cfg:        cfg,
 		leapSecond: leapSecond,
@@ -269,7 +269,7 @@ func (c *Controller) processSample(sample *Sample) {
 	// or outlier samples that cause us to leave tracking) represent the quality of time
 	// that clients were receiving while we were still in tracking mode.
 	sample.Mode = c.mode
-	c.sampler.Sample(*sample)
+	c.observer.Sample(*sample)
 	if mode != c.mode {
 		c.changeMode(mode)
 	}
@@ -372,9 +372,10 @@ func (c *Controller) changeMode(mode Mode) {
 	if c.mode == mode {
 		return
 	}
-	if c.mode != ModeInvalid {
+	old := c.mode
+	if old != ModeInvalid {
 		c.lg.Info("changing mode",
-			"from", c.mode.String(),
+			"from", old.String(),
 			"to", mode.String(),
 		)
 	}
@@ -416,6 +417,7 @@ func (c *Controller) changeMode(mode Mode) {
 	c.mode = mode
 
 	c.gmUpdate()
+	c.observer.ModeChanged(old, mode)
 }
 
 // getDetectLeap builds the parameter-less leap-detection closure to

--- a/time/internal/phcsync/controller_test.go
+++ b/time/internal/phcsync/controller_test.go
@@ -178,12 +178,21 @@ func (b *fakeBuffer) WaitForPulseCorrection(refTime ptime.Time) bool {
 	return false
 }
 
-// recordingSampler captures Sample calls for inspection.
+// recordingSampler captures Sample and ModeChanged calls for inspection.
 type recordingSampler struct {
-	samples []Sample
+	samples      []Sample
+	modeChanges  []modeChange
+}
+
+type modeChange struct {
+	old, new Mode
 }
 
 func (s *recordingSampler) Sample(data Sample) { s.samples = append(s.samples, data) }
+
+func (s *recordingSampler) ModeChanged(old, new Mode) {
+	s.modeChanges = append(s.modeChanges, modeChange{old, new})
+}
 
 // fakeClock is a minimal phcsync.Clock implementation for tests.
 type fakeClock struct {
@@ -344,3 +353,45 @@ func TestChangeModeWiringDetectLeap(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// TestModeChangedFiresWithoutSample verifies that ModeChanged is delivered
+// to observers on every transition path, including ones that aren't driven
+// by a sample. The carrier-loss case (Pause -> ModeReset) is the motivating
+// scenario: Tick returns early in reset, so without an explicit ModeChanged
+// notification a current-state gauge would stay stuck at "tracking" until
+// samples resume.
+func TestModeChangedFiresWithoutSample(t *testing.T) {
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rec := &recordingSampler{}
+	c, err := NewController(&fakeClock{}, rec, nil, DefaultConfig(), ptime.LeapSecond{UTCOffAfter: 37}, 1, lg)
+	if err != nil {
+		t.Fatalf("NewController: %v", err)
+	}
+	// Initial transition: ModeInvalid -> ModeReset.
+	c.SetTimeMsgBuffer(&fakeBuffer{})
+	// Drive sampleless transitions through the controller's internal API.
+	c.lastSample = &Sample{Kind: SampleOK}
+	c.changeMode(ModeConverging)
+	c.changeMode(ModeTracking)
+	// The case Codex flagged: carrier loss while tracking.
+	c.Pause()
+
+	want := []modeChange{
+		{ModeInvalid, ModeReset},
+		{ModeReset, ModeConverging},
+		{ModeConverging, ModeTracking},
+		{ModeTracking, ModeReset},
+	}
+	if len(rec.modeChanges) != len(want) {
+		t.Fatalf("ModeChanged calls: got %d (%v), want %d (%v)",
+			len(rec.modeChanges), rec.modeChanges, len(want), want)
+	}
+	for i, mc := range rec.modeChanges {
+		if mc != want[i] {
+			t.Errorf("ModeChanged[%d] = %v, want %v", i, mc, want[i])
+		}
+	}
+	if len(rec.samples) != 0 {
+		t.Errorf("expected no Sample calls, got %d", len(rec.samples))
+	}
+}

--- a/time/internal/phcsync/sampler.go
+++ b/time/internal/phcsync/sampler.go
@@ -39,34 +39,52 @@ func (s *Sample) SysSample() phctime.Sample {
 	}
 }
 
-// Sampler handles clock synchronization samples of all types
-type Sampler interface {
-	// Sample reports a clock synchronization sample of any kind
+// Observer receives clock synchronization samples and mode-change events
+// from the controller.
+type Observer interface {
+	// Sample reports a clock synchronization sample of any kind.
+	// data.Mode is the mode the sample was served in; if the sample
+	// triggered a transition, ModeChanged will be called immediately
+	// after with the new mode.
 	Sample(data Sample)
+
+	// ModeChanged reports a transition in the controller's sync mode.
+	// It fires from every transition path, including those not driven
+	// by a sample (e.g. carrier-loss Pause). At controller startup the
+	// initial transition out of ModeInvalid into ModeReset is also
+	// reported here.
+	ModeChanged(oldMode, newMode Mode)
 }
 
-// MultiSampler fans out Sample calls to multiple samplers
-type MultiSampler struct {
-	samplers []Sampler
+// MultiObserver fans out events to multiple observers.
+type MultiObserver struct {
+	observers []Observer
 }
 
-// NewMultiSampler creates a new MultiSampler that fans out to multiple samplers
-func NewMultiSampler(samplers ...Sampler) *MultiSampler {
-	return &MultiSampler{samplers: samplers}
+// NewMultiObserver creates a new MultiObserver that fans out to multiple observers.
+func NewMultiObserver(observers ...Observer) *MultiObserver {
+	return &MultiObserver{observers: observers}
 }
 
-// Sample implements Sampler by calling Sample on all samplers
-func (m *MultiSampler) Sample(data Sample) {
-	for _, s := range m.samplers {
-		s.Sample(data)
+// Sample implements Observer by calling Sample on all observers.
+func (m *MultiObserver) Sample(data Sample) {
+	for _, o := range m.observers {
+		o.Sample(data)
 	}
 }
 
-// Samplers returns an iterator over the samplers
-func (m *MultiSampler) Samplers() iter.Seq[Sampler] {
-	return func(yield func(Sampler) bool) {
-		for _, s := range m.samplers {
-			if !yield(s) {
+// ModeChanged implements Observer by calling ModeChanged on all observers.
+func (m *MultiObserver) ModeChanged(oldMode, newMode Mode) {
+	for _, o := range m.observers {
+		o.ModeChanged(oldMode, newMode)
+	}
+}
+
+// Observers returns an iterator over the observers.
+func (m *MultiObserver) Observers() iter.Seq[Observer] {
+	return func(yield func(Observer) bool) {
+		for _, o := range m.observers {
+			if !yield(o) {
 				return
 			}
 		}

--- a/time/internal/promobs/prometheus.go
+++ b/time/internal/promobs/prometheus.go
@@ -26,6 +26,7 @@ type PrometheusObserver struct {
 
 	// PHC metrics
 	inSyncGauge           prometheus.Gauge
+	syncModeGauge         prometheus.Gauge
 	offsetHistogram       prometheus.Histogram
 	offsetGauge           prometheus.Gauge
 	frequencyGauge        prometheus.Gauge
@@ -80,6 +81,13 @@ func New(clockAccuracyNanos int) *PrometheusObserver {
 	})
 	// It takes a while for samples to start coming through: during this period we should be observed as out of sync.
 	inSyncGauge.Set(0)
+
+	// Sync mode gauge: holds the raw phcsync.Mode integer.
+	syncModeGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "satpulse_phc_sync_mode",
+		Help: syncModeHelp(),
+	})
+	syncModeGauge.Set(0)
 
 	// Clock offset histogram
 	offsetHistogram := prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -148,6 +156,7 @@ func New(clockAccuracyNanos int) *PrometheusObserver {
 
 	// Register metrics
 	reg.MustRegister(inSyncGauge)
+	reg.MustRegister(syncModeGauge)
 	reg.MustRegister(offsetHistogram)
 	reg.MustRegister(offsetGauge)
 	reg.MustRegister(frequencyGauge)
@@ -165,6 +174,7 @@ func New(clockAccuracyNanos int) *PrometheusObserver {
 		reg:                   reg,
 		activeSatellites:      make(map[gpsprot.SVID]map[gpsprot.SignalID]struct{}),
 		inSyncGauge:           inSyncGauge,
+		syncModeGauge:         syncModeGauge,
 		offsetHistogram:       offsetHistogram,
 		offsetGauge:           offsetGauge,
 		frequencyGauge:        frequencyGauge,
@@ -209,23 +219,47 @@ func makeBuckets(clockAccuracyNanos float64) []float64 {
 	return slices.Insert(buckets, i, clockAccuracySeconds)
 }
 
+// ModeChanged drives sync_mode and sync_status from the new controller
+// mode. Both gauges therefore reflect current state — including transitions
+// that aren't sample-driven, such as a Pause() on carrier loss.
+func (p *PrometheusObserver) ModeChanged(_, newMode phcsync.Mode) {
+	p.syncModeGauge.Set(float64(newMode))
+	if newMode.InSync() {
+		p.inSyncGauge.Set(1)
+		p.everInSync = true
+	} else {
+		p.inSyncGauge.Set(0)
+	}
+}
+
+// syncModeHelp builds the help text for the satpulse_phc_sync_mode metric
+// from the phcsync.Mode enum, so the documentation stays in lock-step with
+// the underlying constants.
+func syncModeHelp() string {
+	var b strings.Builder
+	b.WriteString("PHC time sync mode (")
+	for m := phcsync.ModeReset; m < phcsync.NModes; m++ {
+		if m > phcsync.ModeReset {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%d = %s", int(m), m)
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
 // Handler returns the HTTP handler for /metrics endpoint
 func (p *PrometheusObserver) Handler() http.Handler {
 	return promhttp.HandlerFor(p.reg, promhttp.HandlerOpts{})
 }
 
-// Sample implements phcsync.Sampler interface
+// Sample implements phcsync.Observer interface
 func (p *PrometheusObserver) Sample(data phcsync.Sample) {
 	// Always update frequency gauge (convert ppb to dimensionless)
 	p.frequencyGauge.Set(data.Freq / 1e9)
 
-	if data.Mode.InSync() {
-		p.inSyncGauge.Set(1)
-		if !p.everInSync {
-			p.everInSync = true
-		}
-	} else {
-		p.inSyncGauge.Set(0)
+	// data.Mode is sample-attribution: was this sample served in sync?
+	if !data.Mode.InSync() {
 		if p.everInSync {
 			p.samplesCounter.WithLabelValues("out_of_sync").Inc()
 		} else {

--- a/time/internal/promobs/prometheus_replay_test.go
+++ b/time/internal/promobs/prometheus_replay_test.go
@@ -66,9 +66,11 @@ func TestReplay(t *testing.T) {
 	}
 	t.Logf("replayed %d NavEpoch, %d Satellites events", nNavEpoch, nSatellites)
 
-	// Also exercise Sample() with hand-crafted PHC samples
+	// Also exercise Sample() and ModeChanged() with hand-crafted PHC samples.
+	obs.ModeChanged(phcsync.ModeInvalid, phcsync.ModeReset)
 	obs.Sample(phcsync.Sample{Kind: phcsync.SampleMissing, Mode: phcsync.ModeReset, Freq: 1000})
 	obs.Sample(phcsync.Sample{Kind: phcsync.SampleMissing, Mode: phcsync.ModeReset, Freq: 2000})
+	obs.ModeChanged(phcsync.ModeReset, phcsync.ModeTracking)
 	obs.Sample(phcsync.Sample{
 		Kind: phcsync.SampleOK, Mode: phcsync.ModeTracking, Freq: 500,
 		Offset: 50 * time.Nanosecond, FreqDelta: 0.1,
@@ -185,6 +187,15 @@ doneSignalCheck:
 	assertCounterLabel(t, mf, "satpulse_phc_samples_total", "status", "missing", 1)
 	// ModeTracking.InSync() == true, so last sample (Missing in tracking) keeps sync=1
 	assertGauge(t, mf, "satpulse_phc_sync_status", 1)
+	// Last sample is in ModeTracking; gauge holds the raw enum value.
+	assertGauge(t, mf, "satpulse_phc_sync_mode", float64(phcsync.ModeTracking))
+	// A ModeChanged notification — without any accompanying sample — must
+	// drive both gauges immediately, including paths like carrier-loss
+	// Pause where the controller transitions without producing a sample.
+	obs.ModeChanged(phcsync.ModeTracking, phcsync.ModeReset)
+	mfAfterTransition := scrape(t, obs)
+	assertGauge(t, mfAfterTransition, "satpulse_phc_sync_mode", float64(phcsync.ModeReset))
+	assertGauge(t, mfAfterTransition, "satpulse_phc_sync_status", 0)
 	// Frequency gauge should be last sample's Freq / 1e9
 	assertGauge(t, mf, "satpulse_phc_frequency_adjustment", 800.0/1e9)
 	// Offset gauge should be the last OK sample's offset: -30ns

--- a/time/internal/sseobs/sse.go
+++ b/time/internal/sseobs/sse.go
@@ -150,7 +150,7 @@ func (o *SSEObserver) Release() {
 	close(o.sseCh)
 }
 
-// Sample implements phcsync.Sampler - generates PHC sample SSE events
+// Sample implements phcsync.Observer - generates PHC sample SSE events
 func (o *SSEObserver) Sample(data phcsync.Sample) {
 	stepCount, changing := data.Era.StepCount()
 	event := SampleSSE{

--- a/time/internal/sseobs/sse.go
+++ b/time/internal/sseobs/sse.go
@@ -60,7 +60,7 @@ type SampleSSE struct {
 	StepCount         uint32  `json:"stepCount"`
 	StepCountChanging bool    `json:"stepCountChanging,omitempty"`
 	Outlier           bool    `json:"outlier,omitempty"`
-	SyncState         string  `json:"syncState"`
+	Mode              string  `json:"mode"`
 }
 
 // PosVelSSE is the SSE event data for position and velocity.
@@ -189,7 +189,7 @@ func (o *SSEObserver) Sample(data phcsync.Sample) {
 		StepCountChanging: changing,
 		Freq:              data.Freq,
 		Outlier:           data.Kind == phcsync.SampleOutlier,
-		SyncState:         data.Mode.String(),
+		Mode:              data.Mode.String(),
 	}
 	o.sendSSE("phc", event)
 }

--- a/time/internal/sseobs/sse.go
+++ b/time/internal/sseobs/sse.go
@@ -2,6 +2,7 @@ package sseobs
 
 import (
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpscfg"
@@ -19,6 +20,12 @@ import (
 // InitSSE is the type of the SSE for the initialization event
 type InitSSE struct {
 	Receiver *gpsprot.ReceiverInfo `json:"receiver,omitempty"`
+}
+
+// ModeSSE is the SSE event data for sync mode changes.
+// Carries the controller's current mode (post-transition).
+type ModeSSE struct {
+	Mode string `json:"mode"`
 }
 
 // TimeSSE is the type of the SSE for time events
@@ -119,6 +126,10 @@ type SSEObserver struct {
 	lg        *slog.Logger
 	ls        ptime.LeapSecond
 	initEvent sse.Event
+	// modeEvent caches the most recent "mode" event so new SSE clients
+	// can be told the current mode at connect time. nil before the first
+	// ModeChanged is observed.
+	modeEvent atomic.Pointer[sse.Event]
 }
 
 // New creates a new SSE observer with the provided channel and leap second.
@@ -141,8 +152,27 @@ func New(sseCh chan<- sse.Event, ls ptime.LeapSecond, lg *slog.Logger, cfgResult
 	}
 }
 
-func (o *SSEObserver) InitEvent() sse.Event {
-	return o.initEvent
+// InitEvents returns the events to write to a new SSE client before it
+// starts receiving live broadcast events. Currently the static init
+// event, plus the most recent mode event if one has been observed.
+func (o *SSEObserver) InitEvents() []sse.Event {
+	events := []sse.Event{o.initEvent}
+	if p := o.modeEvent.Load(); p != nil {
+		events = append(events, *p)
+	}
+	return events
+}
+
+// ModeChanged implements phcsync.Observer. Stores the latest mode event
+// for delivery to new clients and broadcasts it to current subscribers.
+func (o *SSEObserver) ModeChanged(_, newMode phcsync.Mode) {
+	ev, err := sse.Make("mode", ModeSSE{Mode: newMode.String()})
+	if err != nil {
+		o.lg.Error("failed to create SSE event", "name", "mode", "err", err)
+		return
+	}
+	o.modeEvent.Store(&ev)
+	o.sseCh <- ev
 }
 
 // Release implements Observer - closes the SSE channel

--- a/time/internal/sseobs/sse_test.go
+++ b/time/internal/sseobs/sse_test.go
@@ -59,7 +59,7 @@ func TestSSEObserver_Events(t *testing.T) {
 				})
 			},
 			eventType:    "phc",
-			expectedJSON: `{"offset":123,"freq":1.5,"stepCount":0,"stepCountChanging":true,"syncState":"tracking"}`,
+			expectedJSON: `{"offset":123,"freq":1.5,"stepCount":0,"stepCountChanging":true,"mode":"tracking"}`,
 		},
 		{
 			name: "sample_outlier",
@@ -73,7 +73,7 @@ func TestSSEObserver_Events(t *testing.T) {
 				})
 			},
 			eventType:    "phc",
-			expectedJSON: `{"offset":-456,"freq":-2.3,"stepCount":0,"stepCountChanging":true,"outlier":true,"syncState":"reset"}`,
+			expectedJSON: `{"offset":-456,"freq":-2.3,"stepCount":0,"stepCountChanging":true,"outlier":true,"mode":"reset"}`,
 		},
 		{
 			name: "time",

--- a/time/internal/sseobs/sse_test.go
+++ b/time/internal/sseobs/sse_test.go
@@ -30,11 +30,22 @@ func TestSSEObserver_Events(t *testing.T) {
 		{
 			name: "init",
 			action: func(obs *SSEObserver) {
-				event := obs.InitEvent()
-				obs.sseCh <- event
+				events := obs.InitEvents()
+				if len(events) != 1 {
+					panic("expected single init event before any ModeChanged")
+				}
+				obs.sseCh <- events[0]
 			},
 			eventType:    "init",
 			expectedJSON: `{"receiver":{"vendor":"u-blox","firmware":"HPG 1.32 PROTVER 27.31","hardware":"ZED-F9P","supportedGNSS":["GPS","GLO"]}}`,
+		},
+		{
+			name: "mode_changed",
+			action: func(obs *SSEObserver) {
+				obs.ModeChanged(phcsync.ModeReset, phcsync.ModeTracking)
+			},
+			eventType:    "mode",
+			expectedJSON: `{"mode":"tracking"}`,
 		},
 		{
 			name: "sample_ok",
@@ -389,6 +400,44 @@ func TestNavEpochPVSSE(t *testing.T) {
 	quality := <-ch
 	if !strings.Contains(quality.Format(), "event: quality\n") {
 		t.Errorf("expected quality event, got: %s", quality.Format())
+	}
+}
+
+// TestInitEventsAfterModeChanged checks that once ModeChanged has been
+// observed, InitEvents includes the cached mode event so a fresh client
+// learns the current mode at connect time.
+func TestInitEventsAfterModeChanged(t *testing.T) {
+	ch := make(chan sse.Event, 1)
+	cfgResult := &gpscfg.Result{ReceiverInfo: &gpsprot.ReceiverInfo{Vendor: "test"}}
+	obs := New(ch, ptime.LeapSecond{}, slog.Default(), cfgResult)
+	if got := obs.InitEvents(); len(got) != 1 {
+		t.Fatalf("expected 1 init event before ModeChanged, got %d", len(got))
+	}
+	obs.ModeChanged(phcsync.ModeInvalid, phcsync.ModeReset)
+	<-ch // drain the broadcast emit
+	events := obs.InitEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 init events after ModeChanged, got %d", len(events))
+	}
+	if !strings.Contains(events[0].Format(), "event: init\n") {
+		t.Errorf("first init event should be init, got: %s", events[0].Format())
+	}
+	wire := events[1].Format()
+	if !strings.Contains(wire, "event: mode\n") {
+		t.Errorf("second init event should be mode, got: %s", wire)
+	}
+	if !strings.Contains(wire, `{"mode":"reset"}`) {
+		t.Errorf("mode event payload should be {\"mode\":\"reset\"}, got: %s", wire)
+	}
+	// A subsequent transition replaces the cached mode.
+	obs.ModeChanged(phcsync.ModeReset, phcsync.ModeTracking)
+	<-ch
+	events = obs.InitEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 init events, got %d", len(events))
+	}
+	if !strings.Contains(events[1].Format(), `{"mode":"tracking"}`) {
+		t.Errorf("expected mode=tracking after second ModeChanged, got: %s", events[1].Format())
 	}
 }
 

--- a/time/internal/statsobs/statsobs.go
+++ b/time/internal/statsobs/statsobs.go
@@ -63,7 +63,7 @@ func NewStatsObserver() *StatsObserver {
 	return &StatsObserver{}
 }
 
-// Sample implements phcsync.Sampler
+// Sample implements phcsync.Observer
 func (o *StatsObserver) Sample(data phcsync.Sample) {
 	// Only accumulate when in sync
 	if !data.Mode.InSync() {

--- a/web/app.js
+++ b/web/app.js
@@ -719,7 +719,7 @@
 
   // dashboard.tsx
   var EventSourceContext = Q(null);
-  var EVENT_TYPES = ["satellites", "time", "phc", "survey", "receiver", "posvel", "quality", "init"];
+  var EVENT_TYPES = ["satellites", "time", "phc", "mode", "survey", "receiver", "posvel", "quality", "init"];
   var Dashboard = () => {
     const context = x2(EventSourceContext);
     const [events, setEvents] = d2({});
@@ -755,7 +755,10 @@
       events.satellites && haveLookAngles && /* @__PURE__ */ u3(SkyViewCard, { svs }),
       events.satellites && /* @__PURE__ */ u3(SignalGraphCard, { svs }),
       events.time && /* @__PURE__ */ u3(PropertyCard, { title: "Current GPS Time", data: events.time, format: timeFormat }),
-      events.phc && /* @__PURE__ */ u3(PropertyCard, { title: "PTP Hardware Clock", data: events.phc, format: phcFormat }),
+      (events.phc || events.mode) && // Both events carry a `mode` field; spreading events.mode last
+      // means the dedicated mode event wins over the per-sample mode,
+      // so transitions are visible before the next sample arrives.
+      /* @__PURE__ */ u3(PropertyCard, { title: "PTP Hardware Clock", data: { ...events.phc, ...events.mode }, format: phcFormat }),
       events.receiver && /* @__PURE__ */ u3(PropertyCard, { title: "Receiver", data: events.receiver, format: receiverFormat }),
       events.quality && /* @__PURE__ */ u3(PropertyCard, { title: "Status", data: events.quality, format: statusFormat }),
       events.posvel && /* @__PURE__ */ u3(PropertyCard, { title: "Position", data: events.posvel, format: positionFormat }),
@@ -864,7 +867,7 @@
     tai: ["TAI", formatTAI]
   };
   var phcFormat = {
-    syncState: ["State"],
+    mode: ["State"],
     offset: ["Offset from GPS", formatNanoseconds],
     freq: ["Frequency offset", (arg) => `${arg.toFixed(2)} ppb`],
     stepCount: (count, obj) => [

--- a/web/app.js
+++ b/web/app.js
@@ -723,6 +723,7 @@
   var Dashboard = () => {
     const context = x2(EventSourceContext);
     const [events, setEvents] = d2({});
+    const [phc, setPhc] = d2(null);
     const [haveLookAngles, setHaveLookAngles] = d2(false);
     const [everMoving, setEverMoving] = d2(false);
     y2(() => {
@@ -731,6 +732,10 @@
         for (const [eventType, eventData] of parsedEvents) {
           const obj = validateEvent(eventType, eventData);
           if (obj !== null) {
+            if (eventType === "phc" || eventType === "mode") {
+              setPhc((prev) => ({ ...prev, ...obj }));
+              continue;
+            }
             if (eventType === "satellites" && obj.svs && obj.svs.length > 0) {
               setHaveLookAngles(obj.svs.some((sv) => sv.lookAngles));
             }
@@ -755,10 +760,7 @@
       events.satellites && haveLookAngles && /* @__PURE__ */ u3(SkyViewCard, { svs }),
       events.satellites && /* @__PURE__ */ u3(SignalGraphCard, { svs }),
       events.time && /* @__PURE__ */ u3(PropertyCard, { title: "Current GPS Time", data: events.time, format: timeFormat }),
-      (events.phc || events.mode) && // Both events carry a `mode` field; spreading events.mode last
-      // means the dedicated mode event wins over the per-sample mode,
-      // so transitions are visible before the next sample arrives.
-      /* @__PURE__ */ u3(PropertyCard, { title: "PTP Hardware Clock", data: { ...events.phc, ...events.mode }, format: phcFormat }),
+      phc && /* @__PURE__ */ u3(PropertyCard, { title: "PTP Hardware Clock", data: phc, format: phcFormat }),
       events.receiver && /* @__PURE__ */ u3(PropertyCard, { title: "Receiver", data: events.receiver, format: receiverFormat }),
       events.quality && /* @__PURE__ */ u3(PropertyCard, { title: "Status", data: events.quality, format: statusFormat }),
       events.posvel && /* @__PURE__ */ u3(PropertyCard, { title: "Position", data: events.posvel, format: positionFormat }),

--- a/web/dashboard.tsx
+++ b/web/dashboard.tsx
@@ -19,6 +19,11 @@ type Map = {[key: string]: any};
 export const Dashboard: FunctionComponent = () => {
     const context = useContext(EventSourceContext) as EventSource;
     const [events, setEvents] = useState<Map>({});
+    // phc accumulates fields from both `phc` and `mode` events as they
+    // arrive. The shared `mode` field is therefore last-write-wins by
+    // arrival order, so a stale cached mode delivered at connect is
+    // corrected by the next live event from either stream.
+    const [phc, setPhc] = useState<Map | null>(null);
     const [haveLookAngles, setHaveLookAngles] = useState(false);
     const [everMoving, setEverMoving] = useState(false);
 
@@ -28,6 +33,10 @@ export const Dashboard: FunctionComponent = () => {
             for (const [eventType, eventData] of parsedEvents) {
                 const obj : Map|null = validateEvent(eventType, eventData);
                 if (obj !== null) {
+                    if (eventType === 'phc' || eventType === 'mode') {
+                        setPhc(prev => ({ ...prev, ...obj }));
+                        continue;
+                    }
                     if (eventType === 'satellites' && obj.svs && obj.svs.length > 0) {
                         setHaveLookAngles(obj.svs.some((sv: any) => sv.lookAngles));
                     }
@@ -55,12 +64,7 @@ export const Dashboard: FunctionComponent = () => {
         {events.satellites && haveLookAngles && <SkyViewCard svs={svs} />}
         {events.satellites && <SignalGraphCard svs={svs} />}
         {events.time && <PropertyCard title="Current GPS Time" data={events.time} format={timeFormat} />}
-        {(events.phc || events.mode) && (
-            // Both events carry a `mode` field; spreading events.mode last
-            // means the dedicated mode event wins over the per-sample mode,
-            // so transitions are visible before the next sample arrives.
-            <PropertyCard title="PTP Hardware Clock" data={{ ...events.phc, ...events.mode }} format={phcFormat} />
-        )}
+        {phc && <PropertyCard title="PTP Hardware Clock" data={phc} format={phcFormat} />}
         {events.receiver && <PropertyCard title="Receiver" data={events.receiver} format={receiverFormat} />}
         {events.quality && <PropertyCard title="Status" data={events.quality} format={statusFormat} />}
         {events.posvel && <PropertyCard title="Position" data={events.posvel} format={positionFormat} />}

--- a/web/dashboard.tsx
+++ b/web/dashboard.tsx
@@ -11,7 +11,7 @@ type JSONObject = { [key: string]: JSONValue };
 type JSONArray = JSONValue[];
 
 // Use a more specific type for our parsed event data
-const EVENT_TYPES = ["satellites", "time", "phc", "survey", "receiver", "posvel", "quality", "init"] as const;
+const EVENT_TYPES = ["satellites", "time", "phc", "mode", "survey", "receiver", "posvel", "quality", "init"] as const;
 type EventType = typeof EVENT_TYPES[number];
 
 type Map = {[key: string]: any};
@@ -55,7 +55,12 @@ export const Dashboard: FunctionComponent = () => {
         {events.satellites && haveLookAngles && <SkyViewCard svs={svs} />}
         {events.satellites && <SignalGraphCard svs={svs} />}
         {events.time && <PropertyCard title="Current GPS Time" data={events.time} format={timeFormat} />}
-        {events.phc && <PropertyCard title="PTP Hardware Clock" data={events.phc} format={phcFormat} />}
+        {(events.phc || events.mode) && (
+            // Both events carry a `mode` field; spreading events.mode last
+            // means the dedicated mode event wins over the per-sample mode,
+            // so transitions are visible before the next sample arrives.
+            <PropertyCard title="PTP Hardware Clock" data={{ ...events.phc, ...events.mode }} format={phcFormat} />
+        )}
         {events.receiver && <PropertyCard title="Receiver" data={events.receiver} format={receiverFormat} />}
         {events.quality && <PropertyCard title="Status" data={events.quality} format={statusFormat} />}
         {events.posvel && <PropertyCard title="Position" data={events.posvel} format={positionFormat} />}
@@ -242,7 +247,7 @@ const timeFormat: EventFormat = {
 }
 
 const phcFormat: EventFormat = {
-    syncState: ["State"],
+    mode: ["State"],
     offset: ["Offset from GPS", formatNanoseconds],
     freq: ["Frequency offset", (arg: number) => `${arg.toFixed(2)} ppb`],
     stepCount: (count: number, obj: Map) => [

--- a/web/style.css
+++ b/web/style.css
@@ -196,9 +196,6 @@
   .invisible {
     visibility: hidden;
   }
-  .visible {
-    visibility: visible;
-  }
   .row-span-2 {
     grid-row: span 2 / span 2;
   }

--- a/web/style.css
+++ b/web/style.css
@@ -196,6 +196,9 @@
   .invisible {
     visibility: hidden;
   }
+  .visible {
+    visibility: visible;
+  }
   .row-span-2 {
     grid-row: span 2 / span 2;
   }

--- a/web/test-dashboard.tsx
+++ b/web/test-dashboard.tsx
@@ -41,7 +41,11 @@ const phcEvent = {
   stepCount: 5,
   stepCountChanging: false,
   outlier: false,
-  syncState: "in sync"
+  mode: "tracking"
+};
+
+const modeEvent = {
+  mode: "tracking",
 };
 
 const posvelEvent = {
@@ -147,6 +151,10 @@ class MockEventSource implements MinimalEventSource {
       setTimeout(() => {
         listener(new MessageEvent('phc', { data: JSON.stringify(phcEvent) }));
       }, 400);
+    } else if (type === 'mode') {
+      setTimeout(() => {
+        listener(new MessageEvent('mode', { data: JSON.stringify(modeEvent) }));
+      }, 380);
     } else if (type === 'init') {
       setTimeout(() => {
         listener(new MessageEvent('init', { data: JSON.stringify(initEvent) }));


### PR DESCRIPTION
Until now, observers learned the controller's sync mode only as a side
effect of receiving samples (via Sample.Mode). That conflates
sample-attribution with current state and leaves observers stale during
transitions that don't produce a sample -- notably Controller.Pause on
carrier loss (Tick returns early in reset, so no sample arrives) and
the initial ModeInvalid -> ModeReset.

Add a ModeChanged(oldMode, newMode) method to phcsync.Observer and
fire it from Controller.changeMode. This gives observers a direct
mode-change signal that fires on every transition. Sample.Mode goes
back to being purely sample-attribution.

Apply the new mechanism in three places:

- promobs: add a satpulse_phc_sync_mode gauge (raw phcsync.Mode int,
  help text generated from the enum) and drive both it and the
  existing satpulse_phc_sync_status gauge from ModeChanged.

- sseobs: emit a dedicated "mode" SSE event on every transition,
  cached in an atomic.Pointer and replayed to new clients via
  InitEvents. Rename SampleSSE.SyncState to Mode (json "mode") so the
  per-sample field shares a key with the dedicated event.

- web dashboard: fold "phc" and "mode" events into a single phc state
  object as they arrive, so the shared mode field is last-write-wins by
  arrival order. A stale cached mode delivered at connect is corrected
  by the next live event from either stream.

Also reorder the HTTP SSE handler to subscribe before snapshotting the
init events: any broadcast that fires after Subscribe is queued for us,
so a mode change racing with our connect cannot be lost between
snapshot and live delivery. (A residual microsecond-window race in the
generic bcast.Subscribe predates this PR.)

Fixes #177