### PR TITLE
Smoke-test the config path against the u-blox simulator

### DIFF
--- a/plan/satpulseweb.md
+++ b/plan/satpulseweb.md
@@ -805,26 +805,142 @@ phase-5 scenarios, which need no browser or npm.
 
 ### Phase 9: simulator config tests (one PR)
 
-Extends both harnesses from the monitor path to the config path,
+Extends the smoke tests from the monitor path to the config path,
 using the u-blox receiver simulator (#362,
-[ublox-sim.md](ublox-sim.md)), which is developed in parallel on its
-own branch off master. In smoketest terms the simulator is a new
-packet provider, not a transport: what plays the receiver behind
-the serial transport becomes another scenario-declared dimension,
-orthogonal to the program under test -- either a paced `pack
---realtime` replay of a recorded log (whose one-replay-per-lifetime
-invariant and wait-replay backstop belong to this provider, not to
-the suite) or the interactive simulator, which answers probes and
-config writes and so implies a read-write pty. The dimensions
-compose: satpulsed x simulator smoke-tests the daemon's startup
-config phase, which no replay can reach. The smoketest scenarios
-and phase-8 journeys gain
-config checks: probe identifies the personality, the config panel
-populates from ReadConfig, an apply round-trips and a re-read shows
-the change, and enabling a message makes it appear in the packet
-stream. Not part of the stacked-PR series: it needs the simulator on
-master, so it runs after the stack and the simulator have both
-landed.
+[ublox-sim.md](ublox-sim.md)), now landed on master (#364:
+`gps/app/ubxsim`, hosted behind a pty by `satpulsetool ubxsim`).
+Replay can drive only the monitor path: gpscfg skips probing on a
+read-only port, and a pty replay's probe goes unanswered, so probe
+identification, ReadConfig and ApplyConfig have no black-box
+coverage until something answers. Not part of the stacked-PR
+series: an ordinary PR off master. The Playwright half is deferred
+with phase 8 (see the end of this section); this PR is the
+smoketest half.
+
+The packet-provider seam. In smoketest terms the simulator is a
+new packet provider, not a transport: what plays the receiver
+behind `SATPULSE_TEST_SERIAL` becomes a scenario-declared
+dimension, orthogonal to the program under test, and the
+dimensions compose -- satpulsed x simulator smoke-tests the
+daemon's startup config phase, which no replay can reach. run.py
+currently owns the replay lifecycle directly (transport selection,
+start_replay/wait_replay, the one-replay-per-lifetime invariant),
+so the first commit factors that out into a provider seam, the
+analogue of `program_api.py`: `provider_api.py` defines a
+`Provider` Protocol plus `select(name)`, implemented by
+`provider_replay.py` (the default) and `provider_ubxsim.py`,
+chosen per scenario with `PROVIDER = "ubxsim"`. The provider owns
+how receiver bytes are produced and consumed:
+
+- The serial endpoint. The replay provider requests the transport
+  from the platform as today (`plat.make_transport`, driven by the
+  `CAPTURE_WRITES`/`SELF_SHUTDOWN`/`DISCONNECTABLE` capabilities).
+  The ubxsim provider spawns `satpulsetool ubxsim --link <run
+  dir>/gps.pty [-r <bank>] <personality>` and the symlink is the
+  endpoint -- the /dev/serial/by-id shape gpsio already opens;
+  readiness is the link appearing (created before the slave path
+  is printed).
+- The feed lifecycle. The replay provider keeps the single
+  `pack --realtime` replay, its start-after-readiness ordering,
+  the one-replay-per-lifetime invariant, and the wait-replay
+  backstop. The ubxsim provider starts the simulator before the
+  program (the pty must exist when the program opens the device)
+  and SIGTERMs it only after the program has shut down -- the
+  simulator holds its own slave fd open, so program restarts
+  never EOF it, while killing it early would inject read errors
+  into the program's shutdown.
+- The scenario attributes. `PACKET_LOG` and `FACTOR` become
+  replay-provider attributes (all existing scenarios keep them
+  unchanged; the runner reads them through the provider). The
+  ubxsim provider takes `PERSONALITY` (repo-relative) and an
+  optional `SIM_REPLAY` nav bank. `ctx.factor` defaults to 1 for
+  simulator scenarios (correction-source pacing is its only other
+  consumer).
+
+Provider hooks mirror the run_scenario lifecycle: create before
+`program.prepare` (make the transport or spawn the simulator, and
+point `SATPULSE_TEST_SERIAL` at the endpoint -- run_scenario
+constructs the Context first so the provider can be handed it),
+start after `program.wait_ready` (launch pack; a no-op for
+ubxsim), finish as the post-run backstop (wait_replay; a no-op for
+ubxsim), close in the cleanup path. `ctx.start_replay` and
+`ctx.wait_replay` become delegates, so existing scenarios and
+checks do not change. The observers-before-packets invariant is a
+replay-provider concern: simulator nav output regenerates every
+epoch (and pty backpressure pauses it while no one reads the
+slave), so a late observer misses nothing.
+
+Capabilities and platforms: the ubxsim provider rejects
+`CAPTURE_WRITES`, `SELF_SHUTDOWN` and `DISCONNECTABLE` as scenario
+errors -- write capture is meaningless when the simulator consumes
+and answers the program's writes, and device-loss modelling stays
+with the replay provider (a CFG-RST pty drop is a listed ublox-sim
+extension, not this phase). `satpulsetool ubxsim` builds on Linux
+and macOS only, so elsewhere (FreeBSD) the provider reports the
+scenario unsupported -- the same SKIP as TransportUnsupported.
+
+Fixtures and timing: the personality is the checked-in F9P
+recording (`gps/app/ubxsim/testdata/f9p/f9p-personality.ubx`, HPG
+1.51). The nav bank is an existing ZED-F9P log -- LoadReplay reads
+the standard JSONL packet-log format, so the fixtures under
+`gps/testdata/packets/u-blox/ZED-F9P/` work as-is; pick one that
+contains NAV-SAT (e.g. daemon-sats-pos-38400.jsonl) and outlasts
+the run, since the NAV engine consumes one epoch per CFG-RATE
+period (1s) in real time -- there is no FACTOR -- and goes silent
+when the bank is exhausted. Record a purpose-built bank only if no
+existing log fits. The message-appearance assertions depend on the
+personality's Default layer having UBX output messages off
+(factory default) while the bank contains them: configuration is
+then the only way they can appear. Scenarios set the serial speed
+to the personality's default CFG-UART1-BAUDRATE (38400) so the
+config phase stays out of the baud-change path (hardware-test
+territory, and speed is nominal on a pty anyway).
+
+Two scenarios, in a new `config/` family:
+
+- `config/startup` -- satpulsed x simulator: the startup-config
+  assertion. Config: `[serial]` at 38400; `[gps]` with `config =
+  true` and `satellitesOutput = true`; one `[[http]]` endpoint; no
+  correction peers. Asserts: (a) detection was active, not
+  passive -- the receiver identity the daemon reports carries the
+  personality's MON-VER model and firmware; (b) the startup
+  ConfigTarget landed on the receiver: NAV-SAT is off in the
+  personality defaults and present in the bank, so satellite data
+  appearing on the daemon's HTTP surface can only mean the
+  daemon's own VALSET enabled it; (c) the log scan stays clean
+  (configuration completed without errors) and shutdown is
+  graceful.
+- `config/wb-apply` -- satpulsewb x simulator: the interactive
+  config path, UI-shaped. Start without `-d`; claim the seat; POST
+  /api/connect with the pty device and speed (the first black-box
+  exercise of interactive connect whose probe answers); poll GET
+  /api/receiver until ok with Info identifying the personality
+  (vendor "u-blox", the F9P model/firmware); POST /api/config/read
+  returns 200 with non-empty props; POST /api/config/apply with a
+  small ConfigTarget that both sets a property that round-trips
+  (e.g. the antenna cable delay) and enables the satellites
+  messages (Opts.SatsMsg); a second read shows the property
+  change, and the enabled messages appear as live data (gps:msg
+  satellites over SSE, or /api/signals turning non-empty).
+
+Mechanical footprint beyond the seam: SCENARIOS registry entries;
+the smoketest Makefile's mypy target gains the provider modules;
+README's scenario list and smoketest/CLAUDE.md document the
+provider dimension; the simulator's stdout+stderr land in
+ubxsim.log in the run dir (kept on failure, not error-scanned --
+the simulator is a test double, not a program under test).
+
+The Playwright half: once phase 8 exists, its journeys gain a
+config journey (the config panel populates from ReadConfig, an
+apply round-trips, the enabled message shows up in the Packets
+tab) against a satpulsewb x ubxsim launch fixture; the Playwright
+setup starts `satpulsetool ubxsim` directly -- the provider seam
+is smoketest-internal. That lands with or after phase 8, not in
+this PR.
+
+Verification: `make`; the full `make smoketest` suite with the new
+scenarios stable over reruns; `make typecheck` (mypy strict) in
+smoketest/.
 
 ### Phase 10: proxy transports (one PR)
 

--- a/smoketest/CLAUDE.md
+++ b/smoketest/CLAUDE.md
@@ -8,8 +8,9 @@ changes safely.
 ## What this is
 
 Black-box smoke tests that run the real `satpulsed` and `satpulsewb` binaries,
-fed by realtime packet-log replay through a FIFO or pty, with no root and no GPS
-hardware. They check program-level behaviour -- config wiring, startup,
+fed by realtime packet-log replay through a FIFO or pty (or the u-blox simulator
+for config scenarios), with no root and no GPS hardware. They check program-level
+behaviour -- config wiring, startup,
 observability endpoints, logging, Ntrip, NTP, corrections, shutdown -- NOT packet
 decoding. Decode correctness is covered by Go package tests and
 `plan/packet-testing.md`; do not add packet/protocol assertions here.
@@ -17,7 +18,9 @@ decoding. Decode correctness is covered by Go package tests and
 The program under test is a scenario dimension (`PROGRAM`, default `satpulsed`;
 `satpulsewb` is the SatPulse Workbench GUI server over `gps/app/session`), chosen
 behind a per-program seam the same way the OS is chosen behind `platform_*`. See
-Program under test below.
+Program under test below. What plays the receiver is a second, orthogonal
+dimension (`PROVIDER`, default `replay`; `ubxsim` is the u-blox simulator, which
+answers config so the config path can be tested). See Packet provider below.
 
 Checks are deliberately shallow: catch gross breakage (panics, failed wiring,
 missing listeners, broken shutdown, missing/empty logs, unusable endpoints),
@@ -134,13 +137,18 @@ A scenario ID `family/name` maps to two files and one registry entry:
 
 - `scenarios/family/name.py` -- the module. Must define:
   - `PACKET_LOG` -- path relative to repo root; reuse logs under
-    `gps/testdata/packets/` (don't add new captures here).
-  - `FACTOR` -- replay speedup (int).
+    `gps/testdata/packets/` (don't add new captures here). A replay-provider
+    attribute: omit it for a `PROVIDER = "ubxsim"` scenario.
+  - `FACTOR` -- replay speedup (int). Replay-only, like `PACKET_LOG`.
   - `run(ctx)` -- the checks. Type the param as `common.SmokeContext`.
   - optional `PROGRAM` -- `"satpulsed"` (default) or `"satpulsewb"`, the program
     under test (see Program under test). A `"satpulsewb"` scenario pairs with a
     `name.args.in` flag list instead of `name.toml.in`, and uses the workbench
     checks in `common.py` (`check_wb_*`, `wb_get`/`wb_post`, `wb_sse`).
+  - optional `PROVIDER` -- `"replay"` (default) or `"ubxsim"`, the packet source
+    (see Packet provider). A `"ubxsim"` scenario declares `PERSONALITY`
+    (repo-relative MON-VER + Default-layer dump) and an optional `SIM_REPLAY` nav
+    bank instead of `PACKET_LOG`/`FACTOR`; `ctx.factor` defaults to 1.
   - optional `ENV` -- environment variables added to the program under test;
     values may use the same `${SATPULSE_TEST_*}` substitutions as input
     templates.
@@ -218,6 +226,35 @@ two programs belongs behind this seam, not as a `PROGRAM == "satpulsewb"` branch
 in `run.py` or a scenario. The program log is `ctx.daemon_log` (named
 `<program>.log`); for satpulsewb it also carries the printed URL that
 `wait_ready` parses.
+
+### Packet provider
+
+`provider_api.py` is the packet-provider seam (a `Provider` Protocol plus
+`select(name)`), implemented by `provider_replay.py` (default) and
+`provider_ubxsim.py`. It is orthogonal to the program: what plays the receiver
+behind `SATPULSE_TEST_SERIAL` is a scenario dimension of its own, chosen per
+scenario like a `Program`, so `satpulsed x ubxsim` composes the daemon with the
+simulator to test the startup config phase no replay can reach. The four hooks
+mirror the `run_scenario` lifecycle, and the runner calls them polymorphically:
+
+- `create(ctx, scen)` -- before `program.prepare`: set up the source and point
+  `SATPULSE_TEST_SERIAL` at its endpoint. The replay provider selects and
+  attaches the transport (from the scenario's capabilities, and reads
+  `PACKET_LOG`/`FACTOR`); ubxsim spawns `satpulsetool ubxsim` and waits for its
+  `--link` symlink. A source the platform cannot supply raises
+  `platform_api.TransportUnsupported` (a SKIP); a scenario error (e.g. ubxsim
+  with `CAPTURE_WRITES`) fails.
+- `start(ctx)` -- after `program.wait_ready`: begin feeding (the replay launch;
+  a no-op for ubxsim, whose simulator already emits).
+- `finish(ctx)` -- the post-run backstop (`wait_replay`; a no-op for ubxsim).
+- `close(ctx)` -- release the source, run last in the cleanup path so ubxsim
+  SIGTERMs the simulator only after the program has shut down.
+
+`ctx.start_replay`/`ctx.wait_replay` stay on the Context (the replay mechanics),
+so existing scenarios and checks calling `ctx.wait_replay()` are unchanged; under
+ubxsim they are no-ops (no replay was started). Keep `run.py` free of a
+`PROVIDER == "..."` branch: a difference between the two sources belongs behind
+this seam, exactly like the program seam.
 
 ### Transports
 

--- a/smoketest/Makefile
+++ b/smoketest/Makefile
@@ -1,5 +1,6 @@
 PY_FILES = run.py system.py ntpsock.py ntpshm.py common.py \
-	program_api.py program_satpulsed.py program_satpulsewb.py scenarios
+	program_api.py program_satpulsed.py program_satpulsewb.py \
+	provider_api.py provider_replay.py provider_ubxsim.py scenarios
 
 .PHONY: dev-deps update-deps typecheck
 

--- a/smoketest/README.md
+++ b/smoketest/README.md
@@ -1,17 +1,19 @@
 # satpulse daemon and workbench smoke tests
 
 Black-box smoke tests that run the real `satpulsed` and `satpulsewb`
-binaries, fed by realtime packet-log replay through a FIFO or pty, with
-no root and no GPS hardware. They exercise program behaviour --
-configuration wiring, startup, observability endpoints, logging, Ntrip,
-corrections, and shutdown -- not packet decoding (that is covered by
-package tests and `plan/packet-testing.md`).
+binaries, fed by realtime packet-log replay through a FIFO or pty (or the
+u-blox simulator for config scenarios), with no root and no GPS hardware.
+They exercise program behaviour -- configuration wiring, startup,
+observability endpoints, logging, Ntrip, corrections, and shutdown -- not
+packet decoding (that is covered by package tests and
+`plan/packet-testing.md`).
 
 The program under test is a scenario dimension: `satpulsed` by default,
 `satpulsewb` (SatPulse Workbench, the browser GUI over `gps/app/session`)
-when a scenario sets `PROGRAM = "satpulsewb"`. Both replay the same
-packet logs; only the per-program specifics differ (see Program under
-test below).
+when a scenario sets `PROGRAM = "satpulsewb"`. What plays the receiver is
+a second, orthogonal dimension: a packet-log replay by default, the u-blox
+simulator when a scenario sets `PROVIDER = "ubxsim"` (see Program under
+test and Packet provider below).
 
 See `plan/smoke-test.md` for the design, and the Delivery section of
 `plan/satpulseweb.md` for the workbench phase.
@@ -63,11 +65,16 @@ For each scenario the runner (`run.py`):
 2. asks the program (see Program under test) to prepare its input,
    substituting the `SATPULSE_TEST_*` resource variables: satpulsed
    renders `<name>.toml.in`, satpulsewb renders `<name>.args.in`;
-3. creates the serial input transport (a FIFO by default, or a pty for a
-   scenario that needs to disconnect) and starts any required fake peers;
+3. sets up the packet source (see Packet provider) and points
+   `SATPULSE_TEST_SERIAL` at it -- the serial input transport (a FIFO by
+   default, or a pty for a scenario that needs to disconnect) for a replay
+   scenario, or the u-blox simulator for a `PROVIDER = "ubxsim"` scenario -- and
+   starts any required fake peers;
 4. starts the program (`satpulsed` or `satpulsewb`);
-5. starts a single `satpulsetool pack --realtime <factor>` replay of the
-   scenario's packet log into that input, in the background;
+5. starts the provider's feed: a replay scenario runs a single
+   `satpulsetool pack --realtime <factor>` replay of its packet log into the
+   input, in the background; a `ubxsim` scenario needs no separate replay (the
+   simulator generates nav itself);
 6. calls the scenario's `run(ctx)`, which performs its checks while the
    replay flows (live checks such as SSE and Ntrip) and after it
    finishes (`ctx.wait_replay()`, then log and error checks);
@@ -133,12 +140,45 @@ the two programs:
 - the **base allow-list** for the log error scan, and the **ports to free**
   after shutdown.
 
-Everything else -- port allocation, run dirs, the serial transport, the replay
-lifecycle, the fake peers, and the parallel executor -- stays shared in
-`run.py`. Scenario families are organised by feature, not by program, and hold
-scenarios for both side by side: the workbench corrections scenario lives beside
-the daemon's `stream/pull-*` ones and reuses the family's captured-serial-writes
-RTCM check as-is.
+Everything else -- port allocation, run dirs, the fake peers, and the parallel
+executor -- stays shared in `run.py`. Scenario families are organised by feature,
+not by program, and hold scenarios for both side by side: the workbench
+corrections scenario lives beside the daemon's `stream/pull-*` ones and reuses
+the family's captured-serial-writes RTCM check as-is.
+
+## Packet provider
+
+What plays the receiver behind `SATPULSE_TEST_SERIAL` is a second scenario
+dimension, orthogonal to the program under test, chosen with `PROVIDER` (default
+`replay`). It composes with the program: `satpulsed x ubxsim` smoke-tests the
+daemon's startup config phase, which no replay can reach. `provider_api.py`
+defines the seam (a `Provider` Protocol plus `select(name)`); `provider_replay.py`
+and `provider_ubxsim.py` implement it, chosen per scenario like a Program. The
+provider owns how receiver bytes are produced and consumed -- the serial
+endpoint, the feed lifecycle, and its own source attributes -- and nothing else,
+so `run.py` carries no `PROVIDER ==` branch:
+
+- **replay** (the default) -- a recorded packet log streamed in real time. It
+  owns transport selection (from the scenario's capabilities, see Transports),
+  the single `pack --realtime` replay, the one-replay-per-lifetime invariant, and
+  the `PACKET_LOG`/`FACTOR` attributes. Every existing scenario is a replay
+  scenario and keeps `PACKET_LOG`/`FACTOR` unchanged.
+- **ubxsim** (`PROVIDER = "ubxsim"`) -- the u-blox receiver simulator behind a
+  pty (`satpulsetool ubxsim`), the one source that answers probes and config, so
+  the config path (probe identification, `ReadConfig`, `ApplyConfig`, and the
+  daemon's startup config phase) gets black-box coverage a read-only replay
+  cannot. The scenario declares `PERSONALITY` (a recorded MON-VER + Default-layer
+  dump) and an optional `SIM_REPLAY` nav bank; `ctx.factor` defaults to `1`. The
+  provider spawns the simulator before the program (the pty must exist when the
+  program opens the device) and SIGTERMs it only after the program has shut down
+  (the simulator holds its own slave fd open, so program restarts never EOF it,
+  while an early kill would inject read errors into the program's shutdown). It
+  rejects `CAPTURE_WRITES`/`SELF_SHUTDOWN`/`DISCONNECTABLE` (write capture is
+  meaningless when the simulator answers the writes; device-loss stays with the
+  replay provider) and reports the scenario unsupported (a SKIP) off Linux/macOS,
+  where `satpulsetool ubxsim` does not build. Its stdout+stderr land in
+  `ubxsim.log` in the run dir, kept on failure and not error-scanned -- the
+  simulator is a test double, not a program under test.
 
 satpulsewb scenarios cannot use the no-argument default (it binds a fixed port
 on all interfaces, which is neither parallel-safe nor in the allocated block),
@@ -151,11 +191,14 @@ program prints.
 
 ```
 smoketest/
-  run.py                    execution environment: resources, replay, shutdown
+  run.py                    execution environment: resources, lifecycle, shutdown
   common.py                 checks and helpers shared across scenario families
   program_api.py            the program-under-test seam (Protocol + select)
   program_satpulsed.py      satpulsed: config input, config-derived peers
   program_satpulsewb.py     satpulsewb: flag-list input, URL/token readiness
+  provider_api.py           the packet-provider seam (Protocol + select)
+  provider_replay.py        replay: transport selection + the pack replay
+  provider_ubxsim.py        ubxsim: the u-blox simulator behind a pty
   platform_api.py           the serial-transport seam (Protocol)
   platform_unix.py          Unix transports (FIFO/pty), shutdown, privilege
   ntpshm.py                 NTP SHM read/remove helper for root-required scenarios
@@ -180,15 +223,20 @@ in `run.py` as `family/name`, and maps to a module and an input template:
 The scenario module declares:
 
 - `PACKET_LOG` -- packet log to replay (path relative to the repo root;
-  the scenarios reuse logs under `gps/testdata/packets/`);
-- `FACTOR` -- replay speedup factor;
+  the scenarios reuse logs under `gps/testdata/packets/`); a replay-provider
+  attribute (omit it for a `ubxsim` scenario);
+- `FACTOR` -- replay speedup factor; likewise replay-only;
 - `run(ctx)` -- the checks to perform, using helpers from `common.py` and
   the owning scenario-family package;
 - `ENV` -- optional environment variables for the program under test, with
   `${SATPULSE_TEST_*}` substitutions available in their values;
 - `PROGRAM = "satpulsewb"` -- optional; selects the workbench program (default
   `satpulsed`). A workbench scenario may also declare `CORRECTION_SOURCE` (a fake
-  correction source the runner starts, for a corrections scenario).
+  correction source the runner starts, for a corrections scenario);
+- `PROVIDER = "ubxsim"` -- optional; selects the u-blox simulator as the packet
+  source (default `replay`, see Packet provider). A `ubxsim` scenario declares
+  `PERSONALITY` (repo-relative) and an optional `SIM_REPLAY` nav bank instead of
+  `PACKET_LOG`/`FACTOR`.
 
 Checks used only by one scenario family live in that family's package, e.g.
 `scenarios/ntrip/__init__.py` or `scenarios/proxy/__init__.py`. Keep
@@ -237,6 +285,15 @@ make update-deps
   capture (`NAV-SVIN`) drives `gps:msg` kind `survey`, and after the replay ends
   a late SSE client is still primed with it from the hub's sticky-kind cache
   (the slow-changing state a reloaded browser must not have to wait for).
+- `config/startup` (satpulsed x ubxsim) -- the daemon's startup config phase
+  against the u-blox simulator: active detection carries the personality's
+  MON-VER model and firmware, and the startup ConfigTarget landing shows up as
+  NAV-SAT (off in the personality defaults) becoming live satellite data.
+- `config/wb-apply` (satpulsewb x ubxsim) -- the interactive config path,
+  UI-shaped: connect to the simulator's pty, identify the receiver, read the
+  config, apply a ConfigTarget that both round-trips a property (the antenna
+  cable delay) and enables satellite messages, then confirm a re-read and live
+  satellite data.
 - `ntrip/basic` -- Ntrip caster source table and RTCM streaming; the source
   table's shared STR fields show their defaults.
 - `ntrip/auth` -- Ntrip caster with an authenticated mountpoint.

--- a/smoketest/provider_api.py
+++ b/smoketest/provider_api.py
@@ -1,0 +1,81 @@
+"""Packet-provider seam for the smoke-test runner.
+
+What plays the receiver behind SATPULSE_TEST_SERIAL is a scenario dimension,
+orthogonal to the program under test: `replay` by default (a recorded packet
+log streamed through a FIFO or pty), `ubxsim` when a scenario sets PROVIDER =
+"ubxsim" (the u-blox receiver simulator behind a pty, which answers probes and
+config, so the config path -- probe identification, ReadConfig, ApplyConfig,
+and the daemon's startup config phase -- gets black-box coverage a read-only
+replay cannot reach).
+
+The Provider owns how receiver bytes are produced and consumed, and nothing
+else: the serial endpoint, the feed lifecycle, and the source-side scenario
+attributes (PACKET_LOG/FACTOR for replay, PERSONALITY/SIM_REPLAY for ubxsim).
+run.py's replay lifecycle -- transport selection, the single pack replay, the
+one-replay-per-lifetime invariant, and the wait-replay backstop -- lives behind
+this seam so run.py stays free of PROVIDER == "..." branches, exactly as the
+program seam keeps it free of PROGRAM branches.
+
+This is the provider counterpart to program_api. Like a Program (and unlike the
+one-per-process platform module), a Provider is chosen per scenario, so both
+providers coexist in one process and share this Protocol; run.py holds one per
+scenario and calls it polymorphically.
+
+The four hooks mirror the run_scenario lifecycle:
+
+  - create: before program.prepare -- make the transport or spawn the
+    simulator, and point SATPULSE_TEST_SERIAL at the endpoint. run_scenario
+    constructs the Context first so the provider can be handed it.
+  - start: after program.wait_ready -- begin feeding packets (launch the pack
+    replay; a no-op for ubxsim, whose simulator already runs).
+  - finish: the post-run backstop -- wait for the feed to drain (a no-op for
+    ubxsim).
+  - close: the cleanup path -- release the transport, or SIGTERM the simulator.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from run import Context, ScenarioModule
+
+
+class Provider(Protocol):
+    """The packet source and the per-provider steps around feeding it."""
+
+    def create(self, ctx: Context, scen: ScenarioModule) -> None:
+        """Set up the packet source and point SATPULSE_TEST_SERIAL at its endpoint.
+
+        Runs before program.prepare (which renders input referencing the serial
+        path). The replay provider selects and attaches the transport; the
+        ubxsim provider spawns the simulator and waits for its symlink. A
+        platform that cannot honour the scenario raises
+        platform_api.TransportUnsupported, which the runner reports as SKIP.
+        """
+        ...
+
+    def start(self, ctx: Context) -> None:
+        """Begin feeding packets, after the program is observable (wait_ready)."""
+        ...
+
+    def finish(self, ctx: Context) -> None:
+        """Post-run backstop: wait for the feed to drain cleanly."""
+        ...
+
+    def close(self, ctx: Context) -> None:
+        """Release the provider's resources. Idempotent."""
+        ...
+
+
+def select(name: str) -> Provider:
+    """Return the Provider for a scenario's PROVIDER name (default replay)."""
+    if name == "replay":
+        import provider_replay
+
+        return provider_replay.Replay()
+    if name == "ubxsim":
+        import provider_ubxsim
+
+        return provider_ubxsim.Ubxsim()
+    raise RuntimeError(f"unknown PROVIDER {name!r}")

--- a/smoketest/provider_replay.py
+++ b/smoketest/provider_replay.py
@@ -1,0 +1,90 @@
+"""The replay packet provider (see provider_api).
+
+The default provider: a recorded packet log streamed in real time through the
+serial transport. It owns transport selection, the single `pack --realtime`
+replay with its one-replay-per-lifetime invariant, the wait-replay backstop,
+and the PACKET_LOG/FACTOR scenario attributes -- everything the runner used to
+own inline, now behind the provider seam so run.py carries no PROVIDER branch.
+
+The transport mechanics (feeding pack, draining and optionally capturing the
+program's writes, disconnect, and the FIFO/pty distinction) stay on the runner
+Context and the platform module; this provider decides which transport the
+scenario's capabilities call for, when the replay runs, and when to wait for it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if os.name == "posix":
+    import platform_unix as plat
+else:  # pragma: no cover - the runner already refuses a non-posix host
+    raise RuntimeError(f"smoke tests do not yet support os.name={os.name!r}")
+
+if TYPE_CHECKING:
+    from run import Context, ScenarioModule
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class Replay:
+    """Realtime packet-log replay over the FIFO/pty transport."""
+
+    def create(self, ctx: Context, scen: ScenarioModule) -> None:
+        """Select and attach the transport, and record the replay attributes.
+
+        The transport follows from the capabilities the scenario declares, not
+        a named mechanism: CAPTURE_WRITES (a write-path scenario recording what
+        the program sent back) needs a read-write transport; SELF_SHUTDOWN and
+        DISCONNECTABLE both need a transport that can model the device vanishing.
+        They are orthogonal -- serial-loss disconnects without capturing, the
+        stream/pull-* scenarios capture without disconnecting -- and the platform
+        maps them to a concrete transport (FIFO for neither, pty for either) or
+        reports the request unsupported (a SKIP). PACKET_LOG/FACTOR are read
+        here rather than in run.py, so the runner reaches them through the
+        provider like any other source attribute.
+        """
+        capture_writes = bool(getattr(scen, "CAPTURE_WRITES", False))
+        # DISCONNECTABLE requests the pty's disconnect capability without the
+        # self-shutdown lifecycle: satpulsewb's device-loss scenario disconnects
+        # and then asserts the program keeps running (SELF_SHUTDOWN's inverse),
+        # so it needs the pty but not the no-signal exit check.
+        disconnectable = bool(getattr(scen, "SELF_SHUTDOWN", False)) or bool(
+            getattr(scen, "DISCONNECTABLE", False)
+        )
+        packet_log = scen.PACKET_LOG
+        if not os.path.isabs(packet_log):
+            packet_log = os.path.join(REPO, packet_log)
+        ctx.packet_log = packet_log
+        ctx.env["SATPULSE_TEST_PACKET_LOG"] = packet_log
+        ctx.factor = scen.FACTOR
+        # make_transport reads the FIFO path the runner allocated; on a pty it
+        # ignores it and names the slave. Point SATPULSE_TEST_SERIAL at whatever
+        # path the program must open before program.prepare renders it.
+        ctx._transport = plat.make_transport(
+            ctx.env["SATPULSE_TEST_SERIAL"], readwrite=capture_writes, disconnectable=disconnectable
+        )
+        ctx.env["SATPULSE_TEST_SERIAL"] = ctx._transport.path()
+        # Enable capture before attaching so the transport captures from the
+        # first byte; attach takes ownership (a pty starts its drain thread)
+        # before the program starts.
+        if capture_writes:
+            ctx.start_write_capture()
+        ctx._transport.attach()
+
+    def start(self, ctx: Context) -> None:
+        """Launch the single background replay, once the program is observable."""
+        ctx.start_replay()
+
+    def finish(self, ctx: Context) -> None:
+        """Backstop the suite invariant that the replay finished cleanly."""
+        ctx.wait_replay()
+
+    def close(self, ctx: Context) -> None:
+        """Stop the replay and release the transport. Idempotent."""
+        if ctx.replay_proc is not None and ctx.replay_proc.poll() is None:
+            ctx.replay_proc.kill()
+        ctx._close_replay_files()
+        if ctx._transport is not None:
+            ctx._transport.close()

--- a/smoketest/provider_ubxsim.py
+++ b/smoketest/provider_ubxsim.py
@@ -1,0 +1,125 @@
+"""The u-blox simulator packet provider (see provider_api).
+
+`satpulsetool ubxsim` hosts the u-blox receiver simulator (gps/app/ubxsim)
+behind a pty: it answers UBX config and probe messages and emits nav messages
+by replaying a bank, gated by its own MSGOUT configuration. That makes it the
+one provider that can drive the config path -- probe identification, ReadConfig,
+ApplyConfig, and the daemon's startup config phase -- which a read-only replay
+cannot reach because gpscfg skips probing on a port nothing answers.
+
+Lifecycle rationale: the simulator starts before the program (the pty must
+exist when the program opens the device) and is SIGTERMed only after the
+program has shut down. The simulator holds its own slave fd open, so program
+restarts never EOF it; killing it early would instead inject read errors into
+the program's shutdown. It is a test double, not a program under test, so its
+stdout+stderr go to ubxsim.log in the run dir and are not error-scanned.
+
+Capabilities: the simulator consumes and answers the program's writes, so write
+capture is meaningless, and device-loss modelling stays with the replay provider
+(a CFG-RST pty drop is a listed simulator extension, not this phase). The
+provider therefore rejects CAPTURE_WRITES, SELF_SHUTDOWN and DISCONNECTABLE as
+scenario errors. `satpulsetool ubxsim` builds on Linux and macOS only, so
+elsewhere the provider reports the scenario unsupported -- the same SKIP as an
+unsupported transport.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import IO, TYPE_CHECKING
+
+from platform_api import TransportUnsupported
+
+if TYPE_CHECKING:
+    from run import Context, ScenarioModule
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The simulator builds behind //go:build linux || darwin, so only these hosts
+# can run it; anywhere else the scenario is unsupported (a SKIP), mirroring a
+# transport the platform cannot supply.
+_SUPPORTED = ("linux", "darwin")
+
+
+class Ubxsim:
+    """A pty-hosted u-blox receiver simulator as the packet source."""
+
+    def __init__(self) -> None:
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._log_file: IO[bytes] | None = None
+
+    def create(self, ctx: Context, scen: ScenarioModule) -> None:
+        """Spawn the simulator and point SATPULSE_TEST_SERIAL at its pty symlink.
+
+        The symlink is the endpoint -- the /dev/serial/by-id shape gpsio already
+        opens -- and its appearance is readiness: ubxsim creates it before it
+        prints the slave path. The nav bank (SIM_REPLAY) is optional; without it
+        the simulator is silent, like a receiver with no antenna, but the config
+        scenarios always want nav content the startup config can enable.
+        """
+        for cap in ("CAPTURE_WRITES", "SELF_SHUTDOWN", "DISCONNECTABLE"):
+            if getattr(scen, cap, False):
+                raise RuntimeError(f"the ubxsim provider does not support {cap}")
+        if sys.platform not in _SUPPORTED:
+            raise TransportUnsupported(
+                f"satpulsetool ubxsim is not built on {sys.platform!r} (Linux/macOS only)"
+            )
+        personality = getattr(scen, "PERSONALITY", "")
+        if not personality:
+            raise RuntimeError("a ubxsim scenario must declare PERSONALITY")
+        if not os.path.isabs(personality):
+            personality = os.path.join(REPO, personality)
+        bank = getattr(scen, "SIM_REPLAY", "")
+        if bank and not os.path.isabs(bank):
+            bank = os.path.join(REPO, bank)
+        # ctx.factor defaults to 1 for simulator scenarios (the NAV engine
+        # consumes one epoch per second in real time; correction-source pacing
+        # is factor's only other consumer). Record the bank as the packet log so
+        # the SmokeContext still names a source, though nothing replays it here.
+        ctx.factor = 1
+        ctx.packet_log = bank
+
+        link = os.path.join(ctx.run_dir, "gps.pty")
+        cmd = [ctx.satpulsetool, "ubxsim", "--link", link]
+        if bank:
+            cmd += ["-r", bank]
+        cmd.append(personality)
+        self._log_file = open(os.path.join(ctx.run_dir, "ubxsim.log"), "wb")
+        self._proc = subprocess.Popen(cmd, stdout=self._log_file, stderr=subprocess.STDOUT)
+        self._wait_link(link)
+        ctx.env["SATPULSE_TEST_SERIAL"] = link
+
+    def _wait_link(self, link: str, timeout: float = 10) -> None:
+        deadline = time.time() + timeout
+        while not os.path.exists(link):
+            if self._proc is not None and self._proc.poll() is not None:
+                raise RuntimeError(
+                    f"ubxsim exited before creating {link} (code {self._proc.returncode}); "
+                    "see ubxsim.log"
+                )
+            if time.time() >= deadline:
+                raise RuntimeError(f"ubxsim did not create {link} within {timeout:g}s")
+            time.sleep(0.02)
+
+    def start(self, ctx: Context) -> None:
+        """No-op: the simulator generates nav itself, with no separate replay."""
+
+    def finish(self, ctx: Context) -> None:
+        """No-op: there is no replay to wait for."""
+
+    def close(self, ctx: Context) -> None:
+        """SIGTERM the simulator, after the program has already shut down."""
+        if self._proc is not None and self._proc.poll() is None:
+            self._proc.send_signal(signal.SIGTERM)
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        self._proc = None
+        if self._log_file is not None:
+            self._log_file.close()
+            self._log_file = None

--- a/smoketest/run.py
+++ b/smoketest/run.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
-"""Daemon smoke test runner (direct environment).
+"""Smoke test runner (direct environment).
 
-Runs real satpulsed binaries fed by realtime packet-log replay through a
-FIFO, with no root and no GPS hardware. See plan/smoke-test.md.
+Runs real satpulsed and satpulsewb binaries fed by a hardware-free packet
+source -- a realtime packet-log replay or the u-blox receiver simulator --
+with no root and no GPS hardware. See plan/smoke-test.md.
 
 Each scenario has an explicit ID in SCENARIOS. For scenario ID family/name:
-  - scenarios/family/name.toml.in : config template using ${SATPULSE_TEST_*}
-  - scenarios/family/name.py      : defines PACKET_LOG, FACTOR, and run(ctx)
+  - scenarios/family/name.toml.in (satpulsed) or name.args.in (satpulsewb):
+    input template using ${SATPULSE_TEST_*}
+  - scenarios/family/name.py      : defines run(ctx) plus the program and
+    packet provider the scenario declares (PROGRAM, PROVIDER and the
+    provider's attributes; see CLAUDE.md)
 
 The runner allocates a resource block (ports, paths) per scenario, renders
-the config, starts the daemon, replays the packet log into the FIFO, then
-calls the scenario's run(ctx) to perform its checks. Scenarios are
-parallel-safe and run concurrently by default.
+the program's input, starts the program and its packet source, then calls
+the scenario's run(ctx) to perform its checks. Scenarios are parallel-safe
+and run concurrently by default.
 """
 
 from __future__ import annotations
@@ -40,6 +44,7 @@ REPO = os.path.dirname(HERE)
 import common  # noqa: E402  (after sys.path is set up)
 import platform_api  # noqa: E402
 import program_api  # noqa: E402
+import provider_api  # noqa: E402
 
 # Platform seam: the per-OS module supplies the transport, shutdown, and
 # privilege primitives (see platform_api). Select it by os.name so run.py
@@ -61,6 +66,8 @@ SCENARIOS = [
     "http/wb-default",
     "http/wb-listen",
     "http/wb-survey",
+    "config/startup",
+    "config/wb-apply",
     "ntrip/basic",
     "ntrip/auth",
     "ntrip/anyuser",
@@ -205,22 +212,22 @@ class Context:
         name: str,
         run_dir: str,
         env: dict[str, str],
-        factor: int | float,
-        packet_log: str,
         daemon_log: str,
         requires_root: bool,
         use_sudo: bool,
-        transport: platform_api.Transport,
     ) -> None:
         self.name = name
         self.run_dir = run_dir
         self.env = env
-        # Serial input transport, chosen by the capabilities the scenario needs
-        # (see run_scenario): a plain replay sink, or one that is read-write
-        # (start_write_capture) and/or disconnectable (disconnect).
-        self._transport = transport
-        self.factor = factor
-        self.packet_log = packet_log
+        # Serial input transport, set by the replay provider's create hook
+        # (None under ubxsim, which serves its own pty): a plain replay sink,
+        # or one that is read-write (start_write_capture) and/or
+        # disconnectable (disconnect). factor and packet_log are provider
+        # attributes recorded here by the same hook (factor also paces
+        # correction sources; both keep their defaults under ubxsim).
+        self._transport: platform_api.Transport | None = None
+        self.factor: int | float = 1
+        self.packet_log = ""
         self.daemon_log = daemon_log
         # Which listeners/peers the program needs, set by program.prepare (from
         # the daemon's rendered config, or left at the defaults for satpulsewb,
@@ -772,6 +779,7 @@ class Context:
         The transport decides where pack's output goes (a FIFO write fd, a dup
         of the pty master).
         """
+        assert self._transport is not None, "start_replay needs the replay provider's transport"
         cmd = [self.satpulsetool, "pack", "--realtime", str(self.factor), self.packet_log]
         errf = open(self.replay_err, "wb")
         self._replay_err_file = errf
@@ -798,7 +806,8 @@ class Context:
             raise RuntimeError(f"replay (pack) exited with code {rc}: {self._replay_stderr()}")
 
     def _close_replay_files(self) -> None:
-        self._transport.close_replay()
+        if self._transport is not None:
+            self._transport.close_replay()
         if self._replay_err_file is not None:
             self._replay_err_file.close()
             self._replay_err_file = None
@@ -818,6 +827,7 @@ class Context:
         RTCM corrections the daemon wrote back to the receiver; the non-RTCM
         probe bytes the daemon emits during detection are filtered out by tag.
         """
+        assert self._transport is not None, "start_write_capture needs the replay provider's transport"
         self._transport.enable_write_capture(self.serial_writes)
 
     def disconnect(self) -> None:
@@ -828,6 +838,7 @@ class Context:
         vanished USB serial device. After this the daemon should shut down on
         its own; assert that with wait_exit().
         """
+        assert self._transport is not None, "disconnect needs the replay provider's transport"
         self._transport.disconnect()
 
     def wait_exit(self, timeout: float = 10) -> int:
@@ -899,29 +910,19 @@ def run_scenario(name: str, use_sudo: bool) -> tuple[str, Status, str]:
     # Program owns what differs between the two (input prep, start command,
     # readiness, allowed log lines, ports to free). See program_api.
     program = program_api.select(getattr(scen, "PROGRAM", "satpulsed"))
-    factor = scen.FACTOR
-    packet_log = scen.PACKET_LOG
-    if not os.path.isabs(packet_log):
-        packet_log = os.path.join(REPO, packet_log)
-
-    # Serial-input transport capabilities the scenario needs, computed from what
-    # it does, not from a named mechanism. CAPTURE_WRITES (a write-path scenario
-    # recording what the program sent back) needs a read-write transport;
-    # SELF_SHUTDOWN and DISCONNECTABLE both need a transport that can model the
-    # device vanishing. They are orthogonal to capture: serial-loss disconnects
-    # without capturing, the stream/pull-* scenarios capture without
-    # disconnecting. The platform maps them to a concrete transport (below).
-    capture_writes = bool(getattr(scen, "CAPTURE_WRITES", False))
+    # The packet provider is an orthogonal scenario dimension (default replay):
+    # it owns what plays the receiver behind SATPULSE_TEST_SERIAL and how the
+    # feed is driven (transport selection and the pack replay for replay; the
+    # u-blox simulator for ubxsim). See provider_api.
+    provider = provider_api.select(getattr(scen, "PROVIDER", "replay"))
+    # SELF_SHUTDOWN is a lifecycle property (does the program exit when its input
+    # goes away?) the runner asserts after run(); the provider reads it (and the
+    # other capabilities) independently to pick a disconnectable transport.
     self_shutdown = bool(getattr(scen, "SELF_SHUTDOWN", False))
-    # DISCONNECTABLE requests a transport that can be unplugged without the
-    # self-shutdown lifecycle: satpulsewb's device-loss scenario disconnects and
-    # then asserts the program keeps running (SELF_SHUTDOWN's inverse), so it
-    # needs the pty but not the no-signal exit check.
-    disconnectable = self_shutdown or bool(getattr(scen, "DISCONNECTABLE", False))
     # INPUT (the old transport selector) is obsolete: transport is now chosen
-    # from the capabilities above. Reject it loudly so a scenario merged from a
-    # branch predating this change fails here rather than silently running over
-    # the FIFO instead of the pty it asked for.
+    # from the scenario's capabilities by the replay provider. Reject it loudly
+    # so a scenario merged from a branch predating this change fails here rather
+    # than silently running over the FIFO instead of the pty it asked for.
     if hasattr(scen, "INPUT"):
         return (name, "FAIL", "INPUT is obsolete; declare CAPTURE_WRITES and/or SELF_SHUTDOWN instead")
     # A scenario known to fail (e.g. a bug not yet fixed) declares XFAIL = reason.
@@ -929,45 +930,35 @@ def run_scenario(name: str, use_sudo: bool) -> tuple[str, Status, str]:
 
     run_dir = tempfile.mkdtemp(prefix=f"satpulse-smoke-{name.replace('/', '-')}-")
     env = allocate_env(name, run_dir)
-    env["SATPULSE_TEST_PACKET_LOG"] = packet_log
-    daemon_env = os.environ.copy()
-    scenario_env = cast(dict[str, str], getattr(scen, "ENV", {}))
-    for key, value in scenario_env.items():
-        daemon_env[key] = program_api.substitute(value, env)
     os.makedirs(env["SATPULSE_TEST_LOG_DIR"], exist_ok=True)
-    # Create the serial-input transport with the requested capabilities and
-    # point the program's device path at it (the FIFO path the runner allocated,
-    # or the pty slave name) before preparing the input that references
-    # SATPULSE_TEST_SERIAL. A platform that cannot supply those capabilities
-    # reports the scenario unsupported here, which is a SKIP.
-    try:
-        transport = plat.make_transport(
-            env["SATPULSE_TEST_SERIAL"], readwrite=capture_writes, disconnectable=disconnectable)
-    except platform_api.TransportUnsupported as e:
-        shutil.rmtree(run_dir, ignore_errors=True)
-        return (name, "SKIP", str(e))
-    env["SATPULSE_TEST_SERIAL"] = transport.path()
 
     daemon_log = os.path.join(run_dir, f"{program.name}.log")
-    ctx = Context(
-        name, run_dir, env, factor, packet_log, daemon_log,
-        requires_root, use_sudo, transport=transport,
-    )
+    ctx = Context(name, run_dir, env, daemon_log, requires_root, use_sudo)
     ctx.prog_bin = bin_path(program.name)
-    # Prepare the program's input (render the config or the flag list) and
-    # record which listeners/peers it needs on ctx.
-    program.prepare(ctx, scen)
-    # Enable capture before attaching so the transport captures from the first
-    # byte; attach takes ownership (a pty starts its drain thread) before the
-    # program starts.
-    if capture_writes:
-        ctx.start_write_capture()
-    transport.attach()
 
     daemon: subprocess.Popen[bytes] | None = None
     status: Status = "PASS"
     detail = ""
     try:
+        # Set up the packet source and point SATPULSE_TEST_SERIAL at its
+        # endpoint (the FIFO/pty for replay, the simulator's symlink for
+        # ubxsim) before the program's input is rendered. Inside the try so
+        # that any later failure still reaches the finally's provider.close:
+        # a half-set-up source (e.g. the spawned simulator) must be released,
+        # not orphaned. A provider that cannot honour the scenario on this
+        # platform reports it unsupported (the SKIP mapping below); a scenario
+        # error (e.g. ubxsim with CAPTURE_WRITES) is an ordinary FAIL, with
+        # the run dir kept like any other failure.
+        provider.create(ctx, scen)
+
+        daemon_env = os.environ.copy()
+        scenario_env = cast(dict[str, str], getattr(scen, "ENV", {}))
+        for key, value in scenario_env.items():
+            daemon_env[key] = program_api.substitute(value, env)
+        # Prepare the program's input (render the config or the flag list) and
+        # record which listeners/peers it needs on ctx.
+        program.prepare(ctx, scen)
+
         # Start the fake peers the program needs, each before the program
         # starts so its first sample/connect lands rather than warning and
         # backing off (config-derived for satpulsed, scenario-declared for
@@ -994,17 +985,19 @@ def run_scenario(name: str, use_sudo: bool) -> tuple[str, Status, str]:
             raise RuntimeError(f"{program.name} exited at startup (code {daemon.returncode})")
         program.wait_ready(ctx)
 
-        # A single replay then runs in the background while checks observe
-        # the live program.
-        ctx.start_replay()
+        # The provider then begins feeding packets while checks observe the
+        # live program: the replay provider launches its single background
+        # replay; ubxsim is already emitting nav.
+        provider.start(ctx)
 
         scen.run(ctx)
 
-        # Backstop the suite invariant that the replay finished cleanly,
-        # even if the scenario did not call wait_replay itself. Idempotent
-        # when the scenario already waited. Done before shutdown so pack
-        # finishes against a live daemon rather than dying of SIGPIPE.
-        ctx.wait_replay()
+        # Backstop the provider's feed: the replay provider waits for the
+        # replay to finish cleanly, even if the scenario did not call
+        # wait_replay itself (idempotent when it did), before shutdown so pack
+        # finishes against a live daemon rather than dying of SIGPIPE; ubxsim
+        # has nothing to wait for.
+        provider.finish(ctx)
 
         if self_shutdown:
             # No signal: losing the serial input must be enough to make the
@@ -1048,13 +1041,14 @@ def run_scenario(name: str, use_sudo: bool) -> tuple[str, Status, str]:
             err = ctx.remove_ntp_shm()
             if err is not None:
                 raise RuntimeError(f"failed to remove NTP SHM segment {ctx.ntp_shm_segment}: {err}")
+    except platform_api.TransportUnsupported as e:
+        # The platform cannot supply the requested packet source: the same
+        # clean SKIP as a missing external dependency (the run dir is removed
+        # below, since only FAIL/XPASS keep it).
+        status, detail = "SKIP", str(e)
     except Exception:
         status, detail = "FAIL", traceback.format_exc()
     finally:
-        if ctx.replay_proc is not None and ctx.replay_proc.poll() is None:
-            ctx.replay_proc.kill()
-        ctx._close_replay_files()
-        ctx._transport.close()
         if daemon is not None and daemon.poll() is None:
             plat.stop_daemon(
                 daemon,
@@ -1065,6 +1059,11 @@ def run_scenario(name: str, use_sudo: bool) -> tuple[str, Status, str]:
         ctx.stop_ntp_sock()
         ctx.stop_push_peers()
         ctx.stop_source()
+        # Release the packet source last, after the program has stopped: the
+        # replay provider closes the transport, and the ubxsim provider SIGTERMs
+        # the simulator only now, so an early kill cannot inject read errors
+        # into the program's shutdown.
+        provider.close(ctx)
         if requires_root:
             err = ctx.remove_ntp_shm()
             if err is not None:

--- a/smoketest/scenarios/config/__init__.py
+++ b/smoketest/scenarios/config/__init__.py
@@ -1,0 +1,147 @@
+"""Checks for the config family: the startup and interactive config paths.
+
+Both scenarios run against the u-blox simulator (PROVIDER ubxsim), the one
+packet source that answers probes and config, so these checks assert on the
+config wiring a read-only replay cannot reach: the receiver identity the program
+reports (active detection carried the personality's MON-VER model and firmware)
+and message enablement landing as live satellite data. The personality's Default
+layer leaves NAV-SAT off, so satellite data appearing can only mean a VALSET
+enabled it.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from typing import Callable, cast
+
+import common
+
+# The identity the simulator's MON-VER carries
+# (gps/app/ubxsim/testdata/f9p/f9p-personality.ubx, a real ZED-F9P recording).
+SIM_VENDOR = "u-blox"
+SIM_MODEL = "ZED-F9P"
+SIM_FIRMWARE = "HPG 1.51"
+
+
+def read_sse(
+    url: str, done: Callable[[dict[str, list[str]]], bool], read_seconds: float = 15.0
+) -> dict[str, list[str]]:
+    """Read an SSE stream into {event-name: [data-line, ...]} until done or timeout.
+
+    A background reader accumulates each event's data payloads; the caller's
+    done() predicate inspects the accumulator and stops the read as soon as its
+    condition holds, else the read ends at read_seconds. Both config checks watch
+    a live stream the simulator keeps feeding, so this replaces common.collect_sse
+    (which returns only event names) where the data payload is what matters.
+    """
+    got: dict[str, list[str]] = {}
+    try:
+        resp = urllib.request.urlopen(url, timeout=read_seconds + 2)
+    except OSError as e:
+        raise AssertionError(f"could not open SSE stream {url}: {e}")
+    name = ""
+
+    def reader() -> None:
+        nonlocal name
+        try:
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").rstrip("\n")
+                if line.startswith("event: "):
+                    name = line[len("event: ") :]
+                elif line.startswith("data: ") and name:
+                    got.setdefault(name, []).append(line[len("data: ") :])
+        except Exception:
+            pass
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+    deadline = time.time() + read_seconds
+    while time.time() < deadline and not done(got):
+        time.sleep(0.1)
+    resp.close()
+    t.join(timeout=2)
+    return got
+
+
+def _assert_identity(rcv: dict[str, object], where: str) -> None:
+    assert rcv.get("vendor") == SIM_VENDOR, f"{where}: vendor {rcv.get('vendor')!r} != {SIM_VENDOR!r}"
+    assert rcv.get("hardware") == SIM_MODEL, f"{where}: hardware {rcv.get('hardware')!r} != {SIM_MODEL!r}"
+    fw = cast(str, rcv.get("firmware") or "")
+    assert SIM_FIRMWARE in fw, f"{where}: firmware {fw!r} does not contain {SIM_FIRMWARE!r}"
+
+
+def check_daemon_startup_config(ctx: common.SmokeContext) -> None:
+    """Active detection identified the simulator, and the startup config landed.
+
+    Reads the daemon's SSE while the simulator emits. The sticky `init` event
+    (written to every new client) carries the receiver identity active detection
+    learned: a read-only port would probe nothing and leave it empty, so a
+    populated identity proves the probe ran and matched the simulated ZED-F9P.
+    The live `satellites` event proves the daemon's startup VALSET enabled
+    NAV-SAT, which the personality defaults leave off -- so the satellite data
+    can only be the startup ConfigTarget landing on the receiver.
+    """
+
+    def seen(g: dict[str, list[str]]) -> bool:
+        return bool(g.get("init")) and bool(g.get("satellites"))
+
+    got = read_sse(ctx.http_url("/sse"), seen, read_seconds=20.0)
+    inits = got.get("init", [])
+    assert inits, "no SSE init event: active detection did not identify the receiver"
+    rcv = None
+    for d in inits:
+        r = json.loads(d).get("receiver")
+        if r:
+            rcv = r
+            break
+    assert rcv, f"init event carried no receiver identity: {inits[:2]}"
+    _assert_identity(rcv, "daemon init event")
+    assert got.get("satellites"), (
+        "no satellites SSE event: the startup config did not enable NAV-SAT "
+        "(off in the personality defaults, so its absence means the VALSET did not land)"
+    )
+
+
+def check_wb_receiver_identity(ctx: common.SmokeContext, timeout: float = 15.0) -> None:
+    """Poll /api/receiver until it identifies the simulated ZED-F9P.
+
+    The interactive connect probes the pty and the simulator answers, so the
+    session runs active detection and populates Info -- the first black-box
+    exercise of an interactive connect whose probe is answered.
+    """
+
+    def attempt() -> dict[str, object] | None:
+        st, b = common.wb_get(ctx, "/api/receiver")
+        if st != 200:
+            return None
+        r = cast("dict[str, object]", json.loads(b))
+        if not r.get("ok"):
+            return None
+        info = r.get("Info")
+        return cast("dict[str, object]", info) if isinstance(info, dict) else None
+
+    info = common.poll(attempt, timeout=timeout)
+    assert info, "/api/receiver never identified a receiver"
+    _assert_identity(info, "wb /api/receiver Info")
+
+
+def check_wb_sats_live(ctx: common.SmokeContext, read_seconds: float = 15.0) -> None:
+    """A live gps:msg of kind satellites appears once ApplyConfig enables it.
+
+    The personality leaves NAV-SAT off, so the session can only surface
+    satellites after the apply's Opts.SatsMsg VALSET enables them on the
+    simulator; a live gps:msg kind=satellites on the workbench SSE stream is
+    that enablement showing up as data.
+    """
+    marker = '"kind":"satellites"'
+
+    def done(g: dict[str, list[str]]) -> bool:
+        return any(marker in d for d in g.get("gps:msg", []))
+
+    got = read_sse(ctx.wb_url("/sse"), done, read_seconds=read_seconds)
+    assert any(marker in d for d in got.get("gps:msg", [])), (
+        f"no live gps:msg kind=satellites after enabling Opts.SatsMsg; saw {got.get('gps:msg', [])[:3]}"
+    )

--- a/smoketest/scenarios/config/startup.py
+++ b/smoketest/scenarios/config/startup.py
@@ -1,0 +1,26 @@
+"""satpulsed x u-blox simulator: the startup config path.
+
+The daemon runs its startup config phase against the simulator over a pty -- the
+write path a read-only FIFO replay cannot provide, so gpscfg actually probes and
+configures. Asserts that detection was active (the receiver identity carries the
+simulated ZED-F9P's MON-VER model and firmware), that the startup ConfigTarget
+landed (NAV-SAT, off in the personality defaults, becomes live satellite data on
+the daemon's SSE surface), and -- via the runner's shared shutdown/log-scan path
+-- that configuration completed without errors and shutdown is graceful.
+
+No FACTOR/PACKET_LOG: the simulator generates nav itself from SIM_REPLAY, one
+epoch per second, so the bank need only outlast the run's checks (this F9P log
+holds ~31 NAV-SAT epochs).
+"""
+
+import common
+from scenarios import config
+
+PROGRAM = "satpulsed"
+PROVIDER = "ubxsim"
+PERSONALITY = "gps/app/ubxsim/testdata/f9p/f9p-personality.ubx"
+SIM_REPLAY = "gps/testdata/packets/u-blox/ZED-F9P/daemon-sats-pos-38400.jsonl"
+
+
+def run(ctx: common.SmokeContext) -> None:
+    config.check_daemon_startup_config(ctx)

--- a/smoketest/scenarios/config/startup.toml.in
+++ b/smoketest/scenarios/config/startup.toml.in
@@ -1,0 +1,14 @@
+# satpulsed startup config against the u-blox simulator: active detection over
+# the pty, plus the satellites-output ConfigTarget landing on the receiver. The
+# speed is the personality's default CFG-UART1-BAUDRATE (38400), so the config
+# phase stays out of the baud-change path; speed is nominal on a pty anyway.
+[serial]
+device = "${SATPULSE_TEST_SERIAL}"
+speed = 38400
+
+[gps]
+config = true
+satellitesOutput = true
+
+[[http]]
+listen = "127.0.0.1:${SATPULSE_TEST_HTTP_PORT}"

--- a/smoketest/scenarios/config/wb-apply.args.in
+++ b/smoketest/scenarios/config/wb-apply.args.in
@@ -1,0 +1,7 @@
+# satpulsewb over an explicit -L bind with the token enabled, and no -d: the
+# scenario drives the interactive connect + config path itself against the
+# u-blox simulator (the one packet source whose probe answers), so ReadConfig
+# and ApplyConfig get black-box coverage a read-only replay cannot give.
+-L
+127.0.0.1:${SATPULSE_TEST_HTTP_PORT}
+-T

--- a/smoketest/scenarios/config/wb-apply.py
+++ b/smoketest/scenarios/config/wb-apply.py
@@ -1,0 +1,64 @@
+"""satpulsewb x u-blox simulator: the interactive config path, UI-shaped.
+
+Starts the workbench without -d and drives the config path the way the browser
+does: claim the write seat, connect to the simulator's pty (the first black-box
+exercise of an interactive connect whose probe answers), wait for /api/receiver
+to identify the simulated ZED-F9P, read the config, apply a small ConfigTarget
+that both sets a round-trippable property (the antenna cable delay) and enables
+the satellites messages (Opts.SatsMsg), then confirm a second read shows the new
+delay and the enabled messages arrive as live satellite data.
+
+No FACTOR/PACKET_LOG: the simulator generates nav itself from SIM_REPLAY.
+"""
+
+import json
+
+import common
+from scenarios import config
+
+PROGRAM = "satpulsewb"
+PROVIDER = "ubxsim"
+PERSONALITY = "gps/app/ubxsim/testdata/f9p/f9p-personality.ubx"
+SIM_REPLAY = "gps/testdata/packets/u-blox/ZED-F9P/daemon-sats-pos-38400.jsonl"
+
+# A round-trippable property the simulator's config database stores and returns
+# verbatim. Nanoseconds on the wire (ConfigProps marshals antennaCableDelay as
+# an integer nanosecond count).
+CABLE_DELAY_NS = 12000
+# Opts.SatsMsg wire value: satellite positions (NAV-SAT) plus signals (NAV-SIG),
+# the same numeric flag the config panel sends (SatsMsgSat | SatsMsgSignal).
+SATS_MSG = 3
+
+
+def run(ctx: common.SmokeContext) -> None:
+    seat = common.wb_claim(ctx)  # connect and config are writer POSTs
+
+    status, body = common.wb_post(
+        ctx, f"/api/connect?seat={seat}", {"device": ctx.serial, "speed": 38400}
+    )
+    assert status == 200, f"connect failed: {status} {body!r}"
+
+    config.check_wb_receiver_identity(ctx)
+
+    status, body = common.wb_post(ctx, f"/api/config/read?seat={seat}", {})
+    assert status == 200, f"config/read expected 200, got {status}: {body!r}"
+    props = json.loads(body)
+    assert props, f"config/read returned empty props: {body!r}"
+
+    status, body = common.wb_post(
+        ctx,
+        f"/api/config/apply?seat={seat}",
+        {"Props": {"antennaCableDelay": CABLE_DELAY_NS}, "Opts": {"SatsMsg": SATS_MSG}},
+    )
+    assert status == 200, f"config/apply expected 200, got {status}: {body!r}"
+
+    # The property round-trips: a second read reflects the applied delay.
+    status, body = common.wb_post(ctx, f"/api/config/read?seat={seat}", {})
+    assert status == 200, f"config/read (2) expected 200, got {status}: {body!r}"
+    props2 = json.loads(body)
+    assert props2.get("antennaCableDelay") == CABLE_DELAY_NS, (
+        f"antennaCableDelay did not round-trip: sent {CABLE_DELAY_NS}, read {props2.get('antennaCableDelay')!r}"
+    )
+
+    # The enabled messages show up as live data.
+    config.check_wb_sats_live(ctx)


### PR DESCRIPTION
Phase 9 of the satpulseweb plan (#357), smoketest half: replay can drive only the monitor path, because gpscfg skips probing on a read-only port and a pty replay's probe goes unanswered, so probe identification, ReadConfig, ApplyConfig, and the daemon's startup config phase had no black-box coverage until something answers.

What plays the receiver becomes a second scenario dimension, orthogonal to the program under test: a packet-provider seam (provider_api.py, the provider counterpart to the phase-5 program seam) with a replay provider (the previous inline behaviour: transport selection, the single pack replay, PACKET_LOG/FACTOR) and a ubxsim provider hosting satpulsetool ubxsim behind a pty symlink. The dimensions compose: satpulsed x simulator reaches the daemon's startup config phase, which no replay can.

Two scenarios in a new config family, both against the checked-in F9P personality: config/startup asserts active detection carries the personality's MON-VER identity and that satellite data appearing (NAV-SAT is off in the personality defaults) proves the startup VALSET landed; config/wb-apply drives the workbench's interactive path end to end (seat claim, connect, receiver identity, config read, an apply that round-trips the antenna cable delay and enables the satellites messages, re-read, live satellite data).

Depends on the simulator's CFG-PRT and empty-group-wildcard fixes (ecbe785f, 6cade4fc), already merged to master.

Review commit by commit: the first commit is the plan spec, the second the implementation. All 26 pre-existing scenarios are unchanged; full suite 28 passed / 1 root-skip, mypy strict clean.

See plan/satpulseweb.md (phase 9).