### PR TITLE
Run the FreeBSD build and tests in a VM

### DIFF
--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -1,6 +1,7 @@
-# This workflow cross-compiles satpulse for FreeBSD on an Ubuntu runner.
-# GitHub does not offer a FreeBSD runner, so this only catches build breaks,
-# not test failures. For more information see:
+# This workflow builds and tests satpulse on FreeBSD. GitHub offers no
+# FreeBSD runner, so the job boots a FreeBSD VM on an Ubuntu runner with
+# vmactions/freebsd-vm and runs the native build and test suite there.
+# For more information see:
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Build (FreeBSD)
@@ -15,17 +16,17 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      GOOS: freebsd
-      GOARCH: amd64
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
+    - name: Build and test on FreeBSD
+      uses: vmactions/freebsd-vm@v1
       with:
-        go-version: '1.25.x'
-
-    - name: Build commands
-      run: ./unix-build.sh
+        usesh: true
+        prepare: |
+          pkg install -y go git
+        run: |
+          git config --global --add safe.directory '*'
+          ./unix-build.sh
+          go test ./...


### PR DESCRIPTION
GitHub offers no FreeBSD runner, so the `build-freebsd` workflow only cross-compiled the command binaries on an Ubuntu runner: it caught build breaks but never ran the test suite, so FreeBSD-specific test failures went unnoticed.

This boots a FreeBSD VM on the Ubuntu runner with `vmactions/freebsd-vm` and runs `./unix-build.sh` and `go test ./...` natively (FreeBSD/amd64). `git` and `go` are installed in the VM, and the synced workspace is marked a safe git directory so `unix-build.sh` can stamp the version.

Opened to let CI exercise the VM workflow before merging.