### PR TITLE
Introduce ntime.Time for domain-neutral time values in the refclock path

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -212,6 +212,8 @@ These packages are reusable libraries for time synchronization. They are in the 
 
 `time/lib/median` provides efficient median computation for a fixed-size moving window using a circular buffer with a sorted index array. It supports 64-bit integers, floats, and time.Duration.
 
+`time/lib/ntime` provides a domain-neutral nanosecond timestamp type for the refclock sample path. The domain of a value (UTC, TAI, PHC-raw) is determined by the producer and consumer, not by the type. It depends only on the standard library.
+
 ### internal/
 
 These packages implement subcommands of satpulsetool. They are in the command-line layer and can import from both `gps/` and `time/`.

--- a/time/internal/gpsevent/dispatcher.go
+++ b/time/internal/gpsevent/dispatcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jclark/satpulse/time/internal/timemsg"
 	"github.com/jclark/satpulse/time/internal/ts"
 	"github.com/jclark/satpulse/time/lib/median"
+	"github.com/jclark/satpulse/time/lib/ntime"
 	"github.com/jclark/satpulse/time/lib/ntpshm"
 	"github.com/jclark/satpulse/time/phctime"
 	"golang.org/x/sys/unix"
@@ -398,7 +399,7 @@ func (d *Dispatcher) sysSample(ref ptime.Time, sys time.Time, samplePrecision ti
 	offset := clockTime.Sub(sys).Seconds()
 	leap := d.ls.StateAt(ref).LeapTonight
 	if d.rc != nil {
-		if err := d.rc.Sample(sys, offset, leap); err != nil {
+		if err := d.rc.Sample(ntime.Sys(sys), offset, leap); err != nil {
 			d.lg.Warn("refclock sample failed", "err", err)
 		}
 	}
@@ -412,7 +413,7 @@ func (d *Dispatcher) sysSample(ref ptime.Time, sys time.Time, samplePrecision ti
 func (d *Dispatcher) MsgUTCTime(utc time.Time, tRead time.Time, leap ptime.LeapSecondKind) {
 	offset := utc.Sub(tRead).Seconds()
 	if d.rc != nil {
-		if err := d.rc.Sample(tRead, offset, leap); err != nil {
+		if err := d.rc.Sample(ntime.Sys(tRead), offset, leap); err != nil {
 			d.lg.Warn("refclock sample failed", "err", err)
 		}
 	}

--- a/time/internal/gpsevent/dispatcher_test.go
+++ b/time/internal/gpsevent/dispatcher_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jclark/satpulse/gps/scan"
 	"github.com/jclark/satpulse/time/internal/obs"
 	"github.com/jclark/satpulse/time/internal/refclock"
+	"github.com/jclark/satpulse/time/lib/ntime"
 	"github.com/jclark/satpulse/time/lib/ntpshm"
 )
 
@@ -192,7 +193,7 @@ func TestDispatcherMsgUTCTimeWritesBothSinks(t *testing.T) {
 	}
 	select {
 	case s := <-ch:
-		if !s.Sys.Equal(tRead) || s.Offset != utc.Sub(tRead).Seconds() || s.Leap != ptime.LeapSecondNegative {
+		if s.Sys != ntime.Sys(tRead) || s.Offset != utc.Sub(tRead).Seconds() || s.Leap != ptime.LeapSecondNegative {
 			t.Fatalf("refclock sample = %+v", s)
 		}
 	default:

--- a/time/internal/refclock/refclock.go
+++ b/time/internal/refclock/refclock.go
@@ -5,19 +5,25 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/jclark/satpulse/gps/ptime"
+	"github.com/jclark/satpulse/time/lib/ntime"
+	"github.com/jclark/satpulse/time/sockrefclock"
 	"golang.org/x/sys/unix"
 )
 
 type RefClock interface {
 	io.Closer
-	Sample(sys time.Time, offset float64, leap ptime.LeapSecondKind) error
+	Sample(sys ntime.Time, offset float64, leap ptime.LeapSecondKind) error
 }
 
+// SockRefClock is the interface to a chrony SOCK protocol speaker such
+// as sockrefclock.SockRefClock. Its Sample takes the wire-level leap
+// value; LoggingSockRefClock converts from the domain-level
+// ptime.LeapSecondKind, keeping the wire format hidden from producers.
 type SockRefClock interface {
-	RefClock
+	io.Closer
+	Sample(sys ntime.Time, offset float64, leap sockrefclock.Leap) error
 	RemotePath() string
 }
 
@@ -26,7 +32,7 @@ type ProxyRefClock struct {
 }
 
 type RefClockSample struct {
-	Sys    time.Time
+	Sys    ntime.Time
 	Offset float64
 	Leap   ptime.LeapSecondKind
 }
@@ -40,7 +46,7 @@ func (rc *ProxyRefClock) Close() {
 	close(rc.sampleCh)
 }
 
-func (rc *ProxyRefClock) Sample(sys time.Time, offset float64, leap ptime.LeapSecondKind) error {
+func (rc *ProxyRefClock) Sample(sys ntime.Time, offset float64, leap ptime.LeapSecondKind) error {
 	select {
 	case rc.sampleCh <- RefClockSample{Sys: sys, Offset: offset, Leap: leap}:
 		return nil
@@ -85,8 +91,8 @@ func (rc *LoggingSockRefClock) Close() error {
 	return rc.sock.Close()
 }
 
-func (rc *LoggingSockRefClock) Sample(sys time.Time, offset float64, leap ptime.LeapSecondKind) error {
-	err := rc.sock.Sample(sys, offset, leap)
+func (rc *LoggingSockRefClock) Sample(sys ntime.Time, offset float64, leap ptime.LeapSecondKind) error {
+	err := rc.sock.Sample(sys, offset, sockLeap(leap))
 	lg := rc.lg
 	path := rc.sock.RemotePath()
 	if err != nil {
@@ -108,4 +114,17 @@ func (rc *LoggingSockRefClock) Sample(sys time.Time, offset float64, leap ptime.
 		lg.Debug("successfully sent sample to refclock socket", "path", path, "sys", sys, "offset", offset)
 	}
 	return nil
+}
+
+// sockLeap maps the domain-level leap-second state to the SOCK
+// protocol's wire value.
+func sockLeap(leap ptime.LeapSecondKind) sockrefclock.Leap {
+	switch leap {
+	case ptime.LeapSecondPositive:
+		return sockrefclock.LeapInsert
+	case ptime.LeapSecondNegative:
+		return sockrefclock.LeapDelete
+	default:
+		return sockrefclock.LeapNone
+	}
 }

--- a/time/lib/ntime/ntime.go
+++ b/time/lib/ntime/ntime.go
@@ -1,0 +1,45 @@
+// Package ntime provides a domain-neutral nanosecond timestamp.
+// A Time is just integer nanoseconds from an unspecified epoch; its
+// domain (UTC, TAI, PHC-raw, ...) is determined by the producer and
+// consumer, not by the type. It carries none of the wall-clock
+// semantics of time.Time and none of the TAI interpretation of
+// ptime.Time; its API is the small subset of arithmetic that the
+// refclock sample path needs.
+package ntime
+
+import "time"
+
+// Time is a timestamp in nanoseconds from an unspecified epoch.
+type Time int64
+
+// Sys converts a time.Time to a Time with the same nanosecond value.
+func Sys(sys time.Time) Time {
+	return Time(sys.UnixNano())
+}
+
+// SysTime converts t to a time.Time with the same nanosecond value,
+// in the UTC zone.
+func (t Time) SysTime() time.Time {
+	return time.Unix(0, int64(t)).UTC()
+}
+
+func (t Time) IsZero() bool {
+	return int64(t) == 0
+}
+
+func (t Time) Add(d time.Duration) Time {
+	return Time(int64(t) + int64(d))
+}
+
+func (t Time) Sub(t2 Time) time.Duration {
+	return time.Duration(int64(t) - int64(t2))
+}
+
+func (t Time) Before(t2 Time) bool {
+	return t < t2
+}
+
+func (t Time) Round(d time.Duration) Time {
+	// Let the time package do the tricky bit
+	return Time(int64(time.Duration(int64(t)).Round(d)))
+}

--- a/time/lib/ntime/ntime_test.go
+++ b/time/lib/ntime/ntime_test.go
@@ -1,0 +1,52 @@
+package ntime
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRound(t *testing.T) {
+	tests := []struct {
+		name   string
+		t      Time
+		d      time.Duration
+		expect Time
+	}{
+		{name: "down", t: Time(1_400_000_000), d: time.Second, expect: Time(1_000_000_000)},
+		{name: "up", t: Time(1_500_000_000), d: time.Second, expect: Time(2_000_000_000)},
+		{name: "exact", t: Time(3_000_000_000), d: time.Second, expect: Time(3_000_000_000)},
+		{name: "negative", t: Time(-1_400_000_000), d: time.Second, expect: Time(-1_000_000_000)},
+		{name: "millisecond", t: Time(1_000_499_999), d: time.Millisecond, expect: Time(1_000_000_000)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.t.Round(tc.d); got != tc.expect {
+				t.Errorf("got %d, want %d", got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestConversions(t *testing.T) {
+	sys := time.Date(2026, 4, 19, 12, 0, 0, 123, time.UTC)
+	if got := Sys(sys); got != Time(sys.UnixNano()) {
+		t.Errorf("Sys: got %d, want %d", got, sys.UnixNano())
+	}
+	if got := Sys(sys).SysTime(); !got.Equal(sys) {
+		t.Errorf("SysTime round trip: got %v, want %v", got, sys)
+	}
+}
+
+func TestArithmetic(t *testing.T) {
+	a := Time(5_000_000_000)
+	b := a.Add(250 * time.Millisecond)
+	if b != Time(5_250_000_000) {
+		t.Errorf("Add: got %d", b)
+	}
+	if d := b.Sub(a); d != 250*time.Millisecond {
+		t.Errorf("Sub: got %v", d)
+	}
+	if !a.Before(b) || b.Before(a) {
+		t.Errorf("Before: got %v, %v", a.Before(b), b.Before(a))
+	}
+}

--- a/time/sockrefclock/sockpacket.go
+++ b/time/sockrefclock/sockpacket.go
@@ -1,28 +1,29 @@
 package sockrefclock
 
 import (
-	"time"
 	"unsafe"
 
-	"github.com/jclark/satpulse/gps/ptime"
+	"github.com/jclark/satpulse/time/lib/ntime"
 	"golang.org/x/sys/unix"
 )
 
 const sockMagic = 0x534f434b
 
-type sockLeap int32
+// Leap is the leap-second status field of a SOCK sample, using the
+// values defined by chrony's refclock SOCK protocol.
+type Leap int32
 
 const (
-	leapNormal sockLeap = iota
-	leapInsert
-	leapDelete
+	LeapNone Leap = iota
+	LeapInsert
+	LeapDelete
 )
 
 type sockSample struct {
 	tv     unix.Timeval // System time of the measurement
 	offset float64      // Offset between the true time and the system time (in seconds)
 	pulse  int32        // Non-zero if this is PPS only (no seconds)
-	leap   sockLeap
+	leap   Leap
 	_      int32
 	magic  int32 // must be sockMagic
 }
@@ -30,7 +31,7 @@ type sockSample struct {
 const sizeofSockSample = (64*3 + 32*4) / 8 // timeval is 2 64-bit ints
 
 // sockPacket creates a Chrony refclock SOCK sample packet.
-func sockPacket(sys time.Time, offset float64, leap ptime.LeapSecondKind) ([]byte, error) {
+func sockPacket(sys ntime.Time, offset float64, leap Leap) ([]byte, error) {
 	var s sockSample
 	initSockSample(&s, sys, offset, leap)
 	var buf [sizeofSockSample]byte
@@ -39,20 +40,9 @@ func sockPacket(sys time.Time, offset float64, leap ptime.LeapSecondKind) ([]byt
 	return buf[:], nil
 }
 
-func initSockSample(s *sockSample, sys time.Time, offset float64, leap ptime.LeapSecondKind) {
-	s.tv = unix.NsecToTimeval(sys.UnixNano())
+func initSockSample(s *sockSample, sys ntime.Time, offset float64, leap Leap) {
+	s.tv = unix.NsecToTimeval(int64(sys))
 	s.offset = offset
-	s.leap = leapToSock(leap)
+	s.leap = leap
 	s.magic = sockMagic
-}
-
-func leapToSock(leap ptime.LeapSecondKind) sockLeap {
-	switch leap {
-	case ptime.LeapSecondPositive:
-		return leapInsert
-	case ptime.LeapSecondNegative:
-		return leapDelete
-	default:
-		return leapNormal
-	}
 }

--- a/time/sockrefclock/sockrefclock.go
+++ b/time/sockrefclock/sockrefclock.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/jclark/satpulse/gps/ptime"
+	"github.com/jclark/satpulse/time/lib/ntime"
 )
 
 type SockRefClock struct {
@@ -39,7 +39,7 @@ func (c *SockRefClock) RemotePath() string {
 
 const sockRefClockTimeout = time.Second / 10
 
-func (c *SockRefClock) Sample(sys time.Time, offset float64, leap ptime.LeapSecondKind) error {
+func (c *SockRefClock) Sample(sys ntime.Time, offset float64, leap Leap) error {
 	pkt, err := sockPacket(sys, offset, leap)
 	if err != nil {
 		return err


### PR DESCRIPTION
The refclock path carried sample timestamps as `time.Time`, but nothing along the way uses `time.Time`'s wall-clock functionality; the values are just integer nanoseconds whose domain (UTC, TAI, PHC-raw) is determined by the producer and consumer.

- Add `time/lib/ntime`: a domain-neutral nanosecond timestamp with a small arithmetic-only API plus `time.Time` conversions (`Sys`, `SysTime`). The package depends only on the standard library; conversions to and from `ptime.Time` are explicit casts owned by callers that know the value is TAI.
- Convert `RefClock.Sample`, `RefClockSample.Sys`, and the SOCK packet writer to `ntime.Time`.
- `sockrefclock` no longer depends on `ptime`: it defines the wire-level `Leap` enum of the SOCK protocol, and `refclock`'s `LoggingSockRefClock` converts from the domain-level `ptime.LeapSecondKind`, keeping the wire format hidden from producers.

The SOCK bytes on the wire are unchanged. This is the base of the stack for #257 and #256.

Fixes #258