### PR TITLE
Simulate CFG-RST resets in ubxsim

### DIFF
--- a/gps/app/ubxsim/cfgdb.go
+++ b/gps/app/ubxsim/cfgdb.go
@@ -182,11 +182,31 @@ func (db *cfgDB) cfgcfg(m *ubxbin.CfgCfg) bool {
 		}
 	}
 	if m.LoadMask != 0 {
-		db.ram = maps.Clone(db.dflt)
-		maps.Copy(db.ram, db.flh)
-		maps.Copy(db.ram, db.bbr)
+		db.rebuildRAM()
 	}
 	return true
+}
+
+// reboot rebuilds the RAM layer from the layers below, the way a real
+// receiver reconstructs its active configuration coming out of a reset:
+// "The RAM layer is always rebuilt from the layers below when the chip's
+// processor comes out from reset" (F9 interface description 6.7). The
+// BBR and Flash configuration layers are left as they are; the
+// navBbrMask of CFG-RST clears navigation backup data (ephemeris,
+// almanac, position, ...), not the BBR configuration layer.
+func (db *cfgDB) reboot() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.rebuildRAM()
+}
+
+// rebuildRAM discards the current RAM configuration and rebuilds it from
+// Default, then Flash, then BBR on top, per layer priority. The caller
+// holds db.mu.
+func (db *cfgDB) rebuildRAM() {
+	db.ram = maps.Clone(db.dflt)
+	maps.Copy(db.ram, db.flh)
+	maps.Copy(db.ram, db.bbr)
 }
 
 // layerMap returns the map for a CFG-VALGET layer field, or nil if the

--- a/gps/app/ubxsim/cfgdb_test.go
+++ b/gps/app/ubxsim/cfgdb_test.go
@@ -301,6 +301,30 @@ func TestTooManyItems(t *testing.T) {
 	}
 }
 
+func TestReboot(t *testing.T) {
+	navSat := ucv.KUbxNavSat.KeyU(ucv.UART1).Key()
+	db := newCfgDB(testDefaults())
+	// An unsaved RAM change is discarded by a reboot.
+	db.valset(valsetMsg(ubxbin.CfgValsetLayerRAM, ucv.Item{Key: navSat, Value: 1}))
+	db.reboot()
+	if v := db.ramUint(navSat); v != 0 {
+		t.Fatalf("after reboot got %d, want default 0", v)
+	}
+	// The rebuild takes BBR over Flash over Default, and does not touch
+	// the saved layers.
+	db.valset(valsetMsg(ubxbin.CfgValsetLayerFlash, ucv.Item{Key: navSat, Value: 3}))
+	db.valset(valsetMsg(ubxbin.CfgValsetLayerBBR, ucv.Item{Key: navSat, Value: 2}))
+	db.reboot()
+	if v := db.ramUint(navSat); v != 2 {
+		t.Fatalf("after reboot got %d, want BBR value 2", v)
+	}
+	resp, _ := db.valget(valgetPoll(ubxbin.CfgValgetLayerFlash, 0, navSat))
+	items, _ := ucv.UnmarshalItems(resp.CfgData)
+	if !reflect.DeepEqual(items, []ucv.Item{{Key: navSat, Value: 3}}) {
+		t.Errorf("reboot changed the Flash layer: %+v", items)
+	}
+}
+
 func TestCfgCfg(t *testing.T) {
 	navSat := ucv.KUbxNavSat.KeyU(ucv.UART1).Key()
 	db := newCfgDB(testDefaults())

--- a/gps/app/ubxsim/nav.go
+++ b/gps/app/ubxsim/nav.go
@@ -56,13 +56,18 @@ func (n *navEngine) restart() {
 // the bank) and false when the context is cancelled, the writer fails,
 // or the bank runs out with no reboot pending.
 func (n *navEngine) replay(ctx context.Context) bool {
+	// The whole run is stamped with the generation live at its start, so
+	// when a reboot interrupts an epoch mid-burst the rest of that burst is
+	// dropped by the writer with the queue, instead of being stamped
+	// current and preceding the restarted epoch 0.
+	gen := n.w.generation()
 	next := time.Now()
 	for i := 0; i < len(n.epochs); i++ {
 		for _, pkt := range n.epochs[i] {
 			if !n.enabled(pkt) {
 				continue
 			}
-			if err := n.w.send(ctx, pkt.Data); err != nil {
+			if err := n.w.sendGen(ctx, gen, pkt.Data); err != nil {
 				return false
 			}
 		}

--- a/gps/app/ubxsim/nav.go
+++ b/gps/app/ubxsim/nav.go
@@ -24,31 +24,72 @@ type navEngine struct {
 	epochs [][]Pkt
 	w      *writer
 	lg     *slog.Logger
+	reboot chan struct{}
 }
 
 func (n *navEngine) run(ctx context.Context) {
 	if len(n.epochs) == 0 {
-		// No message bank: the receiver is silent, as with no antenna.
+		// No message bank: the receiver is silent, as with no antenna. It
+		// still drains reboot signals so restart never blocks.
+		for n.idle(ctx) {
+		}
 		return
 	}
+	for n.replay(ctx) {
+		// replay returned on a reboot: restart the bank from the top.
+	}
+}
+
+// restart signals the replay loop to reboot, restarting the bank from
+// the first epoch. The send is non-blocking, so a reboot arriving while
+// one is already pending collapses into it: a real receiver reboots
+// once, not once per queued request.
+func (n *navEngine) restart() {
+	select {
+	case n.reboot <- struct{}{}:
+	default:
+	}
+}
+
+// replay emits the enabled bank once, epoch by epoch, pacing to the nav
+// rate. It returns true when a reboot interrupts it (the caller restarts
+// the bank) and false when the context is cancelled, the writer fails,
+// or the bank runs out with no reboot pending.
+func (n *navEngine) replay(ctx context.Context) bool {
 	next := time.Now()
-	for i := 0; ; i++ {
-		if i >= len(n.epochs) {
-			n.lg.Warn("nav replay bank exhausted", "epochs", len(n.epochs))
-			return
-		}
+	for i := 0; i < len(n.epochs); i++ {
 		for _, pkt := range n.epochs[i] {
 			if !n.enabled(pkt) {
 				continue
 			}
 			if err := n.w.send(ctx, pkt.Data); err != nil {
-				return
+				return false
 			}
 		}
 		next = next.Add(n.epochPeriod())
-		if !sleepCtx(ctx, time.Until(next)) {
-			return
+		reboot, ok := n.sleep(ctx, time.Until(next))
+		if reboot {
+			return true
 		}
+		if !ok {
+			return false
+		}
+	}
+	n.lg.Warn("nav replay bank exhausted", "epochs", len(n.epochs))
+	// Stay alive rather than exit, so a reboot after exhaustion restarts
+	// the replay and the simulator keeps serving.
+	return n.idle(ctx)
+}
+
+// idle blocks with no output until a reboot signal (returns true) or
+// context cancellation (returns false), modelling a receiver that is
+// alive but emitting nothing.
+func (n *navEngine) idle(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-n.reboot:
+		return true
 	}
 }
 
@@ -75,18 +116,28 @@ func (n *navEngine) epochPeriod() time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
-// sleepCtx sleeps for d and reports true, or reports false if ctx is
-// done first.
-func sleepCtx(ctx context.Context, d time.Duration) bool {
+// sleep waits until the next epoch tick, a reboot, or context
+// cancellation. It reports whether a reboot arrived and, absent one,
+// whether the sleep completed (ok false means the context was
+// cancelled). A pending reboot is taken first so a ready timer never
+// starves it.
+func (n *navEngine) sleep(ctx context.Context, d time.Duration) (reboot, ok bool) {
+	select {
+	case <-n.reboot:
+		return true, false
+	default:
+	}
 	if d <= 0 {
-		return ctx.Err() == nil
+		return false, ctx.Err() == nil
 	}
 	t := time.NewTimer(d)
 	defer t.Stop()
 	select {
 	case <-ctx.Done():
-		return false
+		return false, false
+	case <-n.reboot:
+		return true, false
 	case <-t.C:
-		return true
+		return false, true
 	}
 }

--- a/gps/app/ubxsim/ubxsim.go
+++ b/gps/app/ubxsim/ubxsim.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jclark/satpulse/gps/gpsprot"
@@ -182,6 +183,7 @@ func (s *Sim) handleMsg(ctx context.Context, db *cfgDB, w *writer, nav *navEngin
 			if rst := m.(*ubxbin.CfgRst); rstReboots(rst.ResetMode) {
 				lg.Debug("CFG-RST reboot", "resetMode", rst.ResetMode)
 				db.reboot()
+				w.reboot()
 				nav.restart()
 			}
 		}
@@ -424,22 +426,56 @@ type writer struct {
 	out  io.Writer
 	db   *cfgDB
 	port ucv.Port
-	ch   chan []byte
+	ch   chan outPkt
+	gen  atomic.Uint64
+}
+
+// outPkt is a queued packet tagged with the writer generation live when
+// send accepted it. A simulated reboot bumps the generation, so the
+// writer can drop the packets gated by the pre-reset config instead of
+// emitting them ahead of the restarted epoch-0 stream.
+type outPkt struct {
+	gen  uint64
+	data []byte
 }
 
 func newWriter(out io.Writer, db *cfgDB, port ucv.Port) *writer {
-	return &writer{out: out, db: db, port: port, ch: make(chan []byte, txQueueDepth)}
+	return &writer{out: out, db: db, port: port, ch: make(chan outPkt, txQueueDepth)}
 }
 
 // send enqueues a whole packet for the writer, blocking while the queue
-// is full, and returns ctx.Err() if the simulator is shutting down.
+// is full, and returns ctx.Err() if the simulator is shutting down. The
+// packet carries the generation live at the call, so a packet gated under
+// a config a later reboot discards is dropped rather than emitted.
 func (w *writer) send(ctx context.Context, p []byte) error {
+	pkt := outPkt{gen: w.gen.Load(), data: p}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case w.ch <- p:
+	case w.ch <- pkt:
 		return nil
 	}
+}
+
+// reboot abandons the transmit queue's in-flight output the way a real
+// receiver reset does: it bumps the generation so the writer drops every
+// packet accepted under the pre-reset config, whether already queued or
+// mid-drip, instead of emitting it ahead of the restarted epoch-0 stream.
+// The reader calls this on a rebooting CFG-RST before signalling the nav
+// engine, so the epoch-0 burst is sent under the new generation. Two
+// bounded imprecisions: a mid-drip drop leaves a truncated frame whose
+// declared length absorbs the bytes that follow until the checksum fails
+// and the scanner resyncs (one bad frame per reset), and a nav packet
+// between its gate check and its send at the instant of the reboot is
+// stamped with the new generation and can leak once.
+func (w *writer) reboot() {
+	w.gen.Add(1)
+}
+
+// stale reports whether a packet tagged with gen predates the current
+// generation and so belongs to a config a reboot has discarded.
+func (w *writer) stale(gen uint64) bool {
+	return gen != w.gen.Load()
 }
 
 // run drains the queue until ctx is cancelled or a write fails, pacing a
@@ -460,7 +496,10 @@ func (w *writer) passthrough(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case p := <-w.ch:
-			if _, err := w.out.Write(p); err != nil {
+			if w.stale(p.gen) {
+				continue
+			}
+			if _, err := w.out.Write(p.data); err != nil {
 				return
 			}
 		}
@@ -476,6 +515,7 @@ func (w *writer) passthrough(ctx context.Context) {
 // bytes are queued, so an idle port neither wakes nor accrues credit.
 func (w *writer) pace(ctx context.Context, baudKey ucv.Key) {
 	var buf []byte
+	var bufGen uint64
 	var num int64
 	var last time.Time
 	var ticker *time.Ticker
@@ -488,7 +528,7 @@ func (w *writer) pace(ctx context.Context, baudKey ucv.Key) {
 	}
 	defer stop()
 	for {
-		var in <-chan []byte
+		var in <-chan outPkt
 		if tick == nil {
 			in = w.ch // accept the next burst only while idle
 		}
@@ -496,10 +536,13 @@ func (w *writer) pace(ctx context.Context, baudKey ucv.Key) {
 		case <-ctx.Done():
 			return
 		case p := <-in:
-			buf, num, last = p, 0, time.Now()
+			buf, bufGen, num, last = p.data, p.gen, 0, time.Now()
 			ticker = time.NewTicker(tickInterval)
 			tick = ticker.C
 		case now := <-tick:
+			if w.stale(bufGen) {
+				buf = nil // a reboot discarded the packet mid-drip
+			}
 			budget, unlimited := 0, false
 			if baud := w.db.ramUint(baudKey); baud != 0 {
 				num += now.Sub(last).Nanoseconds() * int64(baud)
@@ -513,12 +556,16 @@ func (w *writer) pace(ctx context.Context, baudKey ucv.Key) {
 				if len(buf) == 0 {
 					select {
 					case p := <-w.ch:
-						buf = p
+						buf, bufGen = p.data, p.gen
 					default:
 						idle = true
 					}
 					if idle {
 						break
+					}
+					if w.stale(bufGen) {
+						buf = nil // drop a packet queued under a pre-reset config
+						continue
 					}
 				}
 				n := len(buf)

--- a/gps/app/ubxsim/ubxsim.go
+++ b/gps/app/ubxsim/ubxsim.go
@@ -448,7 +448,16 @@ func newWriter(out io.Writer, db *cfgDB, port ucv.Port) *writer {
 // packet carries the generation live at the call, so a packet gated under
 // a config a later reboot discards is dropped rather than emitted.
 func (w *writer) send(ctx context.Context, p []byte) error {
-	pkt := outPkt{gen: w.gen.Load(), data: p}
+	return w.sendGen(ctx, w.gen.Load(), p)
+}
+
+// sendGen is send with the caller's own generation stamp. The nav engine
+// binds a whole bank run to the generation live when the run started, so
+// the tail of an epoch interrupted mid-burst by a reboot is dropped with
+// the queue instead of being stamped current and preceding the restarted
+// epoch 0.
+func (w *writer) sendGen(ctx context.Context, gen uint64, p []byte) error {
+	pkt := outPkt{gen: gen, data: p}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -457,17 +466,21 @@ func (w *writer) send(ctx context.Context, p []byte) error {
 	}
 }
 
+// generation returns the current writer generation, for a sender that
+// stamps a multi-packet burst with sendGen.
+func (w *writer) generation() uint64 {
+	return w.gen.Load()
+}
+
 // reboot abandons the transmit queue's in-flight output the way a real
 // receiver reset does: it bumps the generation so the writer drops every
 // packet accepted under the pre-reset config, whether already queued or
 // mid-drip, instead of emitting it ahead of the restarted epoch-0 stream.
 // The reader calls this on a rebooting CFG-RST before signalling the nav
-// engine, so the epoch-0 burst is sent under the new generation. Two
-// bounded imprecisions: a mid-drip drop leaves a truncated frame whose
+// engine, so the epoch-0 burst is sent under the new generation. One
+// bounded imprecision: a mid-drip drop leaves a truncated frame whose
 // declared length absorbs the bytes that follow until the checksum fails
-// and the scanner resyncs (one bad frame per reset), and a nav packet
-// between its gate check and its send at the instant of the reboot is
-// stamped with the new generation and can leak once.
+// and the scanner resyncs (one bad frame per reset).
 func (w *writer) reboot() {
 	w.gen.Add(1)
 }

--- a/gps/app/ubxsim/ubxsim.go
+++ b/gps/app/ubxsim/ubxsim.go
@@ -74,12 +74,12 @@ func (s *Sim) Run(ctx context.Context, rw io.ReadWriter) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	w := newWriter(rw, db, s.opts.Port)
-	nav := &navEngine{db: db, port: s.opts.Port, epochs: s.p.Epochs, w: w, lg: s.opts.Logger}
+	nav := &navEngine{db: db, port: s.opts.Port, epochs: s.p.Epochs, w: w, lg: s.opts.Logger, reboot: make(chan struct{}, 1)}
 	var wg sync.WaitGroup
 	wg.Go(func() { nav.run(ctx) })
 	// The writer cancels on a fatal write error so blocked senders unwind.
 	wg.Go(func() { defer cancel(); w.run(ctx) })
-	err := s.readLoop(ctx, db, w, rw)
+	err := s.readLoop(ctx, db, w, nav, rw)
 	cancel()
 	wg.Wait()
 	return err
@@ -88,7 +88,7 @@ func (s *Sim) Run(ctx context.Context, rw io.ReadWriter) error {
 // readLoop demultiplexes the input stream: configuration messages and
 // the MON-VER poll are handled, correction input (RTCM or SPARTN) is
 // answered with UBX-RXM-COR, everything else is ignored.
-func (s *Sim) readLoop(ctx context.Context, db *cfgDB, w *writer, r io.Reader) error {
+func (s *Sim) readLoop(ctx context.Context, db *cfgDB, w *writer, nav *navEngine, r io.Reader) error {
 	sc := scan.New(r, 4096, []gpsprot.PacketFormat{ubx.PacketFormat, rtcm.PacketFormat, spartn.PacketFormat})
 	for {
 		pkt, err := sc.Scan()
@@ -102,7 +102,7 @@ func (s *Sim) readLoop(ctx context.Context, db *cfgDB, w *writer, r io.Reader) e
 			continue
 		}
 		if pkt.Format == ubx.PacketFormat {
-			err = s.handleMsg(ctx, db, w, pkt.Data)
+			err = s.handleMsg(ctx, db, w, nav, pkt.Data)
 		} else {
 			err = s.corInput(ctx, db, w, pkt)
 		}
@@ -115,7 +115,7 @@ func (s *Sim) readLoop(ctx context.Context, db *cfgDB, w *writer, r io.Reader) e
 // handleMsg processes one received UBX packet. Write errors are
 // returned; anything wrong with the packet itself is answered on the
 // wire (NAK) per the interface description's acknowledgement rule.
-func (s *Sim) handleMsg(ctx context.Context, db *cfgDB, w *writer, data string) error {
+func (s *Sim) handleMsg(ctx context.Context, db *cfgDB, w *writer, nav *navEngine, data string) error {
 	lg := s.opts.Logger
 	mid := ubxbin.PacketMsgId(data)
 	switch mid {
@@ -171,6 +171,21 @@ func (s *Sim) handleMsg(ctx context.Context, db *cfgDB, w *writer, data string) 
 		}
 		lg.Debug("CFG-CFG", "ack", ok)
 		return s.writeAckNak(ctx, w, mid, ok)
+	case ubxbin.CfgRstID:
+		// CFG-RST is never ACKed or NAKed (interface description 3.10.18:
+		// "Do not expect this message to be acknowledged by the receiver").
+		// A reset that puts the processor through a reset cycle reboots the
+		// simulator: rebuild RAM from the layers below and restart the nav
+		// engine, while this process and its stream stay alive. The
+		// GNSS-only reset modes leave the config as it is, as today.
+		if m, err := ubxbin.ParseMsg(data); err == nil {
+			if rst := m.(*ubxbin.CfgRst); rstReboots(rst.ResetMode) {
+				lg.Debug("CFG-RST reboot", "resetMode", rst.ResetMode)
+				db.reboot()
+				nav.restart()
+			}
+		}
+		return nil
 	case ubxbin.CfgPrtID:
 		port, ok := s.prtPollPort(data)
 		if !ok {
@@ -188,6 +203,24 @@ func (s *Sim) handleMsg(ctx context.Context, db *cfgDB, w *writer, data string) 
 		return s.writeAckNak(ctx, w, mid, false)
 	}
 	return nil
+}
+
+// rstReboots reports whether a CFG-RST resetMode puts the receiver
+// through a reset cycle that rebuilds the RAM configuration from the
+// layers below. The F9 interface description (6.7 "Configuration reset
+// behavior") lists exactly these modes as going through a reset cycle:
+// the immediate and after-shutdown hardware resets and the controlled
+// software reset. The GNSS-only modes (controlled software reset GNSS
+// only, controlled GNSS stop/start) do not reset the processor and so
+// leave the RAM configuration untouched.
+func rstReboots(mode ubxbin.CfgRstResetMode) bool {
+	switch mode {
+	case ubxbin.CfgRstResetModeHardwareResetImmediately,
+		ubxbin.CfgRstResetModeControlledSoftwareReset,
+		ubxbin.CfgRstResetModeHardwareResetAfterShutdown:
+		return true
+	}
+	return false
 }
 
 // corInput answers a differential correction input message (RTCM or

--- a/gps/app/ubxsim/ubxsim_test.go
+++ b/gps/app/ubxsim/ubxsim_test.go
@@ -262,6 +262,150 @@ func TestNavOutProt(t *testing.T) {
 	})
 }
 
+func sendRst(t *testing.T, w io.Writer, mode ubxbin.CfgRstResetMode) {
+	t.Helper()
+	sendMsg(t, w, &ubxbin.CfgRst{NavBbrMask: ubxbin.CfgRstNavBbrColdStart, ResetMode: mode})
+}
+
+func isAckFor(p scan.Packet, mid ubxbin.MsgID) bool {
+	if p.Format != ubx.PacketFormat {
+		return false
+	}
+	pmid := ubxbin.PacketMsgId(p.Data)
+	if pmid != ubxbin.AckAckID && pmid != ubxbin.AckNakID {
+		return false
+	}
+	return ubxbin.AckMsgID(p.Data) == mid
+}
+
+// valgetRAM polls the RAM layer for keys over the pipe and returns the
+// response values by key, proving the simulator still serves. It fails
+// the test if a CFG-RST is ever acknowledged while the response is
+// awaited.
+func valgetRAM(t *testing.T, w io.Writer, ch <-chan scan.Packet, keys ...ucv.Key) map[ucv.Key]uint64 {
+	t.Helper()
+	sendMsg(t, w, valgetPoll(ubxbin.CfgValgetLayerRAM, 0, keys...))
+	resp := await(t, ch, "CFG-VALGET response", func(p scan.Packet) bool {
+		if isAckFor(p, ubxbin.CfgRstID) {
+			t.Fatalf("CFG-RST was acknowledged")
+		}
+		return isUbx(ubxbin.CfgValgetID)(p)
+	})
+	m, err := ubxbin.ParseMsg(resp.Data)
+	if err != nil {
+		t.Fatalf("parse CFG-VALGET: %v", err)
+	}
+	items, err := ucv.UnmarshalItems(m.(*ubxbin.CfgValget).CfgData)
+	if err != nil {
+		t.Fatalf("unmarshal items: %v", err)
+	}
+	out := make(map[ucv.Key]uint64, len(items))
+	for _, it := range items {
+		out[it.Key] = it.Value
+	}
+	return out
+}
+
+// TestCfgRst checks the reboot semantics of a hardware-reset CFG-RST: it
+// is never acknowledged, it rebuilds RAM from the layers below so an
+// unsaved change is lost while a saved one survives, and it restarts the
+// nav engine with the simulator still serving. A GNSS-only reset mode is
+// not a reboot and leaves the RAM configuration alone.
+func TestCfgRst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := testPersonality()
+		navSat := ucv.KUbxNavSat.KeyU(ucv.UART1).Key()
+		nmeaOut := ucv.KUart1outprotNmea.Key()
+		w, ch := simConn(t, p)
+		await(t, ch, "GGA", isNmea("GGA"))
+
+		// Save navSat=1 to RAM and Flash, giving the epochs a clock and a
+		// value that must survive a reboot.
+		sendMsg(t, w, valsetMsg(ubxbin.CfgValsetLayerRAM|ubxbin.CfgValsetLayerFlash,
+			ucv.Item{Key: navSat, Value: 1}))
+		if !ackResult(t, ch, ubxbin.CfgValsetID) {
+			t.Fatalf("VALSET navSat NAKed")
+		}
+
+		// Turn the port's NMEA output off in RAM only (unsaved): GGA stops.
+		sendMsg(t, w, valsetMsg(ubxbin.CfgValsetLayerRAM, ucv.Item{Key: nmeaOut, Value: 0}))
+		if !ackResult(t, ch, ubxbin.CfgValsetID) {
+			t.Fatalf("VALSET nmeaOut off NAKed")
+		}
+		await(t, ch, "NAV-SAT", isUbx(ubxbin.NavSatID)) // drain the queued epoch
+		for range 3 {
+			await(t, ch, "NAV-SAT", func(p scan.Packet) bool {
+				if isNmea("GGA")(p) {
+					t.Fatalf("GGA sent with the port's NMEA output disabled")
+				}
+				return isUbx(ubxbin.NavSatID)(p)
+			})
+		}
+
+		// A hardware-reset CFG-RST reboots: RAM is rebuilt (NMEA output
+		// back to its default-on) and the nav engine restarts, so GGA
+		// resumes. No ACK/NAK for CFG-RST appears while we wait for it.
+		sendRst(t, w, ubxbin.CfgRstResetModeHardwareResetImmediately)
+		await(t, ch, "GGA", func(p scan.Packet) bool {
+			if isAckFor(p, ubxbin.CfgRstID) {
+				t.Fatalf("CFG-RST was acknowledged")
+			}
+			return isNmea("GGA")(p)
+		})
+
+		// The saved navSat survived; the unsaved nmeaOut change was lost.
+		vals := valgetRAM(t, w, ch, navSat, nmeaOut)
+		if vals[navSat] != 1 {
+			t.Errorf("after reboot navSat=%d, want saved 1", vals[navSat])
+		}
+		if vals[nmeaOut] != 1 {
+			t.Errorf("after reboot nmeaOut=%d, want default 1", vals[nmeaOut])
+		}
+
+		// A GNSS-only reset mode is not a reboot: an unsaved RAM change to
+		// nmeaOut survives it.
+		sendMsg(t, w, valsetMsg(ubxbin.CfgValsetLayerRAM, ucv.Item{Key: nmeaOut, Value: 0}))
+		if !ackResult(t, ch, ubxbin.CfgValsetID) {
+			t.Fatalf("VALSET nmeaOut off NAKed")
+		}
+		sendRst(t, w, ubxbin.CfgRstResetModeControlledGnssStop)
+		if v := valgetRAM(t, w, ch, nmeaOut)[nmeaOut]; v != 0 {
+			t.Errorf("after GNSS-stop reset nmeaOut=%d, want unchanged 0", v)
+		}
+	})
+}
+
+// TestCfgRstFactory checks the factory-reset sequence the workbench
+// sends: a CFG-CFG that clears the saved layers followed by a
+// hardware-reset CFG-RST. Without the CFG-RST reboot the RAM would keep
+// its current value; with it, RAM rebuilds from Default alone.
+func TestCfgRstFactory(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := testPersonality()
+		navSat := ucv.KUbxNavSat.KeyU(ucv.UART1).Key()
+		w, ch := simConn(t, p)
+		await(t, ch, "GGA", isNmea("GGA"))
+
+		// Put navSat=1 into RAM and both non-volatile layers.
+		sendMsg(t, w, valsetMsg(ubxbin.CfgValsetLayerRAM|ubxbin.CfgValsetLayerBBR|ubxbin.CfgValsetLayerFlash,
+			ucv.Item{Key: navSat, Value: 1}))
+		if !ackResult(t, ch, ubxbin.CfgValsetID) {
+			t.Fatalf("VALSET NAKed")
+		}
+
+		// Factory reset: clear the saved layers, then reboot.
+		sendMsg(t, w, &ubxbin.CfgCfg{CfgCfgFixed: ubxbin.CfgCfgFixed{ClearMask: ubxbin.CfgCfgSectionMaskAll}})
+		if !ackResult(t, ch, ubxbin.CfgCfgID) {
+			t.Fatalf("CFG-CFG clear NAKed")
+		}
+		sendRst(t, w, ubxbin.CfgRstResetModeHardwareResetImmediately)
+
+		if v := valgetRAM(t, w, ch, navSat)[navSat]; v != 0 {
+			t.Errorf("after factory reset navSat=%d, want default 0", v)
+		}
+	})
+}
+
 // recWriter records the time and size of each Write so a test can
 // observe how the paced writer meters a packet onto the stream.
 type recWriter struct {

--- a/gps/app/ubxsim/ubxsim_test.go
+++ b/gps/app/ubxsim/ubxsim_test.go
@@ -480,6 +480,74 @@ func TestWriterPacing(t *testing.T) {
 	})
 }
 
+// TestWriterReboot checks that a simulated reboot drops the packets a
+// slow UART port has queued (and the one it is dripping) under the
+// pre-reset config instead of emitting them ahead of the post-reset
+// stream: a real receiver reset abandons its in-flight output. It
+// exercises the writer directly, without the engines.
+func TestWriterReboot(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A high baud so that, without the fix, the whole stale burst would
+		// drip out inside the sleep below and be observed.
+		const baud = 921600
+		db := newCfgDB(ucv.Map{ucv.KUart1Baudrate.Key(): baud})
+		var buf bytes.Buffer
+		w := newWriter(&buf, db, ucv.UART1)
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() { w.run(ctx); close(done) }()
+
+		// Fill the queue with pre-reset nav output. The first packet is
+		// large so the slow line is still dripping it when the reset lands.
+		stale, err := ubxbin.PackMsg(ubxbin.NavSatID, make([]byte, 400))
+		if err != nil {
+			t.Fatalf("pack stale: %v", err)
+		}
+		for range txQueueDepth {
+			if err := w.send(ctx, stale); err != nil {
+				t.Fatalf("send stale: %v", err)
+			}
+		}
+		synctest.Wait() // let the writer take the first packet and park on its tick
+
+		// Reboot, then enqueue the post-reset marker under the new
+		// generation. The stale packets, all under the old generation, must
+		// not reach the wire.
+		w.reboot()
+		fresh, err := ubxbin.PackMsg(ubxbin.MonVerID, []byte("post-reset"))
+		if err != nil {
+			t.Fatalf("pack fresh: %v", err)
+		}
+		if err := w.send(ctx, fresh); err != nil {
+			t.Fatalf("send fresh: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond) // let the fresh packet drip out
+		cancel()
+		<-done
+
+		sc := scan.New(bytes.NewReader(buf.Bytes()), 4096, []gpsprot.PacketFormat{ubx.PacketFormat})
+		gotFresh := false
+		for {
+			pkt, err := sc.Scan()
+			if err != nil {
+				break
+			}
+			if pkt.Format == nil || !pkt.ChecksumValid {
+				continue
+			}
+			switch ubxbin.PacketMsgId(pkt.Data) {
+			case ubxbin.NavSatID:
+				t.Errorf("stale NAV-SAT emitted after reboot")
+			case ubxbin.MonVerID:
+				gotFresh = true
+			}
+		}
+		if !gotFresh {
+			t.Errorf("post-reset MON-VER not emitted")
+		}
+	})
+}
+
 // testSpartn returns a serialized SPARTN frame with the given
 // encryption flag.
 func testSpartn(t *testing.T, eaf bool) []byte {

--- a/gps/app/ubxsim/ubxsim_test.go
+++ b/gps/app/ubxsim/ubxsim_test.go
@@ -548,6 +548,79 @@ func TestWriterReboot(t *testing.T) {
 	})
 }
 
+// TestNavRebootMidBurst checks that a reboot landing while the nav engine
+// is mid-way through an epoch burst does not let the tail of that burst
+// precede the restarted epoch 0: the run is bound to the generation live
+// at its start, so packets the engine sends after the reboot bumped the
+// generation are still dropped. The bank's message stays enabled across
+// the reboot (it is in the defaults), which is exactly the case the queue
+// flush alone cannot catch.
+func TestNavRebootMidBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		db := newCfgDB(ucv.Map{
+			ucv.KUart1Baudrate.Key():             921600,
+			ucv.KUart1outprotUbx.Key():           1,
+			ucv.KUbxNavSat.KeyU(ucv.UART1).Key(): 1,
+		})
+		var buf bytes.Buffer
+		w := newWriter(&buf, db, ucv.UART1)
+		// One epoch, deep enough that the engine is still blocked sending
+		// its burst when the reboot lands. Each packet carries its index.
+		burst := txQueueDepth + 8
+		epoch := make([]Pkt, burst)
+		for i := range epoch {
+			data, err := ubxbin.PackMsg(ubxbin.NavSatID, append([]byte{byte(i)}, make([]byte, 199)...))
+			if err != nil {
+				t.Fatalf("pack: %v", err)
+			}
+			epoch[i] = Pkt{KeyM: ucv.KUbxNavSat, Tag: ubx.Tag, Data: data}
+		}
+		nav := &navEngine{db: db, port: ucv.UART1, epochs: [][]Pkt{epoch}, w: w, lg: slog.New(slog.DiscardHandler), reboot: make(chan struct{}, 1)}
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() { w.run(ctx); close(done) }()
+		navDone := make(chan struct{})
+		go func() { nav.run(ctx); close(navDone) }()
+		synctest.Wait() // the queue is full, the engine blocked mid-burst
+
+		mark := buf.Len()
+		db.reboot()
+		w.reboot()
+		nav.restart()
+		time.Sleep(2 * time.Second) // the restarted epoch 0 drips out fully
+		cancel()
+		<-done
+		<-navDone
+
+		// Everything on the wire after the reboot must be the restarted
+		// epoch from its first packet on; a pre-reset tail would show as
+		// indices out of order at the front.
+		sc := scan.New(bytes.NewReader(buf.Bytes()[mark:]), 4096, []gpsprot.PacketFormat{ubx.PacketFormat})
+		var got []int
+		for {
+			pkt, err := sc.Scan()
+			if err != nil {
+				break
+			}
+			if pkt.Format == nil || !pkt.ChecksumValid || ubxbin.PacketMsgId(pkt.Data) != ubxbin.NavSatID {
+				continue
+			}
+			got = append(got, int(pkt.Data[6])) // first payload byte: the index
+		}
+		if len(got) == 0 || got[0] != 0 {
+			t.Fatalf("first post-reset NAV-SAT index = %v, want 0 (pre-reset tail leaked)", got)
+		}
+		for i, idx := range got {
+			if idx != i {
+				t.Fatalf("post-reset NAV-SAT indices %v, want 0..%d in order", got, burst-1)
+			}
+		}
+		if len(got) != burst {
+			t.Errorf("post-reset NAV-SAT count = %d, want %d", len(got), burst)
+		}
+	})
+}
+
 // testSpartn returns a serialized SPARTN frame with the given
 // encryption flag.
 func testSpartn(t *testing.T, eaf bool) []byte {


### PR DESCRIPTION
The simulator models the layered config database and CFG-CFG fully but silently dropped CFG-RST, so a simulated cold start or factory reset wrongly left the RAM configuration untouched instead of rebuilding it from the saved layers. That blocked browser tests of the workbench's persistent-operations flow.

Treat a CFG-RST whose resetMode puts the processor through a reset cycle (0x00, 0x01, 0x04 per the F9 interface description section 6.7) as a reboot: rebuild the RAM layer from Default, Flash, then BBR in layer priority order and restart the nav engine's replay bank from epoch 0, while the process and its pty stay alive so a connected program's descriptor survives. The GNSS-only reset modes still leave the configuration alone, and CFG-RST is still never acknowledged.

Prerequisite of the configuration-tab browser tests (#376); see plan/playwright.md, Prerequisites.