### PR TITLE
Suppress GGA upload errors during cancellation

### DIFF
--- a/gps/app/stream/pull.go
+++ b/gps/app/stream/pull.go
@@ -327,12 +327,12 @@ func (s *GGASender) Run(ctx context.Context, lg *slog.Logger) {
 			latest = pkt.Data
 		case <-tickCh:
 			if conn != nil && latest != "" {
-				conn, nTimeouts = sendGGA(lg, conn, latest, nTimeouts)
+				conn, nTimeouts = sendGGA(ctx, lg, conn, latest, nTimeouts)
 			}
 		case conn = <-s.connCh:
 			nTimeouts = 0
 			if latest != "" {
-				conn, nTimeouts = sendGGA(lg, conn, latest, nTimeouts)
+				conn, nTimeouts = sendGGA(ctx, lg, conn, latest, nTimeouts)
 			}
 		case <-ctx.Done():
 			return
@@ -344,8 +344,14 @@ func (s *GGASender) Run(ctx context.Context, lg *slog.Logger) {
 // dropped) and the updated consecutive-timeout count.  A clean write timeout
 // keeps the connection through a transient stall; a hard error, or more than
 // maxGGASendTimeouts consecutive timeouts, drops it so the reader reconnects.
-func sendGGA(lg *slog.Logger, conn ReadWriteDeadlineCloser, data string, nTimeouts int) (ReadWriteDeadlineCloser, int) {
+// Errors after cancellation are suppressed because the reader closes the same
+// connection to unblock its scan during shutdown.
+func sendGGA(ctx context.Context, lg *slog.Logger, conn ReadWriteDeadlineCloser, data string, nTimeouts int) (ReadWriteDeadlineCloser, int) {
 	err := writeGGA(conn, data)
+	if err != nil && ctx.Err() != nil {
+		conn.Close()
+		return nil, 0
+	}
 	switch {
 	case err == nil:
 		return conn, 0

--- a/gps/app/stream/pull_test.go
+++ b/gps/app/stream/pull_test.go
@@ -1344,6 +1344,23 @@ func TestGGASenderTimeoutTolerance(t *testing.T) {
 	}
 }
 
+func TestGGASenderCancelSuppressesWriteError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var logBuf bytes.Buffer
+	conn := &failWriteConn{err: net.ErrClosed}
+	got, nTimeouts := sendGGA(ctx, slog.New(slog.NewTextHandler(&logBuf, nil)), conn, "GGA", 1)
+	if got != nil || nTimeouts != 0 {
+		t.Errorf("sendGGA() = (%v, %d), want (nil, 0)", got, nTimeouts)
+	}
+	if !conn.isClosed() {
+		t.Error("connection not closed")
+	}
+	if logBuf.Len() != 0 {
+		t.Errorf("unexpected log: %s", &logBuf)
+	}
+}
+
 // failWriteConn is a ReadWriteDeadlineCloser whose Write always fails with err.
 type failWriteConn struct {
 	err    error


### PR DESCRIPTION
## Summary

- suppress GGA write errors caused by correction-session cancellation
- preserve timeout and hard-error warnings while the session is active
- add a regression test for the cancellation path

## Root cause

The correction reader closes the network connection during cancellation to unblock its scan. The GGA sender could race that intentional close, attempt an upload, and log the closed-connection error as a failure during a clean stop or shutdown.

## Impact

Clean correction stops, restarts, and application shutdowns no longer emit a misleading `NMEA GGA upload failed` warning. Active-session upload failures still retain their existing warning and reconnect behavior.

## Validation

- `make test`
- `make`
- `make smoketest` (26 passed, 1 root-only scenario skipped)