### PR TITLE
Surface a fatal correction write failure as failed, not stopped

### DIFF
--- a/gps/app/stream/pull.go
+++ b/gps/app/stream/pull.go
@@ -432,6 +432,9 @@ func (s *GGASender) SetWriter(ctx context.Context, w ReadWriteDeadlineCloser) bo
 // On cancellation, Run waits for all internal goroutines to exit
 // before returning.
 func (s *Pull) Run(ctx context.Context, selectedGGA <-chan scan.Packet, onState func(State, error)) error {
+	if onState == nil {
+		onState = func(State, error) {}
+	}
 	iCtx, iCancel := context.WithCancel(ctx)
 	defer iCancel()
 	// writeErr captures a fatal write error so Run can return it
@@ -470,6 +473,7 @@ func (s *Pull) Run(ctx context.Context, selectedGGA <-chan scan.Packet, onState 
 	s.Packets.Close()
 	bcastWg.Wait()
 	if writeErr != nil {
+		onState(Failed, writeErr)
 		return writeErr
 	}
 	return iCtx.Err()
@@ -659,6 +663,11 @@ func (s *Pull) writer(ctx context.Context, lg *slog.Logger,
 		_, err := pw.WritePacket([]byte(pkt.Data), pkt.Format)
 		portLock <- port
 		if err != nil {
+			// A write error during shutdown means the port went away as
+			// corrections were stopped, not a failure to surface.
+			if ctx.Err() != nil {
+				return nil
+			}
 			lg.Error("correction serial write failed", "error", err)
 			cancel()
 			return err

--- a/gps/app/stream/pull_test.go
+++ b/gps/app/stream/pull_test.go
@@ -792,6 +792,60 @@ func TestWriteErrorTriggersShutdown(t *testing.T) {
 	}
 }
 
+func TestWriteErrorEmitsFailed(t *testing.T) {
+	src, client := newPipeSource()
+	defer src.close()
+	defer client.Close()
+	writeErr := errors.New("device is not writable")
+	mw := &mockWriter{}
+	portLock := gpsio.NewOutPortLock(mockOutPort{})
+	sink := newTestPull(src, mw, portLock)
+	connected := make(chan struct{})
+	var once sync.Once
+	var mu sync.Mutex
+	var gotFailed bool
+	var gotErr string
+	onState := func(st State, err error) {
+		if st == Connected {
+			once.Do(func() { close(connected) })
+		}
+		if st == Failed {
+			mu.Lock()
+			gotFailed = true
+			if err != nil {
+				gotErr = err.Error()
+			}
+			mu.Unlock()
+		}
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- sink.Run(t.Context(), nil, onState)
+	}()
+	<-connected
+	primeSink(t, client, mw)
+	mw.setError(writeErr)
+	if _, err := client.Write(makeRTCM(1005, 10)); err != nil {
+		t.Fatalf("failed to write packet: %v", err)
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, writeErr) {
+			t.Errorf("Run = %v, want %v", err, writeErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not shut down after write error")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !gotFailed {
+		t.Error("onState was not called with Failed after write error")
+	}
+	if gotErr != writeErr.Error() {
+		t.Errorf("Failed error = %q, want %q", gotErr, writeErr.Error())
+	}
+}
+
 func TestPortLockAcquiredPerWrite(t *testing.T) {
 	src, client := newPipeSource()
 	defer src.close()


### PR DESCRIPTION
When a correction session's serial write-back failed fatally (for example the GPS device is a read-only port, so writing the caster's RTCM to it fails), the pull writer cancelled the session and Pull.Run returned the error, but nothing emitted the Failed state. The session therefore ended with the plain stopped event and the workbench corrections panel flipped silently back to idle, indistinguishable from a user stop; the only evidence was a server-side error log.

Emit Failed with the write error from Pull.Run when the writer died, feeding the same mechanism that already surfaces fatal stream failures: the session translates Failed into the persisted failed event with the error text, and the panel already renders it. A write error that races a stop cancellation is suppressed, mirroring the sendGGA suppression, so a deliberate stop or disconnect is never misreported as a failure.

Found by the Playwright corrections-tab tests (#376).