### PR TITLE
Add ConfigSupportSurveyDur for the survey duration parameter

### DIFF
--- a/gps/gpsprot/configprotocol.go
+++ b/gps/gpsprot/configprotocol.go
@@ -34,6 +34,7 @@ const (
 	ConfigSupportSpeed
 	ConfigSupportSurvey
 	ConfigSupportSurveyAcc
+	ConfigSupportSurveyDur
 	ConfigSupportSurveyMsg
 	ConfigSupportFixedPos
 	ConfigSupportFixedPosAcc
@@ -62,6 +63,7 @@ var configSupportFlagNames = [...]struct {
 	{ConfigSupportSpeed, "speed"},
 	{ConfigSupportSurvey, "survey"},
 	{ConfigSupportSurveyAcc, "surveyAcc"},
+	{ConfigSupportSurveyDur, "surveyDur"},
 	{ConfigSupportSurveyMsg, "surveyMsg"},
 	{ConfigSupportFixedPos, "fixedPos"},
 	{ConfigSupportFixedPosAcc, "fixedPosAcc"},

--- a/gps/internal/ubx/ubxver.go
+++ b/gps/internal/ubx/ubxver.go
@@ -145,6 +145,7 @@ func (v *Version) rtcmSupport() rtcmSupport {
 // flag then applies to u-blox without editing this code.
 const ubxVariable = gpsprot.ConfigSupportSignal |
 	gpsprot.ConfigSupportSurvey | gpsprot.ConfigSupportSurveyAcc |
+	gpsprot.ConfigSupportSurveyDur |
 	gpsprot.ConfigSupportSurveyMsg | gpsprot.ConfigSupportFixedPos |
 	gpsprot.ConfigSupportFixedPosAcc | gpsprot.ConfigSupportRaw |
 	gpsprot.ConfigSupportRTCMMSM4 | gpsprot.ConfigSupportRTCMMSM7 |
@@ -162,6 +163,7 @@ func (v *Version) configSupport() gpsprot.ConfigSupportFlags {
 	if tmode > 0 {
 		flags |= gpsprot.ConfigSupportSurvey |
 			gpsprot.ConfigSupportSurveyAcc |
+			gpsprot.ConfigSupportSurveyDur |
 			gpsprot.ConfigSupportFixedPos |
 			gpsprot.ConfigSupportFixedPosAcc
 		if v.protVerAtLeast(15, 0) && (tmode == 2 || tmode == 3) {

--- a/gps/internal/ubx/ubxver_test.go
+++ b/gps/internal/ubx/ubxver_test.go
@@ -130,6 +130,7 @@ func TestVersionConfigSupport(t *testing.T) {
 	tmode := gpsprot.ConfigSupportSpeed |
 		gpsprot.ConfigSupportSurvey |
 		gpsprot.ConfigSupportSurveyAcc |
+		gpsprot.ConfigSupportSurveyDur |
 		gpsprot.ConfigSupportFixedPos |
 		gpsprot.ConfigSupportFixedPosAcc
 	tmode2 := tmode | gpsprot.ConfigSupportSurveyMsg

--- a/gps/internal/unc/config_test.go
+++ b/gps/internal/unc/config_test.go
@@ -24,6 +24,7 @@ type testResponse struct {
 func TestConfigSupport(t *testing.T) {
 	want := gpsprot.ConfigSupportSignal |
 		gpsprot.ConfigSupportSurvey |
+		gpsprot.ConfigSupportSurveyDur |
 		gpsprot.ConfigSupportFixedPos |
 		gpsprot.ConfigSupportRaw |
 		gpsprot.ConfigSupportRTCMMSM4 |

--- a/internal/gpscmd/gpsflags.go
+++ b/internal/gpscmd/gpsflags.go
@@ -486,6 +486,9 @@ func (p *flagParser) resolveMode(cmdName string) (bool, error) {
 			if flags.Lookup("survey-acc").Changed {
 				vars.configSupport.require(gpsprot.ConfigSupportSurveyAcc, "--survey-acc")
 			}
+			if flags.Lookup("survey-time").Changed {
+				vars.configSupport.require(gpsprot.ConfigSupportSurveyDur, "--survey-time")
+			}
 			vars.configOpts.Survey.Flags |= gpsprot.SurveyAgain
 			vars.mode.Set(gpsprot.Mode{Static: true})
 			if p.mobile {

--- a/internal/gpscmd/gpsflags_test.go
+++ b/internal/gpscmd/gpsflags_test.go
@@ -444,7 +444,7 @@ func TestParseFlagsConfigSupport(t *testing.T) {
 		{"except-signal", []string{"--gnss", "GPS", "--except-signal", "GPSL1C"}, gpsprot.ConfigSupportSignal, 0},
 		{"survey default accuracy", []string{"--survey"}, gpsprot.ConfigSupportSurvey, 0},
 		{"survey explicit accuracy", []string{"--survey", "--survey-acc", "5.5"}, gpsprot.ConfigSupportSurvey | gpsprot.ConfigSupportSurveyAcc, 0},
-		{"survey time", []string{"--survey", "--survey-time", "300"}, gpsprot.ConfigSupportSurvey, 0},
+		{"survey time", []string{"--survey", "--survey-time", "300"}, gpsprot.ConfigSupportSurvey | gpsprot.ConfigSupportSurveyDur, 0},
 		{"pvt survey", []string{"--pvt-out", "survey"}, gpsprot.ConfigSupportSurveyMsg, 0},
 		{"pvt ptp", []string{"--pvt-out", "ptp"}, gpsprot.ConfigSupportSurveyMsg, 0},
 		{"pvt ntp", []string{"--pvt-out", "ntp"}, gpsprot.ConfigSupportSurveyMsg, 0},


### PR DESCRIPTION
The survey capability flags cover the accuracy parameter (`ConfigSupportSurveyAcc`) but not duration, so a receiver whose survey runs without a controllable duration has no way to declare that, and an explicit `--survey-time` would be silently ignored on it.

This adds `ConfigSupportSurveyDur` as the duration analogue of `ConfigSupportSurveyAcc`: an explicitly given `--survey-time` now warns on receivers that ignore it, exactly like `--survey-acc` already does. u-blox declares it alongside its other tmode capabilities; Unicore gains it automatically through its full-minus declaration since it honors the duration. Defaults require nothing, so behavior on receivers that honor duration is unchanged.

Needed by the Septentrio high-level configuration work, where the receiver's survey (`setPVTMode, Static, , auto`) is autonomous and takes neither a duration nor an accuracy argument.

The gpshwtest baselines are deliberately not touched: the next hardware runs should observe `surveyDur` joining the supports lists (ZED-F9P, ZED-X20P, LEA-M8T, UM980) and re-record.