### PR TITLE
Skip init SSE event when no receiver info is available

### DIFF
--- a/time/internal/sseobs/sse.go
+++ b/time/internal/sseobs/sse.go
@@ -138,25 +138,31 @@ func New(sseCh chan<- sse.Event, ls ptime.LeapSecond, lg *slog.Logger, cfgResult
 	if sseCh == nil {
 		panic("sseCh must be non-nil")
 	}
-	initEvent, err := sse.Make("init", InitSSE{
-		Receiver: cfgResult.ReceiverInfo,
-	})
-	if err != nil {
-		lg.Error("failed to create SSE event", "name", "init", "err", err)
+	o := &SSEObserver{
+		sseCh: sseCh,
+		ls:    ls,
+		lg:    lg,
 	}
-	return &SSEObserver{
-		sseCh:     sseCh,
-		ls:        ls,
-		lg:        lg,
-		initEvent: initEvent,
+	if cfgResult != nil && cfgResult.ReceiverInfo != nil {
+		ev, err := sse.Make("init", InitSSE{Receiver: cfgResult.ReceiverInfo})
+		if err != nil {
+			lg.Error("failed to create SSE event", "name", "init", "err", err)
+		} else {
+			o.initEvent = ev
+		}
 	}
+	return o
 }
 
 // InitEvents returns the events to write to a new SSE client before it
 // starts receiving live broadcast events. Currently the static init
-// event, plus the most recent mode event if one has been observed.
+// event (if any receiver info is available), plus the most recent mode
+// event if one has been observed.
 func (o *SSEObserver) InitEvents() []sse.Event {
-	events := []sse.Event{o.initEvent}
+	var events []sse.Event
+	if !o.initEvent.IsZero() {
+		events = append(events, o.initEvent)
+	}
 	if p := o.modeEvent.Load(); p != nil {
 		events = append(events, *p)
 	}

--- a/time/internal/sseobs/sse_test.go
+++ b/time/internal/sseobs/sse_test.go
@@ -441,6 +441,18 @@ func TestInitEventsAfterModeChanged(t *testing.T) {
 	}
 }
 
+// TestNewNilCfgResult checks that New tolerates a nil cfgResult and
+// emits no init event in that case. This happens in degraded startup
+// when GPS detection fails but the daemon continues running because no
+// PHC is configured.
+func TestNewNilCfgResult(t *testing.T) {
+	ch := make(chan sse.Event, 1)
+	obs := New(ch, ptime.LeapSecond{}, slog.Default(), nil)
+	if got := obs.InitEvents(); len(got) != 0 {
+		t.Fatalf("expected 0 init events with nil cfgResult, got %d", len(got))
+	}
+}
+
 // jsonEqual compares two JSON strings for equivalence by parsing and using reflect.DeepEqual
 func jsonEqual(a, b string) bool {
 	var objA, objB interface{}


### PR DESCRIPTION
## Summary
- When GPS detection returns `ErrNotDetected` and no PHC is configured, the daemon continues with `gcfg == nil`. Passing this to `sseobs.New` previously panicked on `cfgResult.ReceiverInfo` if a GUI HTTP endpoint was configured.
- Guard the nil case in `sseobs.New` and skip building an init event when there's no receiver info. An empty init payload conveys nothing, and the dashboard already gates the Receiver card on the presence of `events.receiver`.

Spotted by Codex review on #289 but pre-existing on master.

## Test plan
- [x] `go test ./time/internal/sseobs/ ./time/app/daemon/`
- [x] New `TestNewNilCfgResult` covers the nil-cfgResult path