### PR TITLE
gpshwtest signal coexistence characterization

### DIFF
--- a/gpshwtest/GOAL.md
+++ b/gpshwtest/GOAL.md
@@ -16,7 +16,7 @@ This file defines the goal and how to measure progress toward it. It deliberatel
 
 The program must cover the entire documented high-level configuration vocabulary of `satpulsetool gps` (see `docs/man/satpulsetool-gps.1.md`). Characterization that covers only some properties is not done. The vocabulary:
 
-- Enabled constellations and bands (`--gnss`, `--band`)
+- Enabled signals (`--gnss`, `--band`, `--signal`, `--except-signal`)
 - Timing constellation (`--time-gnss`)
 - Time pulse (`--pps`)
 - Antenna cable delay (`--ant-cable-delay`)
@@ -78,7 +78,7 @@ Failures that are diagnosed down to a satpulsetool defect get recorded in `BUGS.
 For each receiver+firmware the program produces a machine-readable characterization of how device-independent configuration works on that receiver. Its content is the receiver's limitations relative to perfect realization of the model - what cannot be done, what is coupled, what is quantized, how coarsely saving persists - because the perfectly-realized parts need no description. Requirements:
 
 - Expressed in the device-independent vocabulary (model properties and values), never in terms of satpulsetool command-line syntax or the program's internal test cases.
-- High level: patterns and parameters (for example "an enabled constellation must have all its signals enabled, except BDS", "pulse width quantized to 1 us", "fixed position stored to 1 cm"), not a list of probe outcomes.
+- High level: patterns and parameters (for example "QZSS requires GPS", "an enabled constellation must include an L1-family signal", "BDS B1I and B1C are mutually exclusive", "pulse width quantized to 1 us", "fixed position stored to 1 cm"), not a list of probe outcomes.
 - Stable: its content describes the receiver and the configuration semantics, so it must be substantially unchanged when the program's exact probe values or test set change, and when satpulsetool's implementation of configuration changes without changing behavior. Only genuine behavior differences may move it; that stability is what makes the checked-in characterization usable as a regression baseline.
 - Honest: observations the program cannot express in its current vocabulary are carried verbatim rather than forced into a pattern or dropped.
 
@@ -118,6 +118,6 @@ The end state is that this workflow runs unattended through `systest/`: a playbo
 ## Working method
 
 - Probe first, then derive vocabulary: do not invent characterization vocabulary for a property before looking at raw observations from real receivers. Keep the raw-observation output available permanently; it is how unfamiliar receivers get examined.
-- Build the easiest properties first to establish the probe/characterize/vet/compare pipeline end to end; signal combinations and save granularity are the hardest parts.
+- Build the easiest properties first to establish the probe/characterize/vet/compare pipeline end to end; signal coexistence rules and save granularity are the hardest parts.
 - Keep `make typecheck` (mypy strict) passing; commit coherent increments.
 - If these goals turn out to be wrong or ambiguous on contact with reality, flag it to the user rather than silently reinterpreting them.

--- a/gpshwtest/README.md
+++ b/gpshwtest/README.md
@@ -1,6 +1,6 @@
 # gpshwtest
 
-Tests satpulsetool's device-independent GPS configuration against real receivers. It probes a receiver through `satpulsetool gps --json` invocations, records every step, and derives two outputs offline: **failures** (violations of the tool's device-independent guarantees) and a **characterization** of how configuration is realized on that receiver (its limitations relative to the full model). Receiver limitations are never failures. `GOAL.md` defines the goal and the workflow; `SEMANTICS.md` defines the semantics under test.
+Tests satpulsetool's device-independent GPS configuration against real receivers. It probes a receiver through `satpulsetool gps --json` invocations, records every step, and derives two outputs offline: **failures** (violations of the tool's device-independent guarantees) and a **characterization** of how configuration is realized on that receiver (its limitations relative to the full model). Signal-set probing uses targeted coexistence hypotheses rather than exhaustive subset sweeps. Receiver limitations are never failures. `GOAL.md` defines the goal and the workflow; `SEMANTICS.md` defines the semantics under test.
 
 Python 3, stdlib-only at runtime. Type checking: `make typecheck` (mypy strict via uv).
 

--- a/gpshwtest/SEMANTICS.md
+++ b/gpshwtest/SEMANTICS.md
@@ -36,7 +36,7 @@ What was *achieved* is reported in the response, not what was requested. The ach
 
 The enabled-signals property looks like it has two dimensions - constellations and bands - but it does not. Its value is a single *set of signals*, where each signal is a concrete broadcast belonging to one constellation and one frequency band: GPS L1 C/A, GPS L2C, Galileo E1, Galileo E5b, BeiDou B1I, GLONASS L1, QZSS L1S, and so on (`signal.go` defines the full universe).
 
-**Constellations and bands are request syntax, not settings.** A request names constellations, and optionally bands, and that denotes a signal set: the named constellations' signals in the named bands. Naming no bands means all bands. So `GPS,GAL` denotes every GPS and Galileo signal; `GPS,GAL` with band `L1` denotes their L1-band signals only. There is no way to request different bands for different constellations in one invocation, and no notion of enabling a constellation apart from enabling its signals.
+**Constellations and bands are request syntax, not settings.** A request names constellations, and optionally bands, and that denotes a signal set: the named constellations' signals in the named bands. Naming no bands means all bands. So `GPS,GAL` denotes every GPS and Galileo signal; `GPS,GAL` with band `L1` denotes their L1-band signals only. Individual signal syntax can add concrete signals to that set or, without `--gnss`, name the complete enabled set directly; `--except-signal` subtracts concrete signals from a `--gnss`/`--band` expansion. There is no notion of enabling a constellation apart from enabling its signals.
 
 **Realization is a pipeline with a precise meaning of best effort:**
 
@@ -83,7 +83,7 @@ Changes made after the last save do not survive a reload or reset. That is not a
 
 ## Capabilities
 
-A backend declares which optional capabilities it offers as a set of flags (`supports` in the JSON output): band selection, speed configuration, survey and survey accuracy, survey progress messages, fixed position and its accuracy, raw output, RTCM MSM4/MSM7 output, RTCM base ID. The flags bound what can be expected of requests in advance; they do not gate them. Properties show their own nonexistence in the responses, as above.
+A backend declares which optional capabilities it offers as a set of flags (`supports` in the JSON output): signal selection, speed configuration, survey and survey accuracy, survey progress messages, fixed position and its accuracy, raw output, RTCM MSM4/MSM7 output, RTCM base ID. The flags bound what can be expected of requests in advance; they do not gate them. Properties show their own nonexistence in the responses, as above.
 
 An RTCM output request on a backend without the RTCM capabilities currently fails with an error. That behavior predates the capability flags and exists because a message request has no property through which the failure could show; the intended direction is for the flags to carry this information instead of an error.
 

--- a/gpshwtest/analyze.py
+++ b/gpshwtest/analyze.py
@@ -17,9 +17,10 @@ from typing import Any
 
 from characterize import characterize
 from model import (NMEA_VOCAB, EmissionObservation, Observation, SignalObservation,
-                   Value, config_value, emissions, event_kinds, flat_value,
-                   mode_disagreements, nmea_set, raw_set, rtcm_set, stored_form,
-                   transient)
+                   Value, config_model_equal, config_value, emissions,
+                   event_kinds, flat_value, mode_disagreements, nmea_set,
+                   normalize_signal_map, raw_set, requested_signals, rtcm_set,
+                   stored_form, transient)
 from tool import replay
 
 
@@ -162,6 +163,7 @@ class Analyzer:
         if self.ident_error is not None:
             self.failures.append(f"receiver detection failed: {self.ident_error}")
         self.check_values_move()
+        self.check_signal_equivalence()
         enabled = sorted(self.initial.get("signalsEnabled") or {})
         doc = characterize(self.receiver, self.supports, self.observations,
                            self.signal_observations, self.emission_observations,
@@ -289,7 +291,7 @@ class Analyzer:
             # A restore-tail run carries the crashed run's as-found state
             # in the intent; a normal run compares to its own initial.
             want = s.intent.get("want", self.initial)
-            if want and s.config() != want:
+            if want and not config_model_equal(want, s.config()):
                 self.failures.append(f"receiver not left as found: "
                                      f"initial {want!r}, final {s.config()!r}")
         elif role == "reload":
@@ -305,7 +307,8 @@ class Analyzer:
         elif role == "factory":
             pass  # factory state is receiver data, recorded, not compared
         elif role in ("save-all", "reset"):
-            if self.reload_nvm is not None and s.config() != self.reload_nvm:
+            if self.reload_nvm is not None \
+                    and not config_model_equal(self.reload_nvm, s.config()):
                 what = "--save-all recovery" if role == "save-all" else "state after --reset"
                 self.failures.append(
                     f"{what} does not match the NVM state: "
@@ -404,38 +407,95 @@ class Analyzer:
                 f"{config_value(cfg, ('mode',))!r}")
 
     def set_signals(self, s: Step) -> None:
-        gnss, band = s.intent["gnss"], s.intent["band"]
-        name = "-".join(gnss) + ("-" + "-".join(band) if band else "")
+        req = self.signal_request(s)
+        syntax = str(s.intent.get("syntax", "gnss"))
+        tags = s.intent.get("tags")
+        name = s.name.removeprefix("set-signals-")
         if transient(s.error):
             self.failures.append(f"{s.name}: {s.error}")
             return
         cfg = self.take_config("readback", "signals")
         if cfg is None:
             return
-        back = config_value(cfg, ("signalsEnabled",))
+        back = normalize_signal_map(config_value(cfg, ("signalsEnabled",)))
         prev = self.prev_vals.get("signals",
-                                  config_value(self.initial, ("signalsEnabled",)))
+                                  normalize_signal_map(config_value(
+                                      self.initial, ("signalsEnabled",))))
         if s.error is not None:
-            self.signal_observations.append(SignalObservation(gnss, band, s.error, None))
+            self.signal_observations.append(SignalObservation(
+                req, syntax, s.error, None,
+                gnss=s.intent.get("gnss"), band=s.intent.get("band"),
+                tags=tags if isinstance(tags, list) else []))
             if back != prev:
                 self.failures.append(
                     f"signals {name}: refusal changed state: {prev!r} -> {back!r}")
             return
-        reported = config_value(s.config(), ("signalsEnabled",))
+        reported = normalize_signal_map(config_value(s.config(), ("signalsEnabled",)))
+        achieved = back
         self.signal_observations.append(SignalObservation(
-            gnss, band, None, back, reported if reported != back else None))
-        self.prev_vals["signals"] = back
+            req, syntax, None, achieved, reported if reported != achieved else None,
+            gnss=s.intent.get("gnss"), band=s.intent.get("band"),
+            tags=tags if isinstance(tags, list) else []))
+        self.prev_vals["signals"] = achieved
+
+    def signal_request(self, s: Step) -> dict[str, list[str]] | None:
+        """The model signal set recorded for this step, or reconstructed
+        from old gnss/band intents when possible."""
+        req = normalize_signal_map(s.intent.get("request"))
+        if req:
+            return req
+        gnss = s.intent.get("gnss")
+        if not isinstance(gnss, list):
+            return None
+        band = s.intent.get("band")
+        bands = band if isinstance(band, list) else None
+        supported = self.discovered_signal_set()
+        return requested_signals([str(g) for g in gnss], bands, supported)
+
+    def discovered_signal_set(self) -> dict[str, list[str]]:
+        """Best current supported signal set from discovery observations,
+        falling back to the initial readback for old/truncated runs."""
+        supported: dict[str, list[str]] = {}
+        for o in self.signal_observations:
+            if o.error is not None or o.achieved is None:
+                continue
+            if "discover" in o.tags or o.syntax == "gnss":
+                for g, sigs in o.achieved.items():
+                    supported.setdefault(g, sigs)
+        if supported:
+            return supported
+        return normalize_signal_map(config_value(self.initial, ("signalsEnabled",)))
+
+    def check_signal_equivalence(self) -> None:
+        """Equivalent signal sets must behave the same regardless of CLI
+        syntax; otherwise the bug is in satpulsetool, not the receiver."""
+        groups: dict[str, list[SignalObservation]] = {}
+        for o in self.signal_observations:
+            if o.requested is None:
+                continue
+            groups.setdefault(json.dumps(o.requested, sort_keys=True), []).append(o)
+        for rows in groups.values():
+            if len({o.syntax for o in rows}) < 2:
+                continue
+            outcomes = {json.dumps({"error": o.error is not None,
+                                    "achieved": o.achieved},
+                                   sort_keys=True) for o in rows}
+            if len(outcomes) > 1:
+                req = rows[0].requested
+                detail = [(o.syntax, o.error is not None, o.achieved) for o in rows]
+                self.failures.append(
+                    f"signals: equivalent request {req!r} differed by syntax: {detail!r}")
 
     def restore_signals(self, s: Step) -> None:
-        want = s.intent["want"]
+        want = normalize_signal_map(s.intent["want"])
         if s.error is not None:
             self.failures.append(f"signals: restore to {want!r} failed: {s.error}")
             return
         cfg = self.take_config("verify-restore", "signals")
-        if cfg is not None and config_value(cfg, ("signalsEnabled",)) != want:
+        back = normalize_signal_map(config_value(cfg or {}, ("signalsEnabled",)))
+        if cfg is not None and back != want:
             self.failures.append(
-                f"signals: restore to {want!r} read back as "
-                f"{config_value(cfg, ('signalsEnabled',))!r}")
+                f"signals: restore to {want!r} read back as {back!r}")
 
     def observe_step(self, s: Step) -> None:
         """An observe step reached directly (not consumed by a set-like
@@ -570,7 +630,7 @@ class Analyzer:
                 self.failures.append(
                     f"reload: unsaved {'.'.join(path)} change to {v!r} survived reload")
                 return
-        if self.reload_nvm is not None and cfg != self.reload_nvm:
+        if self.reload_nvm is not None and not config_model_equal(self.reload_nvm, cfg):
             self.failures.append(
                 f"reload: configuration after second reload differs from the "
                 f"NVM state: {self.reload_nvm!r} -> {cfg!r}")

--- a/gpshwtest/analyze.py
+++ b/gpshwtest/analyze.py
@@ -19,8 +19,8 @@ from characterize import characterize
 from model import (NMEA_VOCAB, EmissionObservation, Observation, SignalObservation,
                    Value, config_model_equal, config_value, emissions,
                    event_kinds, flat_value, mode_disagreements, nmea_set,
-                   normalize_signal_map, raw_set, requested_signals, rtcm_set,
-                   stored_form, transient)
+                   normalize_signal_map, raw_set, rtcm_set, stored_form,
+                   transient)
 from tool import replay
 
 
@@ -439,22 +439,13 @@ class Analyzer:
         self.prev_vals["signals"] = achieved
 
     def signal_request(self, s: Step) -> dict[str, list[str]] | None:
-        """The model signal set recorded for this step, or reconstructed
-        from old gnss/band intents when possible."""
+        """The explicitly recorded model signal set for this step."""
         req = normalize_signal_map(s.intent.get("request"))
-        if req:
-            return req
-        gnss = s.intent.get("gnss")
-        if not isinstance(gnss, list):
-            return None
-        band = s.intent.get("band")
-        bands = band if isinstance(band, list) else None
-        supported = self.discovered_signal_set()
-        return requested_signals([str(g) for g in gnss], bands, supported)
+        return req if req else None
 
     def discovered_signal_set(self) -> dict[str, list[str]]:
         """Best current supported signal set from discovery observations,
-        falling back to the initial readback for old/truncated runs."""
+        falling back to the initial readback for truncated runs."""
         supported: dict[str, list[str]] = {}
         for o in self.signal_observations:
             if o.error is not None or o.achieved is None:

--- a/gpshwtest/baselines/EVK-M101-SPG-5.10-PROTVER-34.10.json
+++ b/gpshwtest/baselines/EVK-M101-SPG-5.10-PROTVER-34.10.json
@@ -9,23 +9,9 @@
     "mode.height": {"unsupported": true},
     "rtcmBaseID": {"unsupported": true},
     "signals": {
-      "observed": [
-        {
-          "error": "refused",
-          "request": {
-            "BDS": ["B1I"],
-            "GAL": ["E1"],
-            "GLO": ["L1"],
-            "GPS": ["L1"],
-            "QZSS": ["L1", "L1S"],
-            "SBAS": ["L1"]
-          }
-        },
-        {"error": "refused", "request": {"BDS": ["B1I"], "QZSS": ["L1", "L1S"]}},
-        {"error": "refused", "request": {"GAL": ["E1"], "QZSS": ["L1", "L1S"]}},
-        {"error": "refused", "request": {"GLO": ["L1"], "QZSS": ["L1", "L1S"]}},
-        {"error": "refused", "request": {"GLO": ["L1"], "SBAS": ["L1"]}}
-      ],
+      "mutuallyExclusiveSignals": [{"BDS": ["B1I"], "GLO": ["L1"]}],
+      "observed": [{"error": "refused", "request": {"GPS": ["L1"], "QZSS": ["L1S"]}}],
+      "requiresGNSS": {"QZSS": ["GPS"], "SBAS": ["BDS", "GAL", "GPS"]},
       "signalSet": {
         "BDS": ["B1I"],
         "GAL": ["E1"],
@@ -43,5 +29,5 @@
     "supportedGNSS": ["GPS", "GAL", "BDS", "GLO", "QZSS", "SBAS"],
     "vendor": "u-blox"
   },
-  "supports": ["speed"]
+  "supports": ["port", "speed"]
 }

--- a/gpshwtest/baselines/LEA-M8T-0-TIM-1.10-PROTVER-22.0.json
+++ b/gpshwtest/baselines/LEA-M8T-0-TIM-1.10-PROTVER-22.0.json
@@ -25,6 +25,18 @@
             "SBAS": ["L1"]
           },
           "result": {"BDS": ["B1I"], "GAL": ["E1"], "GPS": ["L1"], "QZSS": ["L1", "L1S"], "SBAS": ["L1"]}
+        },
+        {
+          "request": {"BDS": ["B1I"], "GAL": ["E1"], "GLO": ["L1"], "QZSS": ["L1", "L1S"], "SBAS": ["L1"]},
+          "result": {"BDS": ["B1I"], "GAL": ["E1"], "QZSS": ["L1", "L1S"], "SBAS": ["L1"]}
+        },
+        {
+          "request": {"BDS": ["B1I"], "GAL": ["E1"], "GLO": ["L1"]},
+          "result": {"BDS": ["B1I"], "GAL": ["E1"]}
+        },
+        {
+          "request": {"BDS": ["B1I"], "GLO": ["L1"], "GPS": ["L1"]},
+          "result": {"BDS": ["B1I"], "GPS": ["L1"]}
         }
       ],
       "signalSet": {
@@ -44,5 +56,5 @@
     "supportedGNSS": ["GPS", "GAL", "BDS", "GLO", "QZSS", "SBAS"],
     "vendor": "u-blox"
   },
-  "supports": ["fixedPos", "fixedPosAcc", "raw", "speed", "survey", "surveyAcc", "surveyMsg"]
+  "supports": ["fixedPos", "fixedPosAcc", "port", "raw", "speed", "survey", "surveyAcc", "surveyMsg"]
 }

--- a/gpshwtest/baselines/UM980-Build17548.json
+++ b/gpshwtest/baselines/UM980-Build17548.json
@@ -10,7 +10,6 @@
     "saveGranularity": {"singleGroup": true},
     "showPort": {"unsupported": true},
     "signals": {
-      "emptyConstellationsDropped": true,
       "signalSet": {
         "BDS": ["B1C", "B1I", "B2I", "B2a", "B2b", "B3I"],
         "GAL": ["E1", "E5a", "E5b"],
@@ -22,5 +21,5 @@
     "timePulse.width": {"quantum": 1e-06}
   },
   "receiver": {"firmware": "Build17548", "hardware": "UM980", "supportedGNSS": [], "vendor": "Unicore"},
-  "supports": ["band", "fixedPos", "raw", "rtcmBaseID", "rtcmMSM4", "rtcmMSM7", "rtcmQZSS", "survey"]
+  "supports": ["fixedPos", "raw", "rtcmBaseID", "rtcmMSM4", "rtcmMSM7", "rtcmQZSS", "signal", "survey"]
 }

--- a/gpshwtest/baselines/ZED-F9P-HPG-1.51-PROTVER-27.50.json
+++ b/gpshwtest/baselines/ZED-F9P-HPG-1.51-PROTVER-27.50.json
@@ -10,12 +10,19 @@
     "rtcmOut": {"missing": [{"missing": ["1005"], "request": ["MSM4", "ARP"]}]},
     "signals": {
       "observed": [
-        {"error": "refused", "request": {"BDS": ["B1I", "B2I"], "QZSS": ["L1", "L1S", "L2C"]}},
-        {"error": "refused", "request": {"GAL": ["E1", "E5b"], "QZSS": ["L1", "L1S", "L2C"]}},
-        {"error": "refused", "request": {"GLO": ["L1", "L2"], "QZSS": ["L1", "L1S", "L2C"]}},
-        {"error": "refused", "request": {"GLO": ["L1", "L2"], "SBAS": ["L1"]}}
+        {"error": "refused", "request": {"GPS": ["L1", "L2C"], "QZSS": ["L1", "L1S"]}},
+        {"error": "refused", "request": {"GPS": ["L1", "L2C"], "QZSS": ["L1"]}},
+        {"error": "refused", "request": {"GPS": ["L1", "L2C"], "QZSS": ["L1S", "L2C"]}},
+        {"error": "refused", "request": {"GPS": ["L1", "L2C"], "QZSS": ["L1S"]}},
+        {"error": "refused", "request": {"GPS": ["L1", "L2C"], "QZSS": ["L2C"]}}
       ],
-      "partialSelectionRefused": {"except": {"BDS": [["B1I"]]}},
+      "requiresGNSS": {"QZSS": ["GPS"], "SBAS": ["BDS", "GAL", "GPS"]},
+      "requiresSignalAnyOf": {
+        "BDS": [["B1I"]],
+        "GAL": [["E1"], ["E5b"]],
+        "GLO": [["L1"], ["L2"]],
+        "GPS": [["L1"], ["L2C"]]
+      },
       "signalSet": {
         "BDS": ["B1I", "B2I"],
         "GAL": ["E1", "E5b"],
@@ -34,13 +41,14 @@
     "vendor": "u-blox"
   },
   "supports": [
-    "band",
     "fixedPos",
     "fixedPosAcc",
+    "port",
     "raw",
     "rtcmBaseID",
     "rtcmMSM4",
     "rtcmMSM7",
+    "signal",
     "speed",
     "survey",
     "surveyAcc",

--- a/gpshwtest/baselines/ZED-X20P-HPG-2.10-PROTVER-50.11.json
+++ b/gpshwtest/baselines/ZED-X20P-HPG-2.10-PROTVER-50.11.json
@@ -14,20 +14,23 @@
       ]
     },
     "signals": {
-      "emptyConstellationsDropped": true,
+      "mutuallyExclusiveSignalGroups": [{"gnss": "GPS", "groups": [["L2C"], ["L5"]]}],
       "observed": [
+        {"error": "refused", "request": {"BDS": ["B1I", "B2a", "B3I"]}},
+        {"request": {"BDS": ["B1C", "B2a", "B3I"]}, "result": {"BDS": ["B1C", "B1I", "B2a", "B3I"]}},
+        {"request": {"BDS": ["B1C"]}, "result": {"BDS": ["B1C", "B1I"]}},
         {
-          "error": "refused",
-          "request": {"BDS": ["B1C", "B1I", "B2a", "B3I"], "QZSS": ["L1", "L1S", "L2C", "L5"]}
+          "request": {"BDS": ["B1I"], "GAL": ["E1"], "GLO": ["L1"]},
+          "result": {"GAL": ["E1"], "GLO": ["L1"]}
         },
         {
-          "error": "refused",
-          "request": {"GAL": ["E1", "E5a", "E6"], "QZSS": ["L1", "L1S", "L2C", "L5"]}
+          "request": {"BDS": ["B1I"], "GLO": ["L1"], "GPS": ["L1", "L2C", "L5"]},
+          "result": {"GLO": ["L1"], "GPS": ["L1", "L2C", "L5"]}
         },
-        {"error": "refused", "request": {"GLO": ["L1", "L2"], "QZSS": ["L1", "L1S", "L2C", "L5"]}},
-        {"error": "refused", "request": {"GLO": ["L1", "L2"], "SBAS": ["L1"]}}
+        {"request": {"BDS": ["B1I"], "GLO": ["L1"]}, "result": {"GLO": ["L1"]}}
       ],
-      "partialSelectionRefused": {"except": {"BDS": [["B1C", "B1I"]], "GAL": [["E1"]], "GLO": [["L1"]], "GPS": [["L1"]]}},
+      "requiresGNSS": {"QZSS": ["GPS"], "SBAS": ["BDS", "GAL", "GPS"]},
+      "requiresSignalAnyOf": {"BDS": [["B1C", "B1I"], ["B2a"]], "GAL": [["E1"]], "GLO": [["L1"]], "GPS": [["L1"]]},
       "signalSet": {
         "BDS": ["B1C", "B1I", "B2a", "B3I"],
         "GAL": ["E1", "E5a", "E6"],
@@ -47,13 +50,14 @@
     "vendor": "u-blox"
   },
   "supports": [
-    "band",
     "fixedPos",
     "fixedPosAcc",
+    "port",
     "raw",
     "rtcmBaseID",
     "rtcmMSM4",
     "rtcmMSM7",
+    "signal",
     "speed",
     "survey",
     "surveyAcc",

--- a/gpshwtest/characterize.py
+++ b/gpshwtest/characterize.py
@@ -10,48 +10,14 @@ import json
 from itertools import combinations
 from typing import Any
 
-from model import EmissionObservation, Observation, SignalObservation
+from model import (MAJORS, EmissionObservation, Observation, SignalMap,
+                   SignalObservation, l1_signals, l2_signals, l5_signals,
+                   normalize_signal_map, requested_signals, signal_request_valid)
 
 # RTCM MSM message numbers are <decade><level> with a fixed decade per
 # constellation (RTCM 10403 standard numbering, not receiver-specific).
 RTCM_DECADE = {"GPS": 107, "GLO": 108, "GAL": 109, "SBAS": 110, "QZSS": 111,
                "BDS": 112, "NAVIC": 113}
-
-# Frequency band of a signal name, by prefix, ported from the model's
-# signalIDBandTable (gps/gpsprot/signal.go). Order matters: longer or more
-# specific prefixes come first.
-SIGNAL_BAND_PREFIXES = [
-    ("B2a", "L5"), ("E5b", "E5b"), ("E5a", "L5"), ("L5", "L5"),
-    ("B2", "E5b"), ("L3", "E5b"), ("L1", "L1"), ("E1", "L1"), ("B1", "L1"),
-    ("L2", "L2"), ("E6", "E6"), ("L6", "E6"), ("B3", "E6"),
-]
-
-# The signal-band keys denoted by each band name a request can use.
-REQUEST_BANDS = {"L1": {"L1"}, "L2": {"L2"}, "L5": {"L5"}, "E5b": {"E5b"},
-                 "E5": {"L5", "E5b"}, "E6": {"E6"}, "L6": {"E6"}}
-
-
-def signal_band(name: str) -> str:
-    for prefix, band in SIGNAL_BAND_PREFIXES:
-        if name.startswith(prefix):
-            return band
-    return ""
-
-
-def requested_signals(gnss: list[str], band: list[str] | None,
-                      supported: dict[str, list[str]]) -> dict[str, list[str]] | None:
-    """The signal set a constellation/band request denotes, intersected with
-    the receiver's supported set - what satpulse actually requests. None when
-    the supported set does not cover a named constellation (then the request
-    cannot be expressed in discovered signals and is carried verbatim)."""
-    if any(c not in supported for c in gnss):
-        return None
-    if band is None:
-        return {c: supported[c] for c in gnss}
-    keys = set().union(*(REQUEST_BANDS.get(b, set()) for b in band))
-    return {c: [s for s in supported[c] if signal_band(s) in keys] for c in gnss}
-
-
 
 def characterize(receiver: dict[str, Any], supports: list[str],
                  observations: list[Observation],
@@ -128,46 +94,30 @@ def characterize_prop(obs: list[Observation]) -> dict[str, Any] | None:
     return entry if entry else None
 
 
-def drop_empty(signals: dict[str, list[str]]) -> dict[str, list[str]]:
-    """Drop constellations with no signals: a request that denotes no
-    signals for a constellation and an achieved set that omits it are
-    the same signal set, not an adjustment."""
-    return {c: s for c, s in signals.items() if s}
-
-
 def characterize_signals(obs: list[SignalObservation]) -> dict[str, Any] | None:
     """Characterize signal-set realization, in signal-set vocabulary.
 
-    The supported set is what full requests achieve per constellation.
-    Requests are expressed as the signal sets they denote (intersected
-    with the supported set, which is what satpulse requests): refusals
-    record the refused set, and accepted requests whose achieved set
-    differs from the requested one record both. Exact realization gets
-    no entry. Error wording is satpulsetool presentation and is omitted."""
+    The supported set comes from discovery cases. Requests are already
+    recorded as the signal sets they denote; old gnss/band records are
+    reconstructed from the discovered supported set when possible. Exact
+    realization gets no entry. Error wording is satpulsetool presentation
+    and is omitted."""
     entry: dict[str, Any] = {}
-    supported: dict[str, list[str]] = {}
-    inconsistent = []
-    for o in obs:
-        if o.error is not None or o.band is not None or o.achieved is None:
-            continue
-        for c, sigs in o.achieved.items():
-            if c in supported and supported[c] != sorted(sigs):
-                inconsistent.append({"gnss": o.gnss, "result": o.achieved})
-            supported.setdefault(c, sorted(sigs))
+    supported, inconsistent = supported_signals(obs)
     refused = []
     adjusted = []
     for o in obs:
-        req = requested_signals(o.gnss, o.band, supported)
+        req = observation_request(o, supported)
         if o.error is not None:
-            refused.append({"signals": req} if req is not None
+            refused.append({"request": req} if req is not None
                            else {"gnss": o.gnss, "band": o.band})
         elif o.achieved is not None:
-            achieved = drop_empty({c: sorted(s) for c, s in o.achieved.items()})
+            achieved = normalize_signal_map(o.achieved)
             if req is None:
-                if sorted(achieved) != sorted(o.gnss):
+                if o.gnss is not None and sorted(achieved) != sorted(o.gnss):
                     adjusted.append({"gnss": o.gnss, "band": o.band,
                                      "result": achieved})
-            elif achieved != drop_empty(req):
+            elif achieved != supported_part(req, supported):
                 adjusted.append({"request": req, "result": achieved})
     if supported:
         entry["signalSet"] = supported
@@ -178,7 +128,7 @@ def characterize_signals(obs: list[SignalObservation]) -> dict[str, Any] | None:
     for o in obs:
         if o.accepted is None:
             continue
-        req = requested_signals(o.gnss, o.band, supported)
+        req = observation_request(o, supported)
         mismatched.append({
             "request": req if req is not None else {"gnss": o.gnss, "band": o.band},
             "accepted": o.accepted, "stored": o.achieved})
@@ -187,86 +137,219 @@ def characterize_signals(obs: list[SignalObservation]) -> dict[str, Any] | None:
     return entry if entry else None
 
 
-# satpulsetool itself refuses any request whose denoted set enables no
-# non-augmentation signal from a major constellation (SigSetMajor minus
-# SigSetAugment in gps/gpsprot/signal.go): the major constellations are
-# GPS, GLO, GAL, and BDS, and within them GAL E6 and BDS B2b count as
-# augmentation. QZSS, NAVIC, and SBAS cannot anchor a request.
-MAJORS = {"GPS", "GLO", "GAL", "BDS"}
-AUGMENT_SIGNALS = {"GAL": {"E6"}, "BDS": {"B2b"}}
+def supported_signals(obs: list[SignalObservation]) -> tuple[SignalMap, list[dict[str, Any]]]:
+    """The discovered full signal set plus inconsistent discovery results."""
+    supported: SignalMap = {}
+    inconsistent = []
+    for o in obs:
+        if o.error is not None or o.achieved is None:
+            continue
+        if "discover" not in o.tags and not (o.syntax == "gnss" and o.band is None):
+            continue
+        for c, sigs in normalize_signal_map(o.achieved).items():
+            if c in supported and supported[c] != sigs:
+                inconsistent.append({"request": o.requested, "result": o.achieved})
+            supported.setdefault(c, sigs)
+    for o in obs:
+        if o.error is None and o.achieved is not None:
+            supported = signal_union(supported, o.achieved)
+    return normalize_signal_map(supported), inconsistent
 
 
-def valid_request(req: dict[str, list[str]]) -> bool:
-    """Whether a denoted signal set is a valid request under satpulsetool's
-    own semantics: at least one non-augmentation signal from a major
-    constellation enabled. Invalid requests are refused by the tool on
-    every receiver, so their refusals are not receiver limitations."""
-    return any(set(s) - AUGMENT_SIGNALS.get(c, set())
-               for c, s in req.items() if c in MAJORS)
+def observation_request(o: SignalObservation, supported: SignalMap) -> SignalMap | None:
+    """The model signal set requested by an observation."""
+    req = normalize_signal_map(o.requested)
+    if req:
+        return req
+    if o.gnss is None:
+        return None
+    return requested_signals(o.gnss, o.band, supported)
+
+
+def signal_union(a: SignalMap, b: SignalMap) -> SignalMap:
+    out = {g: list(sigs) for g, sigs in normalize_signal_map(a).items()}
+    for g, sigs in normalize_signal_map(b).items():
+        out[g] = sorted(set(out.get(g, [])) | set(sigs))
+    return normalize_signal_map(out)
 
 
 def signal_patterns(entry: dict[str, Any], obs: list[SignalObservation],
                     supported: dict[str, list[str]],
                     refused: list[dict[str, Any]],
                     adjusted: list[dict[str, Any]]) -> None:
-    """Express the refused and adjusted signal sets as receiver validity
-    patterns where the observations support them, in the spirit of "an
-    enabled constellation must have all its signals enabled, except BDS".
-    Refusals of requests that are invalid under satpulsetool's own
-    semantics (no non-augmentation signal) are excluded entirely: the tool
-    guarantees those refusals on every receiver, so they say nothing about
-    this one. Entries no pattern explains stay verbatim - patterns reduce
-    the noise, never the information. The patterns:
-
-    - partialSelectionRefused: a request giving some constellation a
-      nonempty strict subset of its signals is refused; "except" lists the
-      subsets observed to be accepted exactly.
-    - emptyConstellationsDropped: constellations denoted with no signals
-      are dropped from the request rather than refused."""
-    full = {c: tuple(s) for c, s in supported.items()}
-    allowed_subsets: dict[str, list[list[str]]] = {}
-    for o in obs:
-        if o.error is not None or o.achieved is None:
-            continue
-        req = requested_signals(o.gnss, o.band, supported)
-        for c, sigs in o.achieved.items():
-            t = sorted(sigs)
-            if c in full and tuple(t) != full[c] and req is not None \
-                    and {k: sorted(v) for k, v in o.achieved.items()} == req:
-                if t not in allowed_subsets.setdefault(c, []):
-                    allowed_subsets[c].append(t)
-    saw_partial = False
+    """Express refused and adjusted signal sets as conservative receiver
+    validity patterns. Unexplained entries stay verbatim."""
+    patterns = {
+        "requiresGNSS": requires_gnss(obs, supported),
+        "requiresSignalAnyOf": requires_signal_any_of(obs, supported),
+        "mutuallyExclusiveSignals": mutually_exclusive_signals(obs, supported),
+        "mutuallyExclusiveSignalGroups": mutually_exclusive_signal_groups(obs, supported),
+    }
+    for k, v in patterns.items():
+        if v:
+            entry[k] = v
     observed = []
     for r in refused:
-        req = r.get("signals")
-        if not isinstance(req, dict):
+        req = normalize_signal_map(r.get("request"))
+        if not req:
             observed.append({**r, "error": "refused"})
-            continue
-        if not valid_request(req):
-            continue
-        if any(s and tuple(sorted(s)) != full.get(c)
-               and sorted(s) not in allowed_subsets.get(c, [])
-               for c, s in req.items()):
-            saw_partial = True
-            continue
-        observed.append({"request": req, "error": "refused"})
-    saw_dropped = False
+        elif req == supported_part(req, supported) and signal_request_valid(req) \
+                and not refusal_explained(req, patterns):
+            observed.append({"request": req, "error": "refused"})
     for a in adjusted:
-        req = a.get("request")
-        if isinstance(req, dict) and not valid_request(req):
-            continue
-        if isinstance(req, dict) and any(req.values()) \
-                and a.get("result") == {c: s for c, s in req.items() if s}:
-            saw_dropped = True
-            continue
-        observed.append(a)
-    if saw_partial:
-        entry["partialSelectionRefused"] = \
-            {"except": allowed_subsets} if allowed_subsets else True
-    if saw_dropped:
-        entry["emptyConstellationsDropped"] = True
+        req = normalize_signal_map(a.get("request"))
+        if not req or req == supported_part(req, supported) and signal_request_valid(req):
+            observed.append(a)
     if observed:
         entry["observed"] = dedup(observed)
+
+
+def requires_gnss(obs: list[SignalObservation], supported: SignalMap) -> dict[str, list[str]]:
+    """Augmentation-style constellations that require one of a set of
+    major-constellation anchors."""
+    result: dict[str, list[str]] = {}
+    for target in ("QZSS", "SBAS", "NAVIC"):
+        if target not in supported:
+            continue
+        ok: set[str] = set()
+        refused: set[str] = set()
+        for o in obs:
+            req = observation_request(o, supported)
+            if req is None or target not in req:
+                continue
+            if req != supported_part(req, supported):
+                continue
+            anchors = [g for g in req if g in MAJORS and g != target]
+            if len(anchors) != 1:
+                continue
+            if o.error is None:
+                ok.add(anchors[0])
+            else:
+                refused.add(anchors[0])
+        if ok and refused:
+            result[target] = sorted(ok)
+    return result
+
+
+def requires_signal_any_of(obs: list[SignalObservation],
+                           supported: SignalMap) -> dict[str, list[list[str]]]:
+    """Per-constellation signal groups where at least one signal from each
+    group is required."""
+    result: dict[str, list[list[str]]] = {}
+    for g, sigs in supported.items():
+        rows = signal_rows_for_gnss(obs, supported, g)
+        ok = [r for r, err in rows if not err]
+        bad = [r for r, err in rows if err]
+        groups = []
+        l1 = l1_signals(sigs)
+        if l1 and any(not set(r) & set(l1) for r in bad) \
+                and any(set(r) & set(l1) for r in ok):
+            groups.append(l1)
+        secondary = l2_signals(sigs) + l5_signals(sigs)
+        if l1 and secondary and any(set(r) <= set(l1) for r in bad) \
+                and any(set(r) & set(l1) and set(r) & set(secondary) for r in ok):
+            alts = sorted({s for r in ok for s in r if s in secondary})
+            if alts:
+                groups.append(alts)
+        if groups:
+            result[g] = groups
+    return result
+
+
+def mutually_exclusive_signals(obs: list[SignalObservation],
+                               supported: SignalMap) -> list[SignalMap]:
+    """Two-signal requests that are refused while their individual signals
+    are accepted."""
+    singles = set()
+    refused_pairs = []
+    for o in obs:
+        req = normalize_signal_map(o.requested)
+        if not req:
+            continue
+        if req != supported_part(req, supported):
+            continue
+        atoms = signal_atoms(req)
+        if len(atoms) == 1 and o.error is None:
+            singles.add(atoms[0])
+        elif len(atoms) == 2 and o.error is not None:
+            refused_pairs.append((atoms, req))
+    return dedup([req for atoms, req in refused_pairs
+                  if all(atom in singles for atom in atoms)])
+
+
+def mutually_exclusive_signal_groups(obs: list[SignalObservation],
+                                     supported: SignalMap) -> list[dict[str, Any]]:
+    """L2-family and L5-family requests that work separately but not
+    together with L1."""
+    result = []
+    for g, sigs in supported.items():
+        l1, l2, l5 = set(l1_signals(sigs)), set(l2_signals(sigs)), set(l5_signals(sigs))
+        if not l1 or not l2 or not l5:
+            continue
+        rows = signal_rows_for_gnss(obs, supported, g)
+        ok_l2 = any(not err and set(r) & l1 and set(r) & l2 and not set(r) & l5
+                    for r, err in rows)
+        ok_l5 = any(not err and set(r) & l1 and set(r) & l5 and not set(r) & l2
+                    for r, err in rows)
+        bad_both = any(err and set(r) & l1 and set(r) & l2 and set(r) & l5
+                       for r, err in rows)
+        if ok_l2 and ok_l5 and bad_both:
+            result.append({"gnss": g, "groups": [sorted(l2), sorted(l5)]})
+    return result
+
+
+def signal_rows_for_gnss(obs: list[SignalObservation], supported: SignalMap,
+                         gnss: str) -> list[tuple[list[str], bool]]:
+    rows = []
+    for o in obs:
+        req = observation_request(o, supported)
+        if req is None or gnss not in req:
+            continue
+        if req != supported_part(req, supported):
+            continue
+        if any(g in req and g != gnss and g in MAJORS for g in req):
+            continue
+        rows.append((req[gnss], o.error is not None))
+    return rows
+
+
+def signal_atoms(req: SignalMap) -> list[tuple[str, str]]:
+    return [(g, s) for g, sigs in normalize_signal_map(req).items() for s in sigs]
+
+
+def supported_part(req: SignalMap, supported: SignalMap) -> SignalMap:
+    sup = normalize_signal_map(supported)
+    return normalize_signal_map(
+        {g: [s for s in sigs if s in sup.get(g, [])]
+         for g, sigs in normalize_signal_map(req).items()})
+
+
+def refusal_explained(req: SignalMap, patterns: dict[str, Any]) -> bool:
+    req = normalize_signal_map(req)
+    requires_g = patterns.get("requiresGNSS") or {}
+    if isinstance(requires_g, dict):
+        for g, anchors in requires_g.items():
+            if g in req and not (set(req) & set(anchors)):
+                return True
+    requires_s = patterns.get("requiresSignalAnyOf") or {}
+    if isinstance(requires_s, dict):
+        for g, groups in requires_s.items():
+            if g in req and any(not set(req[g]) & set(group) for group in groups):
+                return True
+    mutex = patterns.get("mutuallyExclusiveSignals") or []
+    for m in mutex:
+        mm = normalize_signal_map(m)
+        if all(set(req.get(g, [])) >= set(sigs) for g, sigs in mm.items()):
+            return True
+    for m in patterns.get("mutuallyExclusiveSignalGroups") or []:
+        if not isinstance(m, dict):
+            continue
+        g = m.get("gnss")
+        groups = m.get("groups")
+        if isinstance(g, str) and isinstance(groups, list) and g in req \
+                and all(set(req[g]) & set(group) for group in groups):
+            return True
+    return False
 
 
 def dedup(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/gpshwtest/characterize.py
+++ b/gpshwtest/characterize.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from model import (MAJORS, EmissionObservation, Observation, SignalMap,
                    SignalObservation, l1_signals, l2_signals, l5_signals,
-                   normalize_signal_map, requested_signals, signal_request_valid)
+                   normalize_signal_map, signal_request_valid)
 
 # RTCM MSM message numbers are <decade><level> with a fixed decade per
 # constellation (RTCM 10403 standard numbering, not receiver-specific).
@@ -97,11 +97,10 @@ def characterize_prop(obs: list[Observation]) -> dict[str, Any] | None:
 def characterize_signals(obs: list[SignalObservation]) -> dict[str, Any] | None:
     """Characterize signal-set realization, in signal-set vocabulary.
 
-    The supported set comes from discovery cases. Requests are already
-    recorded as the signal sets they denote; old gnss/band records are
-    reconstructed from the discovered supported set when possible. Exact
-    realization gets no entry. Error wording is satpulsetool presentation
-    and is omitted."""
+    The supported set comes from discovery cases. Requests are recorded as
+    the signal sets they denote; discovery observations can leave the
+    request unknown. Exact realization gets no entry. Error wording is
+    satpulsetool presentation and is omitted."""
     entry: dict[str, Any] = {}
     supported, inconsistent = supported_signals(obs)
     refused = []
@@ -159,11 +158,7 @@ def supported_signals(obs: list[SignalObservation]) -> tuple[SignalMap, list[dic
 def observation_request(o: SignalObservation, supported: SignalMap) -> SignalMap | None:
     """The model signal set requested by an observation."""
     req = normalize_signal_map(o.requested)
-    if req:
-        return req
-    if o.gnss is None:
-        return None
-    return requested_signals(o.gnss, o.band, supported)
+    return req if req else None
 
 
 def signal_union(a: SignalMap, b: SignalMap) -> SignalMap:

--- a/gpshwtest/model.py
+++ b/gpshwtest/model.py
@@ -59,8 +59,9 @@ class SignalObservation:
     """Outcome of requesting an enabled-signal set. requested is in model
     vocabulary; syntax records which command-line spelling was used. achieved
     is the stored set from the readback; accepted carries the set response's
-    own set only when it differs from the stored one. gnss/band are kept for
-    older records that predate direct signal-set intents."""
+    own set only when it differs from the stored one. gnss/band preserve the
+    command spelling for observations whose model request is intentionally
+    unknown."""
 
     requested: SignalMap | None
     syntax: str

--- a/gpshwtest/model.py
+++ b/gpshwtest/model.py
@@ -9,11 +9,32 @@ interpretation. Nothing here touches hardware.
 import datetime
 import json
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 Value = Any
+SignalMap = dict[str, list[str]]
+
+GNSS_ORDER = ["GPS", "GAL", "BDS", "GLO", "QZSS", "NAVIC", "SBAS"]
+
+# Frequency band of a signal name, by prefix, ported from the model's
+# signalIDBandTable (gps/gpsprot/signal.go). Order matters: longer or more
+# specific prefixes come first.
+SIGNAL_BAND_PREFIXES = [
+    ("B2a", "L5"), ("E5b", "E5b"), ("E5a", "L5"), ("L5", "L5"),
+    ("B2", "E5b"), ("L3", "E5b"), ("L1", "L1"), ("E1", "L1"), ("B1", "L1"),
+    ("L2", "L2"), ("E6", "E6"), ("L6", "E6"), ("B3", "E6"),
+]
+
+# The signal-band keys denoted by each band name a request can use.
+REQUEST_BANDS = {"L1": {"L1"}, "L2": {"L2"}, "L5": {"L5"}, "E5b": {"E5b"},
+                 "E5": {"L5", "E5b"}, "E6": {"E6"}, "L6": {"E6"}}
+
+# satpulsetool refuses any request whose denoted set enables no
+# non-augmentation signal from a major constellation.
+MAJORS = {"GPS", "GLO", "GAL", "BDS"}
+AUGMENT_SIGNALS = {"GAL": {"E6"}, "BDS": {"B2b"}}
 
 # The NMEA sentence types in the model vocabulary. Types outside it (such
 # as event-driven TXT diagnostics) are excluded from comparisons because
@@ -35,15 +56,20 @@ class Observation:
 
 @dataclass
 class SignalObservation:
-    """Outcome of requesting one constellation/band combination. achieved
+    """Outcome of requesting an enabled-signal set. requested is in model
+    vocabulary; syntax records which command-line spelling was used. achieved
     is the stored set from the readback; accepted carries the set response's
-    own set only when it differs from the stored one."""
+    own set only when it differs from the stored one. gnss/band are kept for
+    older records that predate direct signal-set intents."""
 
-    gnss: list[str]
-    band: list[str] | None
+    requested: SignalMap | None
+    syntax: str
     error: str | None
-    achieved: dict[str, list[str]] | None
-    accepted: dict[str, list[str]] | None = None
+    achieved: SignalMap | None
+    accepted: SignalMap | None = None
+    gnss: list[str] | None = None
+    band: list[str] | None = None
+    tags: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -74,6 +100,145 @@ def fmt_value(v: Value) -> str:
         s = f"{v:.9f}".rstrip("0").rstrip(".")
         return s if s else "0"
     return str(v)
+
+
+def normalize_signal_map(v: Any) -> SignalMap:
+    """Return a canonical signal map: known GNSS order, sorted unique
+    signal names, and no empty constellations."""
+    if not isinstance(v, dict):
+        return {}
+    out: SignalMap = {}
+    keys = [g for g in GNSS_ORDER if g in v] + sorted(
+        str(g) for g in v if str(g) not in GNSS_ORDER)
+    for g in keys:
+        sigs = v.get(g)
+        if isinstance(sigs, list):
+            ss = sorted({str(s) for s in sigs})
+            if ss:
+                out[str(g)] = ss
+    return out
+
+
+def normalize_config(v: Any) -> dict[str, Any]:
+    """Return a config JSON object in canonical form for comparisons."""
+    if not isinstance(v, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for k, val in sorted(v.items()):
+        if k == "signalsEnabled":
+            sigs = normalize_signal_map(val)
+            if sigs:
+                out[k] = sigs
+        elif isinstance(val, dict):
+            out[k] = normalize_config(val)
+        elif isinstance(val, list):
+            out[k] = [normalize_config(x) if isinstance(x, dict) else x
+                      for x in val]
+        else:
+            out[k] = val
+    return out
+
+
+def config_model_equal(want: Any, got: Any) -> bool:
+    """Whether two configs are equal in the device-independent model.
+
+    Some non-timing u-blox receivers default the time pulse grid to UTC.
+    satpulsetool reports that as an absent timeGNSS because the model has
+    only GNSS grids, and setting the represented time pulse bundle can move
+    the receiver to GPS with no way to express a restore to UTC."""
+    a, b = normalize_config(want), normalize_config(got)
+    if a == b:
+        return True
+    if "timeGNSS" not in a and b.get("timeGNSS") == "GPS":
+        b = dict(b)
+        del b["timeGNSS"]
+        return a == b
+    return False
+
+
+def signal_map_union(*maps: SignalMap) -> SignalMap:
+    """Union signal maps in canonical form."""
+    out: dict[str, set[str]] = {}
+    for m in maps:
+        for g, sigs in normalize_signal_map(m).items():
+            out.setdefault(g, set()).update(sigs)
+    return normalize_signal_map({g: sorted(sigs) for g, sigs in out.items()})
+
+
+def signal_map_without(m: SignalMap, remove: SignalMap) -> SignalMap:
+    """Return m with remove's signals subtracted."""
+    rem = {g: set(sigs) for g, sigs in normalize_signal_map(remove).items()}
+    out: SignalMap = {}
+    for g, sigs in normalize_signal_map(m).items():
+        keep = [s for s in sigs if s not in rem.get(g, set())]
+        if keep:
+            out[g] = keep
+    return out
+
+
+def signal_map_subset(m: SignalMap, gnss: str) -> SignalMap:
+    """Return just one constellation's signals."""
+    sigs = normalize_signal_map(m).get(gnss, [])
+    return {gnss: sigs} if sigs else {}
+
+
+def signal_map_cli_arg(m: SignalMap) -> str:
+    """Render a signal map as a --signal/--except-signal argument."""
+    parts = []
+    for g, sigs in normalize_signal_map(m).items():
+        parts += [g + s for s in sigs]
+    return ",".join(parts)
+
+
+def signal_band(name: str) -> str:
+    """Return the model band key of a signal name."""
+    for prefix, band in SIGNAL_BAND_PREFIXES:
+        if name.startswith(prefix):
+            return band
+    return ""
+
+
+def signals_in_bands(sigs: list[str], bands: set[str]) -> list[str]:
+    """Signals whose band is in bands."""
+    return [s for s in sigs if signal_band(s) in bands]
+
+
+def l1_signals(sigs: list[str]) -> list[str]:
+    """Signals in the L1/E1/B1 family."""
+    return signals_in_bands(sigs, {"L1"})
+
+
+def l2_signals(sigs: list[str]) -> list[str]:
+    """Signals in the L2/E5b/B2I low-band family."""
+    return [s for s in sigs if signal_band(s) in {"L2", "E5b"} and s != "B2b"]
+
+
+def l5_signals(sigs: list[str]) -> list[str]:
+    """Signals in the L5/E5a/B2a/NavIC L5 family."""
+    return signals_in_bands(sigs, {"L5"})
+
+
+def signal_request_valid(req: SignalMap) -> bool:
+    """Whether a signal-set request is valid under satpulsetool's own
+    semantics: at least one non-augmentation signal from a major
+    constellation enabled."""
+    return any(set(s) - AUGMENT_SIGNALS.get(c, set())
+               for c, s in normalize_signal_map(req).items() if c in MAJORS)
+
+
+def requested_signals(gnss: list[str], band: list[str] | None,
+                      supported: SignalMap) -> SignalMap | None:
+    """The signal set a constellation/band request denotes, intersected with
+    the discovered supported set. None when the supported set does not
+    cover a named constellation."""
+    sup = normalize_signal_map(supported)
+    if any(c not in sup for c in gnss):
+        return None
+    if band is None:
+        return normalize_signal_map({c: sup[c] for c in gnss})
+    keys = set().union(*(REQUEST_BANDS.get(b, set()) for b in band))
+    return normalize_signal_map(
+        {c: [s for s in sup[c] if signal_band(s) in keys] for c in gnss})
 
 
 def config_value(cfg: dict[str, Any], path: tuple[str, ...]) -> Value:

--- a/gpshwtest/probes.py
+++ b/gpshwtest/probes.py
@@ -18,8 +18,11 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable
 
-from model import (NMEA_VOCAB, Value, config_value, emissions, fmt_value, has_fix,
-                   mode_args, nmea_set, raw_set, rtcm_set, transient)
+from model import (NMEA_VOCAB, SignalMap, Value, config_value, emissions, fmt_value,
+                   has_fix, l1_signals, l2_signals, l5_signals, mode_args, nmea_set,
+                   normalize_signal_map, raw_set, requested_signals, rtcm_set,
+                   signal_map_cli_arg, signal_map_union, signal_map_without,
+                   signal_request_valid, transient)
 from tool import Invocation, Tool, ToolFailure, replay
 
 # Settle time after a successful signal-set change: u-blox documents an
@@ -156,25 +159,246 @@ SATS_CASES = [(["sat"], {"satellites"}),
               (["none"], set())]
 
 BANDS_ALL = [["L1"], ["L2"], ["L5"], ["E5"], ["L6"], ["L1", "L2"]]
-BANDS_SINGLE = [["L1"], ["L2"], ["E5b"]]
 
 
-def signal_cases(supported: list[str]) -> list[tuple[list[str], list[str] | None]]:
-    """Build the signal probe set from the discovered constellation list:
-    each constellation alone and with band subsets, augmentation systems
-    paired with each major constellation (receivers couple them - commonly
-    to GPS, but the rules vary per family and constellation, and only the
-    non-GPS pairings make them visible), all constellations together, and
-    band subsets of all."""
-    cases: list[tuple[list[str], list[str] | None]] = [([g], None) for g in supported]
-    cases += [([g], b) for g in supported for b in BANDS_SINGLE]
-    for aug in ("QZSS", "SBAS"):
-        if aug in supported:
-            cases += [([m, aug], None)
-                      for m in ("GPS", "GAL", "BDS", "GLO") if m in supported]
-    cases.append((list(supported), None))
-    cases += [(list(supported), b) for b in BANDS_ALL]
+@dataclass
+class SignalCase:
+    """One signal-set request. requested is the model signal set the flags
+    denote when it is known before execution; discovery cases can leave it
+    absent and let analysis derive it from the run."""
+
+    name: str
+    args: list[str]
+    syntax: str
+    requested: SignalMap | None
+    tags: list[str]
+    gnss: list[str] | None = None
+    band: list[str] | None = None
+
+
+SignalHypothesis = Callable[[SignalMap], list[SignalCase]]
+
+
+def signal_discovery_cases(constellations: list[str],
+                           known: SignalMap) -> list[SignalCase]:
+    """Cases that discover the full signal set before the hypothesis
+    generators run. Augmentation constellations are paired with an anchor
+    because they cannot form a valid signal-set request on their own."""
+    cases = []
+    majors = [g for g in ("GPS", "GAL", "BDS", "GLO") if g in constellations]
+    for g in majors:
+        cases.append(gnss_signal_case(f"discover-{g}", [g], None, known, ["discover"]))
+    anchor = "GPS" if "GPS" in constellations else majors[0] if majors else None
+    if anchor is not None:
+        for g in ("QZSS", "SBAS", "NAVIC"):
+            if g in constellations:
+                cases.append(gnss_signal_case(f"discover-{anchor}-{g}", [anchor, g],
+                                              None, known, ["discover"]))
+    if constellations:
+        cases.append(gnss_signal_case("discover-all", constellations, None, known,
+                                      ["discover", "all"]))
+    for c in cases:
+        c.requested = None
     return cases
+
+
+def signal_cases(supported: SignalMap) -> list[SignalCase]:
+    """Build a bounded, hypothesis-driven signal probe set."""
+    cases: list[SignalCase] = []
+    for hyp in SIGNAL_HYPOTHESES:
+        cases += hyp(supported)
+    return dedup_signal_cases(cases)
+
+
+def syntax_hypothesis(supported: SignalMap) -> list[SignalCase]:
+    cases = []
+    gnss = list(supported)
+    if gnss:
+        cases.append(gnss_signal_case("syntax-gnss-all", gnss, None, supported,
+                                      ["syntax"]))
+        cases.append(direct_signal_case("syntax-signal-all", supported, ["syntax"]))
+        for band in BANDS_ALL:
+            cases.append(gnss_signal_case("syntax-band-" + "-".join(band), gnss,
+                                          band, supported, ["syntax"]))
+        first = first_signal(supported)
+        if first:
+            cases.append(except_signal_case("syntax-except-one", supported, first,
+                                            ["syntax"]))
+    return compact_cases(cases)
+
+
+def anchor_hypothesis(supported: SignalMap) -> list[SignalCase]:
+    cases = []
+    for target in ("QZSS", "SBAS", "NAVIC"):
+        if target not in supported:
+            continue
+        for anchor in ("GPS", "GAL", "BDS", "GLO"):
+            if anchor in supported:
+                req = signal_map_union(signal_subset(supported, anchor),
+                                       signal_subset(supported, target))
+                cases.append(direct_signal_case(
+                    f"anchor-{target}-with-{anchor}", req,
+                    [f"requires-gnss:{target}"]))
+    return compact_cases(cases)
+
+
+def l1_required_hypothesis(supported: SignalMap) -> list[SignalCase]:
+    cases = []
+    for g, sigs in supported.items():
+        l1 = l1_signals(sigs)
+        non_l1 = [s for s in sigs if s not in l1]
+        cases.append(anchored_direct_case(
+            f"l1-only-{g}", supported, g, l1, [f"l1-required:{g}"]))
+        for s in l1:
+            cases.append(anchored_direct_case(
+                f"single-{g}-{s}", supported, g, [s], [f"l1-required:{g}"]))
+        for s in non_l1:
+            cases.append(anchored_direct_case(
+                f"single-{g}-{s}", supported, g, [s], [f"l1-required:{g}"]))
+        for s in l1:
+            base = signal_subset(supported, g)
+            if not signal_request_valid(base) and g != "GPS" and "GPS" in supported:
+                base = signal_map_union(signal_subset(supported, "GPS"), base)
+            cases.append(except_signal_case(
+                f"without-{g}-{s}", base, {g: [s]}, [f"l1-required:{g}"]))
+    return compact_cases(cases)
+
+
+def l2_l5_hypothesis(supported: SignalMap) -> list[SignalCase]:
+    cases = []
+    for g, sigs in supported.items():
+        l1, l2, l5 = l1_signals(sigs), l2_signals(sigs), l5_signals(sigs)
+        if l1 and l2:
+            cases.append(anchored_direct_case(
+                f"l1-l2-{g}", supported, g, l1 + l2, [f"l2-l5:{g}"]))
+        if l1 and l5:
+            cases.append(anchored_direct_case(
+                f"l1-l5-{g}", supported, g, l1 + l5, [f"l2-l5:{g}"]))
+        if l1 and l2 and l5:
+            cases.append(anchored_direct_case(
+                f"l1-l2-l5-{g}", supported, g, l1 + l2 + l5, [f"l2-l5:{g}"]))
+    l1_all = family_map(supported, l1_signals)
+    l2_all = family_map(supported, l2_signals)
+    l5_all = family_map(supported, l5_signals)
+    cases.append(direct_signal_case("all-l1-l2", signal_map_union(l1_all, l2_all),
+                                    ["l2-l5:all"]))
+    cases.append(direct_signal_case("all-l1-l5", signal_map_union(l1_all, l5_all),
+                                    ["l2-l5:all"]))
+    cases.append(direct_signal_case("all-l1-l2-l5",
+                                    signal_map_union(l1_all, l2_all, l5_all),
+                                    ["l2-l5:all"]))
+    return compact_cases(cases)
+
+
+def ublox_conflict_hypothesis(supported: SignalMap) -> list[SignalCase]:
+    cases = []
+    bds = supported.get("BDS", [])
+    glo = supported.get("GLO", [])
+    gps = supported.get("GPS", [])
+    gal = supported.get("GAL", [])
+    if "B1I" in bds and "L1" in glo:
+        base = {"BDS": ["B1I"], "GLO": ["L1"]}
+        cases.append(direct_signal_case("conflict-bds-b1i-glo-l1", base,
+                                        ["ublox-conflict:m8-m10"]))
+        if gps:
+            cases.append(direct_signal_case(
+                "conflict-gps-bds-b1i-glo-l1",
+                signal_map_union(signal_subset(supported, "GPS"), base),
+                ["ublox-conflict:m8-m10"]))
+        if gal:
+            cases.append(direct_signal_case(
+                "conflict-gal-bds-b1i-glo-l1",
+                signal_map_union({"GAL": l1_signals(gal) or gal}, base),
+                ["ublox-conflict:m8"]))
+    if bds:
+        cases.append(direct_signal_case("candidate-bds-b1i", {"BDS": ["B1I"]},
+                                        ["ublox-conflict:m10"]))
+        cases.append(direct_signal_case("candidate-bds-b1c", {"BDS": ["B1C"]},
+                                        ["ublox-conflict:m10"]))
+        cases.append(direct_signal_case("conflict-bds-b1i-b1c",
+                                        {"BDS": ["B1I", "B1C"]},
+                                        ["ublox-conflict:m10"]))
+    l5_all = family_map(supported, l5_signals)
+    if "L1" in glo and l5_all:
+        cases.append(direct_signal_case(
+            "conflict-glo-l1-with-l5",
+            signal_map_union({"GLO": ["L1"]}, l5_all), ["ublox-conflict:f10"]))
+    return compact_cases(cases)
+
+
+SIGNAL_HYPOTHESES: list[SignalHypothesis] = [
+    syntax_hypothesis,
+    anchor_hypothesis,
+    l1_required_hypothesis,
+    l2_l5_hypothesis,
+    ublox_conflict_hypothesis,
+]
+
+
+def gnss_signal_case(name: str, gnss: list[str], band: list[str] | None,
+                     supported: SignalMap, tags: list[str]) -> SignalCase:
+    args = ["--gnss", ",".join(gnss)]
+    if band:
+        args += ["--band", ",".join(band)]
+    return SignalCase(name, args, "band" if band else "gnss",
+                      requested_signals(gnss, band, supported), tags, gnss, band)
+
+
+def direct_signal_case(name: str, req: SignalMap,
+                       tags: list[str]) -> SignalCase:
+    r = normalize_signal_map(req)
+    return SignalCase(name, ["--signal", signal_map_cli_arg(r)], "signal", r, tags)
+
+
+def except_signal_case(name: str, base: SignalMap, remove: SignalMap,
+                       tags: list[str]) -> SignalCase:
+    b = normalize_signal_map(base)
+    r = normalize_signal_map(remove)
+    req = signal_map_without(b, r)
+    args = ["--gnss", ",".join(b), "--except-signal", signal_map_cli_arg(r)]
+    return SignalCase(name, args, "except-signal", req, tags, list(b), None)
+
+
+def anchored_direct_case(name: str, supported: SignalMap, gnss: str,
+                         sigs: list[str], tags: list[str]) -> SignalCase:
+    req = normalize_signal_map({gnss: sigs})
+    if signal_request_valid(req) or gnss == "GPS" or "GPS" not in supported:
+        return direct_signal_case(name, req, tags)
+    return direct_signal_case(name, signal_map_union(signal_subset(supported, "GPS"), req),
+                              tags)
+
+
+def compact_cases(cases: list[SignalCase]) -> list[SignalCase]:
+    return [c for c in cases if c.requested and signal_request_valid(c.requested)]
+
+
+def dedup_signal_cases(cases: list[SignalCase]) -> list[SignalCase]:
+    seen: set[str] = set()
+    out = []
+    for c in cases:
+        k = json.dumps({"args": c.args, "request": c.requested, "syntax": c.syntax},
+                       sort_keys=True)
+        if k not in seen:
+            seen.add(k)
+            out.append(c)
+    return out
+
+
+def signal_subset(supported: SignalMap, gnss: str) -> SignalMap:
+    sigs = supported.get(gnss, [])
+    return {gnss: sigs} if sigs else {}
+
+
+def family_map(supported: SignalMap,
+               family: Callable[[list[str]], list[str]]) -> SignalMap:
+    return normalize_signal_map({g: family(sigs) for g, sigs in supported.items()})
+
+
+def first_signal(m: SignalMap) -> SignalMap:
+    for g, sigs in m.items():
+        if sigs:
+            return {g: [sigs[0]]}
+    return {}
 
 
 @dataclass
@@ -448,30 +672,38 @@ class ProbeRun:
             self.show_config("verify-restore-mode", "verify-restore", "mode")
 
     def probe_signals(self, initial: dict[str, Any], supported: list[str]) -> None:
-        """Probe constellation/band combinations, then restore the initial set."""
-        for gnss, band in signal_cases(supported):
-            name = "-".join(gnss) + ("-" + "-".join(band) if band else "")
-            args = ["--gnss", ",".join(gnss)]
-            if band:
-                args += ["--band", ",".join(band)]
-            inv = self.tool.gps(f"set-signals-{name}", args,
-                                {"op": "set-signals", "gnss": gnss, "band": band})
-            if transient(inv.error):
-                continue
-            if inv.error is None:
-                time.sleep(SIGNAL_SETTLE)
-            self.show_config(f"readback-signals-{name}", "readback", "signals")
+        """Probe signal-set hypotheses, then restore the initial set."""
+        known = normalize_signal_map(config_value(initial, ("signalsEnabled",)))
+        for case in signal_discovery_cases(supported, known):
+            cfg = self.probe_signal_case(case)
+            if cfg is not None:
+                known = signal_map_union(known, normalize_signal_map(
+                    config_value(cfg, ("signalsEnabled",))))
+        for case in signal_cases(known):
+            self.probe_signal_case(case)
         self.restore_signals(initial)
 
+    def probe_signal_case(self, case: SignalCase) -> dict[str, Any] | None:
+        """Run one signal case and return its readback config when present."""
+        intent: dict[str, Any] = {"op": "set-signals", "syntax": case.syntax,
+                                  "request": case.requested, "tags": case.tags}
+        if case.gnss is not None:
+            intent["gnss"] = case.gnss
+        if case.band is not None:
+            intent["band"] = case.band
+        inv = self.tool.gps(f"set-signals-{case.name}", case.args, intent)
+        if transient(inv.error):
+            return None
+        if inv.error is None:
+            time.sleep(SIGNAL_SETTLE)
+        return self.show_config(f"readback-signals-{case.name}", "readback", "signals")
+
     def restore_signals(self, initial: dict[str, Any]) -> None:
-        """Re-enable the initial constellation set. Band subsetting within a
-        constellation cannot be reproduced generically, so a band-limited
-        initial set shows up in analysis as a restore failure rather than
-        silently passing."""
-        want = config_value(initial, ("signalsEnabled",))
-        if not isinstance(want, dict):
+        """Re-enable the exact initial signal set."""
+        want = normalize_signal_map(config_value(initial, ("signalsEnabled",)))
+        if not want:
             return
-        inv = self.tool.gps("restore-signals", ["--gnss", ",".join(want)],
+        inv = self.tool.gps("restore-signals", ["--signal", signal_map_cli_arg(want)],
                             {"op": "restore-signals", "want": want})
         if inv.error is None:
             time.sleep(SIGNAL_SETTLE)


### PR DESCRIPTION
## Summary

- Exercise `satpulsetool gps --signal` / `--except-signal` through modular gpshwtest signal hypotheses.
- Characterize signal coexistence constraints such as QZSS/SBAS anchors, required L1-family signals, BDS/GLO exclusions, and L2/L5 mutual groups.
- Update gpshwtest hardware baselines for the connected F9P, X20P, M8T, UM980, and EVK-M101 receivers.

Refs #310

## Validation

- `make typecheck` in `gpshwtest/`
- `git diff --check`
- Hardware runs:
  - ZED-F9P: 95 observations, no failures
  - ZED-X20P: 114 observations, no failures
  - LEA-M8T: 78 observations, no failures
  - UM980: 108 observations, no failures
  - EVK-M101: 78 observations, no failures
- Replayed all five hardware logs against the updated baselines; all matched.