### PR TITLE
Run the webui npm suites in CI

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,33 @@
+# This workflow runs the webui typecheck and vitest suites.
+
+name: Node tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  node-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: webui/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci --prefix webui
+
+    - name: Typecheck
+      run: npm run typecheck --prefix webui
+
+    - name: Test
+      run: npm test --prefix webui


### PR DESCRIPTION
No CI workflow runs npm today, so the webui vitest suites and the typecheck never run in CI.

Add .github/workflows/node-tests.yml: npm ci in webui with the npm cache keyed on webui/package-lock.json, npm run typecheck, and npm test across the workspaces, on push and pull request to master like the other workflows. Future packages join automatically via --workspaces --if-present.

Groundwork for the Playwright browser tests (#376); see plan/playwright.md, Prerequisites.