### PR TITLE
Fix NMEA packet and address recognition

### DIFF
--- a/gps/internal/nmea/nmeapacket.go
+++ b/gps/internal/nmea/nmeapacket.go
@@ -24,6 +24,7 @@ func (f packetFormat) IsBinary() bool {
 const (
 	stateSync gpsprot.ScanState = iota + gpsprot.ScanStateSync
 	stateHadDollar
+	stateHadFirstAlnum
 	stateNormal
 	stateHadStar
 	stateHadChecksum1
@@ -37,12 +38,13 @@ const maxSentenceLength = nmeamsg.SentenceMaxLength
 // Next implements the gpsprot.PacketFormat interface for NMEA-like packets.
 // Constraints for acceptable NMEA-like packet (not necessarily completely NMEA compliant)
 //  1. First character is `$` and the packet does not contain any other `$` characters.
-//  2. Terminated with a line terminator (CR/LF or LF)
-//  3. All character before the line terminator must be printable ASCII (0x20-0x7E).
-//  4. Total length of packet does not exceed maxSentenceLength characters (including the line terminator).
-//  5. Immediately before the line terminator there is a `*` and two uppercase hex digits;
+//  2. The first two characters after `$` are ASCII alphanumeric characters.
+//  3. Terminated with CRLF; LF alone is also accepted.
+//  4. All characters before the line terminator must be printable ASCII (0x20-0x7E).
+//  5. Total length including CRLF does not exceed maxSentenceLength characters;
+//     a packet ending in LF alone can be at most maxSentenceLength-1 characters.
+//  6. Immediately before the line terminator there is a `*` and two uppercase hex digits;
 //     this `*` is the only one in the packet.
-//  6. The address field is non-empty, where the address is the substring between `$` and the first comma or `*`.
 func (f packetFormat) Next(state gpsprot.ScanState, buf []byte, nextScanIndex, packetLen int) gpsprot.ScanState {
 	b := buf[nextScanIndex]
 
@@ -51,11 +53,10 @@ func (f packetFormat) Next(state gpsprot.ScanState, buf []byte, nextScanIndex, p
 		if b == '$' {
 			return stateHadDollar
 		}
-	case stateHadDollar:
-		if b == '*' || b == ',' {
-			break
+	case stateHadDollar, stateHadFirstAlnum:
+		if ascii.IsAlnum(b) {
+			return state + 1
 		}
-		fallthrough
 	case stateNormal:
 		switch b {
 		case '*':

--- a/gps/internal/nmea/nmeapacket_test.go
+++ b/gps/internal/nmea/nmeapacket_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 
 	"github.com/jclark/satpulse/gps/gpsprot"
-	"github.com/jclark/satpulse/gps/lib/nmeamsg/testdata"
 	"github.com/jclark/satpulse/gps/internal/scantest"
+	"github.com/jclark/satpulse/gps/lib/nmeamsg"
+	"github.com/jclark/satpulse/gps/lib/nmeamsg/testdata"
 )
 
 // TestPacketFormat tests PacketFormat.Next using gpsprot.IsValidPacket and scantest.IsValidPacketBetween.
-// with all syntax test cases. Test cases with expected flags as 0 should be invalid packets,
-// and others should be valid packets. This test will fail until we fix PacketFormat.Next for nmea-lax.
+// Test cases with expected flags as 0 should be invalid packets, and others should be valid packets.
 func TestPacketFormat(t *testing.T) {
 	for _, tt := range testdata.SyntaxTestCases {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -27,13 +27,26 @@ func TestPacketFormat(t *testing.T) {
 			for range 10 {
 				buf, nRandom := scantest.InsertRandomPrefix(tt.Packet, '$')
 				isValid = scantest.IsValidPacketBetween(PacketFormat, buf, nRandom, nRandom+len(tt.Packet))
-				
+
 				if isValid != expectValidPacket {
 					t.Errorf("scantest.IsValidPacketBetween mismatch for %q: got %v, want %v", tt.Packet, isValid, expectValidPacket)
 				}
 			}
 		})
 	}
+}
+
+func FuzzPacketFormat(f *testing.F) {
+	for _, tt := range testdata.SyntaxTestCases {
+		f.Add(tt.Packet)
+	}
+	f.Fuzz(func(t *testing.T, packet string) {
+		got := gpsprot.IsValidPacket(PacketFormat, []byte(packet))
+		want := nmeamsg.CheckSyntax(packet)&nmeamsg.SentenceIsPacket != 0
+		if got != want {
+			t.Errorf("packet definition mismatch for %q: PacketFormat got %v, CheckSyntax got %v", packet, got, want)
+		}
+	})
 }
 
 func TestMsgID(t *testing.T) {
@@ -62,7 +75,6 @@ func TestMsgID(t *testing.T) {
 	}
 }
 
-
 type altChecksumUsage int
 
 const (
@@ -82,7 +94,7 @@ func TestAltChecksum(t *testing.T) {
 		{"$GNGLL,1343.91012,N,10038.68403,E,071109.00,A,A*74\r\n", altNotAvailable},
 		{"$GPGSV,1,1,00,0*65\r\n", altNotAvailable},
 		{"$GNGSA,M,1,,,,,,,,,,,,,99.99,99.99,99.99,1*3F\r\n", altNotAvailable},
-		
+
 		// Unicore packets use alt checksum
 		{"$command,VERSIONB,response: OK*46\r\n", altUsed},
 		{"$command,CONFIG,response: OK*54\r\n", altUsed},
@@ -90,7 +102,7 @@ func TestAltChecksum(t *testing.T) {
 		{"$command,MODE,response: OK*5D\r\n", altUsed},
 		{"$command,CONFIG PPS ENABLE GPS POSITIVE 100000 1000 0 0,response: OK*49\r\n", altUsed},
 		{"$command,MODE BASE TIME 2000,response: OK*7F\r\n", altUsed},
-		
+
 		// Unicore Firebird packet PDTINFO uses normal checksum even though is alt available
 		{"$PDTINFO,UM621-02,G1B1L1E1,V1.2,R6.0.0.0Build2810,2310414000033,000101114303845*10\r\n", altAvailableNotUsed},
 	}
@@ -100,7 +112,7 @@ func TestAltChecksum(t *testing.T) {
 		extracted := PacketFormat.ExtractChecksum(pkt)
 		normal := PacketFormat.ComputeChecksum(pkt)
 		alt := PacketFormat.(gpsprot.AltChecksumPacketFormat).ComputeAltChecksum(pkt)
-		
+
 		normalOK := slices.Equal(extracted, normal)
 		var altOK bool
 		if alt != nil {

--- a/gps/lib/nmeamsg/nmeamsg.go
+++ b/gps/lib/nmeamsg/nmeamsg.go
@@ -12,7 +12,7 @@ const (
 	SentenceIsPacket SentenceSyntaxFlags = 1 << iota // meets all constraints for packetFormat.Next()
 	// Following flags can be set only when SentenceIsPacket is set
 	SentenceAddressLength5           // Address field is exactly 5 uppercase alphanumeric chars (digits + uppercase letters)
-	SentenceProprietaryAddressFormat // Address field is all uppercase alphanumeric chars, starting with 'P' and length 4 or more
+	SentenceProprietaryAddressFormat // Address field starts with 'P' and three ASCII letters
 
 	// GNSS Talker ID bits (mutually exclusive)
 	// Tests the first two characters after initial $
@@ -34,8 +34,9 @@ const (
 
 )
 
-// SentenceMaxLength is the maximum length of a valid NMEA-like packet
-// (including checksum and CRLF).
+// SentenceMaxLength is the maximum length of a valid NMEA-like packet,
+// including checksum and CRLF. A packet ending in LF alone can be at most
+// SentenceMaxLength-1 bytes, since the limit is defined for a CRLF ending.
 //
 // The NMEA 0183 standard specifies 82 characters, but modern receivers
 // exceed this because they need more precision in latitude/longitude fields.
@@ -94,12 +95,12 @@ func CheckSyntax(data string) SentenceSyntaxFlags {
 	if n > SentenceMaxLength {
 		return 0
 	}
-	// Smallest acceptable packet is like $_*00\n
+	// Smallest acceptable packet is like $AA*00\n
 	// Doing this early ensures no risk of out-of-bounds access later
-	if n < 6 {
+	if n < 7 {
 		return 0
 	}
-	if data[0] != '$' {
+	if data[0] != '$' || !ascii.IsAlnum(data[1]) || !ascii.IsAlnum(data[2]) {
 		return 0
 	}
 	if n <= 82 {
@@ -113,6 +114,8 @@ func CheckSyntax(data string) SentenceSyntaxFlags {
 	if data[lineTerminatorIndex-1] == '\r' {
 		lineTerminatorIndex--
 		flags |= SentenceEndsWithCRLF
+	} else if n == SentenceMaxLength {
+		return 0
 	}
 	asteriskIndex := lineTerminatorIndex - 3
 	if data[asteriskIndex] != '*' {
@@ -121,24 +124,24 @@ func CheckSyntax(data string) SentenceSyntaxFlags {
 	if !ascii.IsUpperHexDigit(data[asteriskIndex+1]) || !ascii.IsUpperHexDigit(data[asteriskIndex+2]) {
 		return 0
 	}
-	i := 1
-	for ; i < asteriskIndex; i++ {
-		// Address characters are uppercase letters and digits.
-		if !ascii.IsUpper(data[i]) && !ascii.IsDigit(data[i]) {
-			break
+	i := 3
+	if asteriskIndex == 6 || data[6] == ',' {
+		for {
+			if !ascii.IsUpper(data[i]) && !ascii.IsDigit(data[i]) {
+				break
+			}
+			if i == 5 {
+				if !ascii.IsLower(data[1]) && !ascii.IsLower(data[2]) {
+					flags |= SentenceAddressLength5
+				}
+				i++
+				break
+			}
+			i++
 		}
 	}
-	if i == asteriskIndex || data[i] == ',' {
-		if i == 1 {
-			return 0 // Address cannot be empty
-		}
-		// address part is all  uppercase alphanumric characters
-		if i == 6 {
-			flags |= SentenceAddressLength5 // Address is exactly 5 characters
-		}
-		if data[1] == 'P' && i >= 5 {
-			flags |= SentenceProprietaryAddressFormat // Address starts with P + 3+ uppercase alphanumeric chars
-		}
+	if data[1] == 'P' && ascii.IsLetter(data[2]) && ascii.IsLetter(data[3]) && ascii.IsLetter(data[4]) {
+		flags |= SentenceProprietaryAddressFormat
 	}
 
 	for ; i < asteriskIndex; i++ {

--- a/gps/lib/nmeamsg/nmeamsg_test.go
+++ b/gps/lib/nmeamsg/nmeamsg_test.go
@@ -108,24 +108,29 @@ func checkSyntaxReference(data string) SentenceSyntaxFlags {
 
 	// Constraint 2: Terminated with line terminator (CR/LF or LF)
 	var lineTerminatorIndex int
+	var endsWithCRLF bool
 	if strings.HasSuffix(data, "\r\n") {
 		lineTerminatorIndex = len(data) - 2
+		endsWithCRLF = true
 	} else if strings.HasSuffix(data, "\n") {
 		lineTerminatorIndex = len(data) - 1
 	} else {
 		return 0
 	}
 
-	// Constraint 4: Total length ≤ SentenceMaxLength characters (including line terminator)
-	if len(data) > SentenceMaxLength {
+	// Constraint 4: Total length including a canonical CRLF is at most SentenceMaxLength characters
+	if len(data) > SentenceMaxLength || (!endsWithCRLF && len(data) == SentenceMaxLength) {
 		return 0
 	}
 
 	// Constraint 1: First character is `$` and no other `$` characters
-	if len(data) < 1 || data[0] != '$' {
+	if len(data) < 3 || data[0] != '$' {
 		return 0
 	}
 	if strings.Count(data, "$") != 1 {
+		return 0
+	}
+	if !ascii.IsAlnum(data[1]) || !ascii.IsAlnum(data[2]) {
 		return 0
 	}
 
@@ -183,8 +188,9 @@ func checkSyntaxReference(data string) SentenceSyntaxFlags {
 	}
 
 	// ===== PROPRIETARY FORMAT VALIDATION =====
-	// SentenceProprietaryAddressFormat: Address starts with P + 3+ uppercase alphanumeric chars
-	if len(address) >= 4 && address[0] == 'P' && isUpperAlphanumeric(address[1:]) {
+	// SentenceProprietaryAddressFormat: Address starts with P + 3 ASCII letters
+	if len(address) >= 4 && address[0] == 'P' &&
+		ascii.IsLetter(address[1]) && ascii.IsLetter(address[2]) && ascii.IsLetter(address[3]) {
 		flags |= SentenceProprietaryAddressFormat
 	}
 

--- a/gps/lib/nmeamsg/testdata/nmeatest.go
+++ b/gps/lib/nmeamsg/testdata/nmeatest.go
@@ -95,6 +95,21 @@ var SyntaxTestCases = []struct {
 		Packet:   "$GPGGA,1$23*5A\r\n",
 		Expected: 0,
 	},
+	{
+		Name:     "not a packet - SBF sync prefix",
+		Packet:   "$@AB*5A\r\n",
+		Expected: 0,
+	},
+	{
+		Name:     "not a packet - Septentrio reply prefix",
+		Packet:   "$R*5A\r\n",
+		Expected: 0,
+	},
+	{
+		Name:     "not a packet - Septentrio command prefix",
+		Packet:   "$----*5A\r\n",
+		Expected: 0,
+	},
 
 	// Constraint 5: Immediately before terminator there is `*` and two uppercase hex digits
 	{
@@ -177,6 +192,11 @@ var SyntaxTestCases = []struct {
 		Name:     "valid basic packet",
 		Packet:   "$GPGGA,123*5A\r\n",
 		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceTalkerIsGP | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+	},
+	{
+		Name:     "valid Unicore OK packet",
+		Packet:   "$OK*5A\r\n",
+		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 
 	// Address format tests - approved (exactly 5 chars)
@@ -273,14 +293,24 @@ var SyntaxTestCases = []struct {
 		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
-		Name:     "not proprietary - starts with P but lowercase",
+		Name:     "proprietary address - lowercase manufacturer code",
 		Packet:   "$Pabc,123*5A\r\n",
+		Expected: sentenceIsPacket | sentenceProprietaryAddressFormat | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+	},
+	{
+		Name:     "not a packet - non-letter after P",
+		Packet:   "$P-BC,123*5A\r\n",
+		Expected: 0,
+	},
+	{
+		Name:     "not proprietary - digit in manufacturer code",
+		Packet:   "$PA1C,123*5A\r\n",
 		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
-		Name:     "not proprietary - starts with P but non-alphanumeric",
-		Packet:   "$P-BC,123*5A\r\n",
-		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+		Name:     "proprietary address - unrestricted suffix",
+		Packet:   "$PABC-1,123*5A\r\n",
+		Expected: sentenceIsPacket | sentenceProprietaryAddressFormat | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
 		Name:     "proprietary address - no data fields",
@@ -434,24 +464,34 @@ var SyntaxTestCases = []struct {
 	{
 		Name:     "minimal packet - single char address",
 		Packet:   "$A*5A\r\n",
-		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+		Expected: 0,
 	},
 	{
 		Name:     "minimal packet with empty field",
-		Packet:   "$A,*5A\r\n",
+		Packet:   "$AA,*5A\r\n",
 		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 
-	// Packet length boundary tests (400 char limit)
+	// Packet length boundary tests (400 char limit including CRLF)
 	{
-		Name:     "exactly 400 chars (packet format max)",
-		Packet:   "$GPGGA," + strings.Repeat("X", 387) + "*5A\r\n", // Total = 400
+		Name:     "exactly 400 chars with CRLF",
+		Packet:   "$GPGGA," + strings.Repeat("X", 388) + "*5A\r\n",
 		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceTalkerIsGP | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceEndsWithCRLF,
 	},
 	{
-		Name:     "401 chars (over packet format limit)",
-		Packet:   "$GPGGA," + strings.Repeat("X", 389) + "*5A\r\n", // Total = 401
-		Expected: 0,                                                // Should fail packet detection due to length
+		Name:     "exactly 399 chars with LF",
+		Packet:   "$GPGGA," + strings.Repeat("X", 388) + "*5A\n",
+		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceTalkerIsGP | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars,
+	},
+	{
+		Name:     "401 chars with CRLF",
+		Packet:   "$GPGGA," + strings.Repeat("X", 389) + "*5A\r\n",
+		Expected: 0,
+	},
+	{
+		Name:     "400 chars with LF",
+		Packet:   "$GPGGA," + strings.Repeat("X", 389) + "*5A\n",
+		Expected: 0,
 	},
 
 	// Checksum case variations
@@ -485,6 +525,11 @@ var SyntaxTestCases = []struct {
 	{
 		Name:     "address starting with digit - 1ABCD",
 		Packet:   "$1ABCD,data*5A\r\n",
+		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+	},
+	{
+		Name:     "address with digits after two letters - AB1C2",
+		Packet:   "$AB1C2,data*5A\r\n",
 		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 
@@ -546,9 +591,9 @@ var SyntaxTestCases = []struct {
 		Expected: sentenceIsPacket | sentenceProprietaryAddressFormat | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
-		Name:     "proprietary with digits - P123",
+		Name:     "not proprietary - digit after P",
 		Packet:   "$P123,data*5A\r\n",
-		Expected: sentenceIsPacket | sentenceProprietaryAddressFormat | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
 		Name:     "very long proprietary address",
@@ -594,7 +639,7 @@ var SyntaxTestCases = []struct {
 	{
 		Name:     "partial GNSS match - just G",
 		Packet:   "$G,123*5A\r\n",
-		Expected: sentenceIsPacket | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+		Expected: 0,
 	},
 	{
 		Name:     "partial GNSS match - just GP",
@@ -609,9 +654,9 @@ var SyntaxTestCases = []struct {
 
 	// Mixed validation scenarios
 	{
-		Name:     "proprietary P12345 (5 chars, digits, starts with P)",
+		Name:     "not proprietary - P1234",
 		Packet:   "$P1234,data*5A\r\n",
-		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceProprietaryAddressFormat | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
+		Expected: sentenceIsPacket | sentenceAddressLength5 | sentenceNoCarets | sentenceValidCaretEscaping | sentenceValidDataChars | sentenceLength82OrLess | sentenceEndsWithCRLF,
 	},
 	{
 		Name:     "address with spaces (valid packet, invalid address format)",


### PR DESCRIPTION
Fix #383, #384:

- require two ASCII alphanumeric characters after `$` in both NMEA-like packet definitions
- correct approved and proprietary NMEA address classification
- make the CRLF-inclusive sentence length limit consistent between the scanner and `CheckSyntax`
- add shared boundary cases and a fuzz target that checks both packet definitions agree

Validated with 2 minute fuzz test.