### PR TITLE
satpulsetool ntrip: add --gga option (VRS starter)

### DIFF
--- a/docs/_includes/NEWS.md
+++ b/docs/_includes/NEWS.md
@@ -46,6 +46,7 @@ _Not yet released_
 
 - `satpulsetool` has a new `pack` command, which reads a JSONL packet log and writes selected packets as a packet byte stream corresponding to the original packet contents. It can filter by packet `tag` and `msg`, and can preserve inter-packet timing for FIFO-based replay. (#247)
 - `satpulsetool` has a new `scan` command, which reads a raw GPS packet byte stream and writes a JSONL packet log that can be decoded with `satpulsetool annotate`. (#246)
+- `satpulsetool ntrip` has a new `--gga` option that sends an NMEA GGA sentence to the caster on connect, for use with Virtual Reference Station casters such as u-blox PointPerfect that need the client's position before they will stream. (#325)
 
 ### Miscellaneous
 

--- a/gps/app/stream/pull.go
+++ b/gps/app/stream/pull.go
@@ -98,6 +98,11 @@ type NtripSource struct {
 	Username   string
 	Password   string
 	UserAgent  NtripUserAgent
+	// GGA, if non-empty, is an NMEA GGA sentence (already terminated
+	// with CRLF) sent to the caster as a separate write right after a
+	// successful handshake.  A Virtual Reference Station caster needs
+	// the client's position before it will start streaming.
+	GGA string
 }
 
 // Connect dials the caster, performs the Ntrip v1 handshake, and
@@ -140,6 +145,14 @@ func (s *NtripSource) handshake(conn net.Conn) (io.ReadCloser, error) {
 	}
 	if !bytes.Equal(line, []byte("ICY 200 OK\r\n")) {
 		return nil, fmt.Errorf("Ntrip: %s", strings.TrimSuffix(string(line), "\r\n"))
+	}
+	// A VRS caster needs the client's position before it streams; the
+	// spec allows sending the GGA after the request, so write it on the
+	// accepted stream as a separate write.
+	if len(s.GGA) > 0 {
+		if _, err := conn.Write([]byte(s.GGA)); err != nil {
+			return nil, err
+		}
 	}
 	if br.Buffered() == 0 {
 		return conn, nil

--- a/gps/app/stream/pull_test.go
+++ b/gps/app/stream/pull_test.go
@@ -998,6 +998,37 @@ func TestNtripRequestHeaders(t *testing.T) {
 	}
 }
 
+func TestNtripSendsGGAAfterHandshake(t *testing.T) {
+	gga := "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n"
+	got := make(chan string, 1)
+	ln := newNtripListener(t, func(conn net.Conn, req []byte) {
+		conn.Write([]byte("ICY 200 OK\r\n"))
+		// The GGA is a separate write that arrives after the handshake,
+		// so it must not ride along in the request.
+		if strings.Contains(string(req), "GGA") {
+			t.Errorf("GGA leaked into request: %q", req)
+		}
+		buf := make([]byte, len(gga))
+		n, _ := io.ReadFull(conn, buf)
+		got <- string(buf[:n])
+	})
+	defer ln.close()
+	src := &NtripSource{Addr: ln.addr(), Mountpoint: "MNT", GGA: gga}
+	rc, err := src.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer rc.Close()
+	select {
+	case s := <-got:
+		if s != gga {
+			t.Errorf("GGA mismatch: got %q, want %q", s, gga)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive GGA after handshake")
+	}
+}
+
 func TestNtripUserAgentNoVersion(t *testing.T) {
 	ln := newNtripListener(t, func(conn net.Conn, _ []byte) {
 		conn.Write([]byte("ICY 200 OK\r\n"))

--- a/internal/ntripcmd/ntripcmd.go
+++ b/internal/ntripcmd/ntripcmd.go
@@ -11,17 +11,19 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/jclark/satpulse/gps/app/cmd"
 	"github.com/jclark/satpulse/gps/app/gpsio"
 	"github.com/jclark/satpulse/gps/app/stream"
 	"github.com/jclark/satpulse/gps/gpsreg"
+	"github.com/jclark/satpulse/gps/lib/nmeamsg"
 	"github.com/jclark/satpulse/gps/scan"
 	"github.com/spf13/pflag"
 )
 
-const summary = `[-h|--help] [--user user[:password]] [--bin] <address[:port]> <mountpoint>`
+const summary = `[-h|--help] [--user user[:password]] [--bin] [--gga sentence] <address[:port]> <mountpoint>`
 
 // scanBufSize matches stream.scanBufSize.
 const scanBufSize = 16
@@ -32,15 +34,18 @@ type flagConfig struct {
 	Username   string
 	Password   string
 	Bin        bool
+	GGA        string // validated GGA sentence wire form (with CRLF), or empty
 }
 
 func parseFlags(cmdName string, args []string) (cfg *flagConfig, help bool, usageFunc func(string) string, err error) {
 	var user string
 	var bin bool
+	var gga string
 	flags := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
 	flags.BoolVarP(&help, "help", "h", false, "show help")
 	flags.StringVar(&user, "user", "", "Ntrip credentials (password may be omitted)")
 	flags.BoolVar(&bin, "bin", false, "emit raw bytes to stdout (default: packet log JSONL)")
+	flags.StringVar(&gga, "gga", "", "NMEA GGA sentence to send on connect (for VRS casters)")
 	usageFunc = cmd.UsageFunc(cmdName, summary, flags)
 	if err = flags.Parse(args); err != nil {
 		return
@@ -58,12 +63,42 @@ func parseFlags(cmdName string, args []string) (cfg *flagConfig, help bool, usag
 		Bin:        bin,
 	}
 	cfg.Username, cfg.Password = splitUserPass(user)
+	if gga != "" {
+		if cfg.GGA, err = validateGGA(gga); err != nil {
+			err = fmt.Errorf("--gga: %w", err)
+			return
+		}
+	}
 	return
 }
 
 func splitUserPass(user string) (string, string) {
 	name, pass, _ := strings.Cut(user, ":")
 	return name, pass
+}
+
+// validateGGA checks that s is a syntactically valid GGA sentence with a
+// matching checksum, and returns its wire form with a CRLF appended.  The
+// input is the sentence without a line terminator, e.g. "$GPGGA,...*47".
+func validateGGA(s string) (string, error) {
+	// Tolerate a trailing line terminator from copy-paste; the wire form
+	// always ends in exactly one CRLF.
+	s = strings.TrimRight(s, "\r\n")
+	wire := s + "\r\n"
+	if !nmeamsg.CheckSyntax(wire).IsValidApprovedNMEA() {
+		return "", fmt.Errorf("not a valid NMEA sentence: %q", s)
+	}
+	// IsValidApprovedNMEA guarantees a 5-char address: "$" + 2-char talker
+	// + 3-char sentence format, so the format is s[3:6].
+	if s[3:6] != "GGA" {
+		return "", fmt.Errorf("not a GGA sentence: %q", s)
+	}
+	payload, sum, _ := strings.Cut(s[1:], "*")
+	want, _ := strconv.ParseUint(sum, 16, 8)
+	if byte(want) != nmeamsg.Checksum([]byte(payload)) {
+		return "", fmt.Errorf("checksum mismatch in %q", s)
+	}
+	return wire, nil
 }
 
 // Cmd implements the ntrip subcommand.
@@ -84,6 +119,7 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 		Username:   cfg.Username,
 		Password:   cfg.Password,
 		UserAgent:  stream.NtripUserAgent{Version: version},
+		GGA:        cfg.GGA,
 	}
 	rc, err := src.Connect(ctx)
 	if err != nil {

--- a/internal/ntripcmd/ntripcmd_test.go
+++ b/internal/ntripcmd/ntripcmd_test.go
@@ -93,6 +93,20 @@ func TestParseFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "gga valid",
+			args: []string{"--gga", "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47", "caster.example", "MNT"},
+			expect: &flagConfig{
+				Addr:       "caster.example:2101",
+				Mountpoint: "MNT",
+				GGA:        "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n",
+			},
+		},
+		{
+			name:      "gga bad checksum",
+			args:      []string{"--gga", "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*00", "caster.example", "MNT"},
+			expectErr: true,
+		},
+		{
 			name:       "help short",
 			args:       []string{"-h"},
 			expectHelp: true,
@@ -143,6 +157,40 @@ func TestParseFlags(t *testing.T) {
 			}
 			if !reflect.DeepEqual(cfg, tc.expect) {
 				t.Errorf("got  %+v\nwant %+v", cfg, tc.expect)
+			}
+		})
+	}
+}
+
+func TestValidateGGA(t *testing.T) {
+	const gga = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47"
+	tests := []struct {
+		name string
+		in   string
+		want string // expected wire output; "" means expect an error
+	}{
+		{"gp", gga, gga + "\r\n"},
+		{"gn", "$GNGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*59", "$GNGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*59\r\n"},
+		{"trailing newline tolerated", gga + "\r\n", gga + "\r\n"},
+		{"bad checksum", "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*00", ""},
+		{"not gga", "$GPGLL,4916.45,N,12311.12,W,225444,A*31", ""},
+		{"not nmea", "GPGGA,nope", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateGGA(tc.in)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/plan/vrs.md
+++ b/plan/vrs.md
@@ -21,9 +21,49 @@ Scope notes:
 
 Synthesising NMEA is generally useful beyond VRS (e.g. exposing NMEA over a TCP
 port from a receiver that only emits UBX), so the synthesis lives in its own
-reusable package (`nmeasyn`, stage 3) rather than VRS-specific code.
+reusable package (`nmeasyn`, stage 2) rather than VRS-specific code.
 
-## Stage 1: GGA builder (`gps/lib/nmeamsg/gga.go`)
+## Stage 1: `ntripcmd --gga` option
+
+Standalone diagnostic: forward a caller-supplied GGA so the ntrip pull path can
+be exercised against a VRS caster (such as PointPerfect) without a live receiver
+or position synthesis. The caller pastes a real GGA captured from a receiver;
+`ntripcmd` validates it and sends it verbatim. It needs only the existing
+`nmeamsg` syntax library, so it lands before the GGA synthesis (stage 2).
+
+- Add `--gga sentence`. The argument is a full NMEA GGA sentence without a line
+  terminator (e.g. `$GPGGA,...*47`); a trailing CRLF from copy-paste is
+  tolerated. Presence of the flag marks VRS mode for the command.
+- Validation (`validateGGA`) uses the existing `nmeamsg` syntax helpers, not the
+  stage 2 GGA builder: `nmeamsg.CheckSyntax(...).IsValidApprovedNMEA()` for a
+  well-formed approved sentence, that the address is a `GGA` sentence, and that
+  the `*hh` checksum matches `nmeamsg.Checksum`. On success it returns the wire
+  bytes with a single CRLF appended.
+- Mechanism: once the v1 handshake succeeds (`ICY 200 OK`), `NtripSource` sends
+  the GGA to the caster as a separate write on the accepted stream (the spec
+  allows a GGA after the request); `ntripcmd` constructs the source with the
+  validated bytes. The write happens inside the handshake, so `Source.Connect`
+  stays read-only (`io.ReadCloser`) - the writer half is not exposed yet.
+  Stage 3 keeps this same post-connect write but moves ownership to the
+  `ggaSender` goroutine, which also re-sends on reconnect and tracks a moving
+  client.
+- Per the spec one GGA suffices to start the stream; `ntripcmd` does not resend.
+
+Because it forwards a literal sentence, this stage depends only on the existing
+`nmeamsg` syntax library, not on the GGA synthesis (stage 2). It is the first
+end-to-end proof of the VRS request flow (GGA upload -> caster streams), and -
+because it already uses the post-connect socket write - the first confirmation
+that the caster accepts a GGA on the stream rather than in the request, the
+delivery mechanism stage 3 relies on.
+
+## Stage 2: GGA synthesis
+
+Generate GGA sentences from the receiver's own position, so the daemon can drive
+a VRS caster (and expose NMEA generally) without a hand-supplied sentence. Two
+parts: a low-level GGA builder in `nmeamsg`, and a domain-layer synthesiser
+(`nmeasyn`) that drives the builder from the gpsprot message stream.
+
+### GGA builder (`gps/lib/nmeamsg/gga.go`)
 
 A typed field-set struct holding the GGA fields in wire order, serialised with
 `fieldenc` (the long-term direction for NMEA, as in `gps/lib/qtmmsg`).
@@ -115,7 +155,7 @@ func (g GGAFields) LatLon() (lat, lon float64) // signed decimal degrees, from c
 ```
 
 `LatLon` lets a consumer recover the position numerically without re-parsing the
-formatted sentence (used by the VRS move gate, stage 4).
+formatted sentence (used by the VRS move gate, stage 3).
 
 Tests:
 - Golden sentences for known positions in each hemisphere, exact bytes incl.
@@ -129,29 +169,7 @@ Tests:
 Follow-up (not required here): once `GGAFields` parses via `fieldenc.Decode`,
 it can replace the hand-rolled `parseGGA` in `gps/internal/nmea/nmea.go`.
 
-## Stage 2: `ntripcmd --pos` option
-
-Standalone diagnostic; static faked position, no live message stream, so it
-uses `nmeamsg.MakeGGA` directly (not `nmeasyn`).
-
-- Add `--pos lat,lon` (two floats; no height). Presence of the flag marks
-  VRS mode for the command.
-- When set, build a GGA with `nmeamsg.MakeGGA(nmeamsg.TalkerGP,
-  time.Now().UTC(), lat, lon, 1, nSats, hdop)` (quality 1 = GPS fix; nominal
-  `nSats`/`hdop` constants), serialize it with `nmeamsg.Serialize`, and send it
-  in the Ntrip v1 request body.
-- Mechanism: `stream.NtripSource` gains optional initial-GGA bytes appended
-  after the request's blank line (`request()` / handshake); `ntripcmd`
-  constructs the source with those bytes. (At this stage `Source.Connect` is
-  still read-only - the writer half arrives in stage 4 - so the request body is
-  the only place to put the GGA. Stage 4 adds the writer and moves the initial
-  GGA to a post-connect socket write, leaving this request-body path for the
-  diagnostic only.)
-- Per the spec one GGA suffices to start the stream; `ntripcmd` does not resend.
-
-This is the first user-visible proof that the GGA builder works end to end.
-
-## Stage 3: NMEA synthesis package (`gps/nmeasyn`)
+### NMEA synthesis package (`gps/nmeasyn`)
 
 Placement is fixed by the layering in `docs/internals.md`: `nmeasyn` is a
 **domain-layer** package (bare `gps/`), alongside `gpsprot`. It uses the
@@ -210,7 +228,7 @@ func New(sink Sink) *Synth   // *Synth implements gpsprot.MsgHandler
 **Open: how `nmeasyn` joins the dispatch fan-out** - see Open decisions.
 (Placement is settled above: `gps/nmeasyn`.)
 
-## Stage 4: `stream` pull VRS support (mobile)
+## Stage 3: `stream` pull VRS support (mobile)
 
 The production path. Keeps working for a moving client: an initial GGA on
 connect and live updates as the position changes. The `nmeasyn` sink for pull
@@ -261,14 +279,13 @@ no separate ECEF / position feed.
    GGA with quality > 0 (a valid fix) exists, so there is something to
    force-send on connect; later reconnects use the held latest immediately. The
    initial GGA goes out as the `ggaSender`'s first socket write after connect
-   (v1 allows sending the GGA on the stream after the request), not in the
-   request body, keeping the GGA owned in one place.
+   (v1 allows sending the GGA on the stream after the request), moved out of the
+   handshake so the GGA is owned in one place (the `ggaSender`).
 
 6. **Significant-change gate** - 2D distance threshold (constant or config;
    order of tens of metres). No keepalive timer (spec does not require one).
 
-Dependencies: stage 1 (builder); stage 3 (`nmeasyn`); the read-write `Source`
-change.
+Dependencies: the GGA synthesis (stage 2); the read-write `Source` change.
 
 Behavioural note to document: in VRS mode pull does not connect until a valid
 position fix exists, so corrections are gated on the receiver first achieving a
@@ -279,7 +296,7 @@ Test: Add a scenario to smoketest/ for this.
 ## Open decisions
 
 - **How `nmeasyn` joins the dispatch fan-out** (placement settled: `gps/nmeasyn`,
-  domain layer - see stage 3). The daemon does the binding: `gpsevent` is blind
+  domain layer - see stage 2). The daemon does the binding: `gpsevent` is blind
   to pull (`NewDispatcher` takes no stream argument and `time/internal/gpsevent`
   does not import `gps/app/stream`), so only `time/app/daemon` sees both the pull
   setup and the dispatcher. Construction order already supports this:
@@ -295,21 +312,19 @@ Test: Add a scenario to smoketest/ for this.
   (preferred) vs. assembling the `MultiHandler` in the daemon. `PullSetup` must
   gain a method exposing the sink.
 - Significant-move threshold value, and whether it is configurable.
-- What `ntripcmd` synthesises for quality / `NumSats` / HDOP on a faked fix
-  (quality 1 = GPS, nominal `NumSats`/HDOP).
 - Confirm PointPerfect accepts the Ntrip v1 request, or whether it requires v2
   (`Ntrip-Version: Ntrip/2.0`, HTTP/1.1 status line). We currently only accept
   `ICY 200 OK`. If v2 is required, that is separate work.
 
 ## Testing
 
-- Stage 1: golden sentences, padding, `LatLon` round-trip, encode/decode
-  round-trip.
-- Stage 2: request bytes include the GGA line; optional integration against a
-  fake caster.
-- Stage 3: `nmeasyn` builds the expected GGA from a synthetic epoch (fix level
-  -> quality, DOP -> HDOP, used SVs -> NumSats, no-fix -> quality 0); ECEF-only
-  epoch exercises the conversion.
-- Stage 4: `ggaSender` - force-send on connect, send on significant 2D move,
+- Stage 1: `validateGGA` accepts good sentences and rejects bad-checksum /
+  non-GGA / non-NMEA input; the GGA is sent as a separate write after the
+  handshake (`ICY 200 OK`), not in the request.
+- Stage 2: golden sentences, padding, `LatLon` round-trip, encode/decode
+  round-trip (builder); `nmeasyn` builds the expected GGA from a synthetic epoch
+  (fix level -> quality, DOP -> HDOP, used SVs -> NumSats, no-fix -> quality 0),
+  ECEF-only epoch exercises the conversion.
+- Stage 3: `ggaSender` - force-send on connect, send on significant 2D move,
   silence when stationary or quality 0, write-deadline / write-error handling,
   reconnect re-send; config parsing.


### PR DESCRIPTION
A tiny starter for VRS Ntrip support -- part of #325, not a full implementation.

This adds a `--gga` option to `satpulsetool ntrip` that validates a caller-supplied NMEA GGA sentence and sends it to the caster as a separate write right after the v1 handshake, so the ntrip pull path can be exercised against a VRS caster such as u-blox PointPerfect. The only production change to `stream` is an optional `GGA` field on `NtripSource` plus that post-handshake write.

This is stage 1 of `plan/vrs.md` only. The substantial pieces are still to come as later stages: the typed GGA builder, the `nmeasyn` synthesiser that derives a GGA from the receiver's own position, and mobile pull VRS support (per-mountpoint `vrs` flag, reconnect re-send, significant-move gate). None of that is here.

It also reorders `plan/vrs.md` to put `--gga` first (it needs only the existing `nmeamsg` syntax helpers) and folds the builder and synthesiser into stage 2.

See `plan/vrs.md`.
