### PR TITLE
gpsio: drain serial output before closing so resets reach the receiver

### DIFF
--- a/gps/app/gpsio/conn.go
+++ b/gps/app/gpsio/conn.go
@@ -58,6 +58,9 @@ type Conn interface {
 	OutPort
 	Stop()
 	LocalAddr() string
+	// Drain blocks until pending output has been transmitted. It is a
+	// no-op on connections with no serial output buffer.
+	Drain() error
 }
 
 const scanBufSize = 16

--- a/gps/app/gpsio/net.go
+++ b/gps/app/gpsio/net.go
@@ -74,6 +74,10 @@ func (c *NetConn) Close() error {
 	return c.conn.Close()
 }
 
+// Drain is a no-op on a socket: there is no serial output buffer to flush,
+// and the daemon (which alone uses socket connections) never calls it.
+func (c *NetConn) Drain() error { return nil }
+
 func (c *NetConn) Stop() {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/gps/app/gpsio/serial.go
+++ b/gps/app/gpsio/serial.go
@@ -23,13 +23,14 @@ import (
 // Close will wait for any in-progress reads or writes to complete,
 // before restoring serial settings and closing the underlying file descriptor.
 type SerialConn struct {
-	file      ioFile
-	kind      term.DevKind
-	mu        sync.Mutex
-	stopped   bool // protected by mu
-	readLock  chan struct{}
-	writeLock chan struct{}
-	pktLog    *PacketLog
+	file         ioFile
+	kind         term.DevKind
+	mu           sync.Mutex
+	stopped      bool // protected by mu
+	readLock     chan struct{}
+	writeLock    chan struct{}
+	pktLog       *PacketLog
+	lastWriteLen int // bytes of the most recent write; read by Drain
 }
 
 // ioFile is the minimal file-like interface SerialConn needs.
@@ -174,19 +175,19 @@ func (c *SerialConn) writeThenChangeSpeed(p []byte, speed int, pktFmt gpsprot.Pa
 	}
 	n, err := c.file.Write(p)
 	if err == nil {
+		c.lastWriteLen = n
 		if speed != 0 {
 			if t := c.term(); t != nil {
-				// If it's a UART, then the TCSETSW flag should in theory take care of delaying the speed change
+				// If it's a UART, then the drain in Change should in theory take care of delaying the speed change
 				// until the data as been transmitted.
 				// But I found that on the Raspberry Pi, which uses a PL011 UART, it doesn't work without a little delay,
 				// for reasons I don't understand.
-				// With something like a USB-serial converter, it seems unlikely that the TCSETW flag will work,
+				// With something like a USB-serial converter, it seems unlikely that the drain will work,
 				// since the kernel does not have access to the UART buffer to determine when it is empty.
 				// So in this case, we increase the delay to ensure the data is transmitted before we change the speed,
 				// since that is the most important thing.
 				// We ideally want get the ACK back, which means we need to change the speed promptly.
 				// But we can recover from a lost ACK.
-				const minDelay = time.Millisecond
 				delay := minDelay
 				if c.kind != term.DevUART {
 					delay += t.TransmitTime(n)
@@ -269,7 +270,30 @@ func (c *SerialConn) Close() error {
 	return closeErr
 }
 
+// Drain waits for pending output to be transmitted. satpulsetool gps calls it
+// before Close so a final no-response command (e.g. a reset) reaches the
+// receiver before the port settings are restored and the port is closed. It
+// mirrors WriteThenChangeSpeed: the drain ioctl for all TTYs, plus the
+// computed transmit time for non-UART devices, whose adapter buffer the kernel
+// cannot observe.
+func (c *SerialConn) Drain() error {
+	t := c.term()
+	if t == nil {
+		return nil
+	}
+	delay := minDelay
+	if c.kind != term.DevUART {
+		delay += t.TransmitTime(c.lastWriteLen)
+	}
+	time.Sleep(delay)
+	return t.Drain()
+}
+
 const readTimeout = time.Millisecond * 100
+
+// minDelay is the minimum settle time before restoring or changing serial
+// settings, on top of the computed transmit time for non-UART devices.
+const minDelay = time.Millisecond
 
 func openTerm(path string, speed int) (*term.Term, error) {
 	opts := []term.AttrSetter{

--- a/gps/lib/term/term.go
+++ b/gps/lib/term/term.go
@@ -93,8 +93,10 @@ func (t *Term) Change(opts ...AttrSetter) error {
 			return err
 		}
 	}
-	err := t.setAttrDrain(&attr.ts)
-	if err != nil {
+	if err := t.Drain(); err != nil {
+		return err
+	}
+	if err := t.setAttrNow(&attr.ts); err != nil {
 		return err
 	}
 	t.attr = attr

--- a/gps/lib/term/term_bsd.go
+++ b/gps/lib/term/term_bsd.go
@@ -42,8 +42,9 @@ func (t *Term) setAttrNow(attr *unix.Termios) error {
 	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TIOCSETA, attr), "ioctl(TIOCSETA)")
 }
 
-func (t *Term) setAttrDrain(attr *unix.Termios) error {
-	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TIOCSETAW, attr), "ioctl(TIOCSETAW)")
+// Drain blocks until all pending output has been transmitted.
+func (t *Term) Drain() error {
+	return t.wrapErr(unix.IoctlSetInt(t.fd, unix.TIOCDRAIN, 0), "ioctl(TIOCDRAIN)")
 }
 
 func (t *Term) getAttr() (tp *unix.Termios, err error) {

--- a/gps/lib/term/term_linux.go
+++ b/gps/lib/term/term_linux.go
@@ -70,8 +70,11 @@ func (t *Term) setAttrNow(attr *unix.Termios) error {
 	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TCSETS, attr), "ioctl(TCSETS)")
 }
 
-func (t *Term) setAttrDrain(attr *unix.Termios) error {
-	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TCSETSW, attr), "ioctl(TCSET)")
+// Drain blocks until all pending output has been transmitted. The nonzero
+// TCSBRK argument selects drain-without-break, which is how glibc's tcdrain
+// is implemented.
+func (t *Term) Drain() error {
+	return t.wrapErr(unix.IoctlSetInt(t.fd, unix.TCSBRK, 1), "ioctl(TCSBRK)")
 }
 
 func (t *Term) getAttr() (tp *unix.Termios, err error) {

--- a/gps/lib/term/term_windows.go
+++ b/gps/lib/term/term_windows.go
@@ -158,7 +158,7 @@ func normalizeCOM(path string) string {
 	return path
 }
 
-// Change changes the attributes of the terminal.
+// Change changes the attributes of the terminal after output has drained.
 func (t *Term) Change(opts ...AttrSetter) error {
 	attr := t.attr
 	for _, opt := range opts {
@@ -166,6 +166,9 @@ func (t *Term) Change(opts ...AttrSetter) error {
 		if err != nil {
 			return err
 		}
+	}
+	if err := t.Drain(); err != nil {
+		return err
 	}
 	err := windows.SetCommState(t.handle, &attr.dcb)
 	if err != nil {
@@ -224,6 +227,11 @@ func (t *Term) Buffered() (int, error) {
 func (t *Term) Flush() error {
 	err := windows.PurgeComm(t.handle, windows.PURGE_RXCLEAR|windows.PURGE_TXCLEAR)
 	return t.wrapErr(err, "PurgeComm")
+}
+
+// Drain blocks until all pending output has been transmitted.
+func (t *Term) Drain() error {
+	return t.wrapErr(windows.FlushFileBuffers(t.handle), "FlushFileBuffers")
 }
 
 func (t *Term) Restore() error {

--- a/internal/gpscmd/gpscmd.go
+++ b/internal/gpscmd/gpscmd.go
@@ -155,6 +155,11 @@ func run(ctx context.Context, lg *slog.Logger, target *gpsprot.ConfigTarget, raw
 	defer func() {
 		addr := conn.LocalAddr()
 		lg.Debug("closing the GPS connection", "addr", addr)
+		// Drain first so a final no-response command (e.g. a reset) reaches
+		// the receiver before Close restores and closes the port.
+		if e := conn.Drain(); e != nil {
+			lg.Debug("error draining the GPS connection before close", "addr", addr, "error", e)
+		}
 		e := conn.Close()
 		if e != nil {
 			lg.Error("error closing the GPS connection", "addr", addr, "error", e)


### PR DESCRIPTION
## The bug

`satpulsetool gps` can silently fail to reset a receiver. When the last thing sent is a command the receiver does not acknowledge -- a reset (`--reload`, `--reset`; on Allystar these are `CFG-SIMPLERST`) -- the reset intermittently never takes effect.

Root cause: on close, `SerialConn.Close` restores the port's original termios via `term.Restore`, which applies immediately (`TCSETS`) **without waiting for pending output to drain**. Because a reset is fire-and-forget (no ACK to wait on), the tool writes it and exits at once. `Restore` then reverts the baud rate to the port's pre-open value while the reset bytes are still in the UART/USB transmit buffer -- so they are clocked out at the wrong rate or truncated, and the receiver never sees a valid reset.

The failure is timing-dependent, which made it a heisenbug: **anything that delays the close hides it** (enabling `--packet-log`, running under `strace`, or any path that waits after the last write). On the bench Allystar receivers, a bare `--reload` issued right after another invocation had left the port streaming failed to reset the receiver in roughly 4 of 5 runs; with packet logging on, it worked every time.

The existing speed-change path (`WriteThenChangeSpeed`) already handled this -- it sleeps for the computed transmit time before changing the baud on non-UART devices, because the kernel cannot see a USB-serial adapter's buffer. The close path just never got the same treatment.

## The fix

Add `SerialConn.Drain()` (on the `Conn` interface) and call it before `Close()` in `satpulsetool gps`. It waits for output to drain, mirroring `WriteThenChangeSpeed`:

- the drain ioctl (`TCSBRK` on Linux, `TIOCDRAIN` on BSD, `FlushFileBuffers` on Windows) for all TTYs, plus
- a computed `TransmitTime` sleep for non-UART devices, whose adapter buffer the kernel cannot observe.

The daemon keeps plain `Close()` -- it has no trailing command it cares about, and its shutdown must never block on a removed USB device.

Also folds the same drain into `term.Change`, which had the identical gap on **Windows** (it applied new settings without draining, unlike the Unix `TCSETSW` path), and drops the now-unused `setAttrDrain` helper.

## Verification

- `make test` green (74 packages); cross-compiles clean for `darwin` and `windows`.
- On hardware (`strace`, TAU951M over USB-serial): the close sequence is now `write(reset)` -> sleep -> drain ioctl (`TCSBRK,1`) -> `TCSETS` baud revert -> `close`; before the fix there was no drain between the write and the revert.

## Scope notes

- `Drain()` is called only by `satpulsetool gps`; the daemon shutdown path is untouched.
- The drain ioctl is a blocking wait, confined to the CLI close and the pre-existing speed-change path (never daemon shutdown), so a removed/wedged device can only stall a CLI invocation, not the daemon.
