### PR TITLE
term: make Term an interface

### DIFF
--- a/cmd/pollpps/pollpps.go
+++ b/cmd/pollpps/pollpps.go
@@ -32,6 +32,12 @@ func main() {
 		t.Restore()
 		t.Close()
 	}()
+	statusReader, ok := t.(term.ModemStatusReader)
+	if !ok {
+		_ = t.Restore()
+		_ = t.Close()
+		log.Fatalf("%s: terminal does not support modem-status reading", device)
+	}
 
 	fmt.Printf("Monitoring PPS on CTS line of %s\n", device)
 
@@ -48,7 +54,7 @@ func main() {
 	for {
 		select {
 		case <-ticker.C:
-			status, err := t.ModemStatus()
+			status, err := statusReader.ModemStatus()
 			if err != nil {
 				log.Printf("Error reading modem status: %v", err)
 				continue

--- a/gps/app/gpsio/serial.go
+++ b/gps/app/gpsio/serial.go
@@ -34,9 +34,9 @@ type SerialConn struct {
 }
 
 // ioFile is the minimal file-like interface SerialConn needs.
-// *term.Term, *term.File, and *pollingFile satisfy it.
+// term.Term, *term.File, and *pollingFile satisfy it.
 // TTY-specific operations (speed change, flush, restore, error counts)
-// are performed via type assertion to *term.Term.
+// are performed via type assertion to term.Term.
 type ioFile interface {
 	io.ReadWriteCloser
 	Path() string
@@ -101,16 +101,16 @@ func (c *SerialConn) Direct() bool {
 	return false
 }
 
-// term returns the underlying *term.Term if this SerialConn is backed by a
-// TTY, nil otherwise. TTY-specific operations (speed change, restore) are
-// gated on the result.
-func (c *SerialConn) term() *term.Term {
-	t, _ := c.file.(*term.Term)
+// term returns the underlying terminal capability if this SerialConn is backed
+// by a configurable terminal, nil otherwise. Terminal-specific operations
+// (speed change, restore) are gated on the result.
+func (c *SerialConn) term() term.Term {
+	t, _ := c.file.(term.Term)
 	return t
 }
 
-// Speed returns the current termios speed of the underlying TTY,
-// or 0 if this connection is not backed by a TTY.
+// Speed returns the current speed of the underlying configurable terminal,
+// or 0 if this connection does not provide terminal capabilities.
 func (c *SerialConn) Speed() int {
 	if t := c.term(); t != nil {
 		return t.Speed()
@@ -295,7 +295,7 @@ const readTimeout = time.Millisecond * 100
 // settings, on top of the computed transmit time for non-UART devices.
 const minDelay = time.Millisecond
 
-func openTerm(path string, speed int) (*term.Term, error) {
+func openTerm(path string, speed int) (term.Term, error) {
 	opts := []term.AttrSetter{
 		term.RawMode,
 		term.Local,

--- a/gps/app/gpsio/serial_test.go
+++ b/gps/app/gpsio/serial_test.go
@@ -1,0 +1,105 @@
+package gpsio
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/jclark/satpulse/gps/lib/term"
+)
+
+type fakeIOFile struct {
+	closed bool
+}
+
+var _ ioFile = (*fakeIOFile)(nil)
+
+func (f *fakeIOFile) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (f *fakeIOFile) Write(p []byte) (int, error) { return len(p), nil }
+
+func (f *fakeIOFile) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (f *fakeIOFile) Path() string { return "fake" }
+
+func (f *fakeIOFile) Buffered() (int, error) { return 0, nil }
+
+type fakeTerm struct {
+	fakeIOFile
+	speed       int
+	changeCalls int
+	restored    bool
+}
+
+var _ term.Term = (*fakeTerm)(nil)
+
+func (f *fakeTerm) Change(...term.AttrSetter) error {
+	f.changeCalls++
+	return nil
+}
+
+func (f *fakeTerm) Speed() int { return f.speed }
+
+func (f *fakeTerm) TransmitTime(int) time.Duration { return 0 }
+
+func (f *fakeTerm) DevKind() term.DevKind { return term.DevUnknown }
+
+func (f *fakeTerm) Flush() error { return nil }
+
+func (f *fakeTerm) Drain() error { return nil }
+
+func (f *fakeTerm) Restore() error {
+	f.restored = true
+	return nil
+}
+
+func TestSerialConnUsesTermCapability(t *testing.T) {
+	f := &fakeTerm{speed: 4800}
+	c := newSerialConn(f, term.DevUART)
+
+	if got := c.term(); got != f {
+		t.Fatalf("term() = %T, want fake terminal", got)
+	}
+	if got := c.Speed(); got != 4800 {
+		t.Errorf("Speed() = %d, want 4800", got)
+	}
+	if n, err := c.WriteThenChangeSpeed([]byte("test"), 9600); err != nil || n != 4 {
+		t.Fatalf("WriteThenChangeSpeed() = %d, %v; want 4, nil", n, err)
+	}
+	if f.changeCalls != 1 {
+		t.Errorf("Change calls = %d, want 1", f.changeCalls)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !f.restored {
+		t.Error("Close did not restore terminal settings")
+	}
+	if !f.closed {
+		t.Error("Close did not close terminal")
+	}
+}
+
+func TestSerialConnKeepsIOFileFallbackNonTerminal(t *testing.T) {
+	f := new(fakeIOFile)
+	c := newSerialConn(f, term.DevUnknown)
+
+	if got := c.term(); got != nil {
+		t.Fatalf("term() = %T, want nil", got)
+	}
+	if got := c.Speed(); got != 0 {
+		t.Errorf("Speed() = %d, want 0", got)
+	}
+	if n, err := c.WriteThenChangeSpeed([]byte("test"), 9600); err != nil || n != 4 {
+		t.Fatalf("WriteThenChangeSpeed() = %d, %v; want 4, nil", n, err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !f.closed {
+		t.Error("Close did not close fallback file")
+	}
+}

--- a/gps/lib/term/term_bsd.go
+++ b/gps/lib/term/term_bsd.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type serialICounter struct{}
+type serialErrorState struct{}
 
 func Speed(speed int) AttrSetter {
 	b, ok := speedToB(speed)
@@ -32,13 +32,13 @@ func (attr *Attr) speed() int {
 
 // readError is a stub on BSD -- there is no way to detect serial errors
 // through the kernel, so Read never returns *Error on these platforms.
-func (t *Term) readError() *Error { return nil }
+func (t *unixTerm) readError() *Error { return nil }
 
-func (t *Term) Flush() error {
+func (t *unixTerm) Flush() error {
 	return t.wrapErr(unix.IoctlSetPointerInt(t.fd, unix.TIOCFLUSH, 0), "ioctl(TIOCFLUSH)")
 }
 
-func (t *Term) setAttrNow(attr *unix.Termios) error {
+func (t *unixTerm) setAttrNow(attr *unix.Termios) error {
 	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TIOCSETA, attr), "ioctl(TIOCSETA)")
 }
 
@@ -46,7 +46,7 @@ func (t *Term) setAttrNow(attr *unix.Termios) error {
 // blocks for the transmit time of the buffered output, and the Go
 // runtime's preemption and timer signals interrupt blocking syscalls
 // routinely, so EINTR here is runtime noise, not an event: retry.
-func (t *Term) Drain() error {
+func (t *unixTerm) Drain() error {
 	for {
 		err := unix.IoctlSetInt(t.fd, unix.TIOCDRAIN, 0)
 		if err != unix.EINTR {
@@ -55,7 +55,7 @@ func (t *Term) Drain() error {
 	}
 }
 
-func (t *Term) getAttr() (tp *unix.Termios, err error) {
+func (t *unixTerm) getAttr() (tp *unix.Termios, err error) {
 	tp, err = unix.IoctlGetTermios(t.fd, unix.TIOCGETA)
 	err = t.wrapErr(err, "ioctl(TIOCGETA)")
 	return
@@ -63,7 +63,7 @@ func (t *Term) getAttr() (tp *unix.Termios, err error) {
 
 // checkNotExclusive is a no-op on BSD: there is no TIOCGEXCL, so exclusive mode
 // can be set but not queried.
-func (t *Term) checkNotExclusive() error { return nil }
+func (t *unixTerm) checkNotExclusive() error { return nil }
 
 var errFlockNotSupported error = unix.ENOTSUP
 

--- a/gps/lib/term/term_darwin.go
+++ b/gps/lib/term/term_darwin.go
@@ -32,7 +32,7 @@ var baudRates = []struct {
 	{921600, 921600},
 }
 
-func (t *Term) DevKind() DevKind {
+func (t *unixTerm) DevKind() DevKind {
 	before, after, ok := strings.Cut(t.path, ".")
 	if ok && (before == "/dev/cu" || before == "/dev/tty") {
 		if strings.HasPrefix(after, "usbmodem") {

--- a/gps/lib/term/term_darwin_test.go
+++ b/gps/lib/term/term_darwin_test.go
@@ -35,8 +35,8 @@ func TestDevKind_Darwin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			// Create a minimal Term with just the path set
-			term := &Term{path: tt.path}
+			// Create a minimal Unix terminal with just the path set.
+			term := &unixTerm{path: tt.path}
 			result := term.DevKind()
 
 			if result != tt.expected {

--- a/gps/lib/term/term_freebsd.go
+++ b/gps/lib/term/term_freebsd.go
@@ -28,6 +28,6 @@ var baudRates = []struct {
 	{unix.B921600, 921600},
 }
 
-func (t *Term) DevKind() DevKind {
+func (t *unixTerm) DevKind() DevKind {
 	return DevUnknown
 }

--- a/gps/lib/term/term_linux.go
+++ b/gps/lib/term/term_linux.go
@@ -64,11 +64,11 @@ func (attr *Attr) speed() int {
 	return speed
 }
 
-func (t *Term) Flush() error {
+func (t *unixTerm) Flush() error {
 	return t.wrapErr(unix.IoctlSetInt(t.fd, unix.TCFLSH, unix.TCIOFLUSH), "ioctl(TCFLSH)")
 }
 
-func (t *Term) setAttrNow(attr *unix.Termios) error {
+func (t *unixTerm) setAttrNow(attr *unix.Termios) error {
 	return t.wrapErr(unix.IoctlSetTermios(t.fd, unix.TCSETS2, attr), "ioctl(TCSETS2)")
 }
 
@@ -80,7 +80,7 @@ func (t *Term) setAttrNow(attr *unix.Termios) error {
 // EINTR here is runtime noise, not an event: retry. (POSIX tcdrain may
 // legitimately return EINTR; under Go we must be more diligent than libc
 // callers about retrying it.)
-func (t *Term) Drain() error {
+func (t *unixTerm) Drain() error {
 	for {
 		err := unix.IoctlSetInt(t.fd, unix.TCSBRK, 1)
 		if err != unix.EINTR {
@@ -89,7 +89,7 @@ func (t *Term) Drain() error {
 	}
 }
 
-func (t *Term) getAttr() (tp *unix.Termios, err error) {
+func (t *unixTerm) getAttr() (tp *unix.Termios, err error) {
 	tp, err = unix.IoctlGetTermios(t.fd, unix.TCGETS2)
 	err = t.wrapErr(err, "ioctl(TCGETS2)")
 	return
@@ -102,7 +102,7 @@ var errExclusive = errors.New("terminal is in exclusive mode (TIOCEXCL)")
 // it, open would already have failed with EBUSY had the flag been set, so a
 // flag seen here was set by another process after our open succeeded, and
 // failing on it would just hand the port to a latecomer.
-func (t *Term) checkNotExclusive() error {
+func (t *unixTerm) checkNotExclusive() error {
 	if !capSysAdmin() {
 		return nil
 	}
@@ -188,20 +188,27 @@ func probePoll(fd int) error {
 	return nil
 }
 
+type serialErrorState struct {
+	count serialICounter
+	valid bool
+}
+
 // readError returns a *Error describing serial errors that have occurred
 // since the previous call, or nil if none. It also establishes the
-// baseline counters on the first call after Init.
-func (t *Term) readError() *Error {
+// baseline counters on the first successful call after initialization or
+// after a transient TIOCGICOUNT failure.
+func (t *unixTerm) readError() *Error {
 	icNew, err := ioctlGetSerialICounter(t.fd)
 	if err != nil {
-		t.iCount = nil
+		t.serialError.valid = false
 		return nil
 	}
-	if t.iCount == nil {
-		t.iCount = icNew
+	if !t.serialError.valid {
+		t.serialError.count = *icNew
+		t.serialError.valid = true
 		return nil
 	}
-	ic := t.iCount
+	ic := &t.serialError.count
 	ec := ErrorCounts{
 		Framing:    icNew.Frame - ic.Frame,
 		Overrun:    icNew.Overrun - ic.Overrun,
@@ -232,7 +239,7 @@ func (t *Term) readError() *Error {
 	return &Error{Path: t.path, Flags: flags, Counts: &ec}
 }
 
-func (t *Term) DevKind() DevKind {
+func (t *unixTerm) DevKind() DevKind {
 	s := unix.Stat_t{}
 	err := unix.Fstat(t.fd, &s)
 	if err != nil {

--- a/gps/lib/term/term_linux_test.go
+++ b/gps/lib/term/term_linux_test.go
@@ -18,9 +18,13 @@ func TestArbitrarySpeed(t *testing.T) {
 		t.Fatalf("close setup fd: %v", err)
 	}
 
-	term, err := Open(path, RawMode)
+	opened, err := Open(path, RawMode)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
+	}
+	term, ok := opened.(*unixTerm)
+	if !ok {
+		t.Fatalf("Open returned %T, want *unixTerm", opened)
 	}
 	t.Cleanup(func() {
 		if err := term.Close(); err != nil {

--- a/gps/lib/term/term_unix.go
+++ b/gps/lib/term/term_unix.go
@@ -14,16 +14,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Term allows its cached attributes to be read from any goroutine concurrently
+// unixTerm allows its cached attributes to be read from any goroutine concurrently
 // with Change. Calls to Change must be serialized by the caller.
-type Term struct {
-	fd      int
-	path    string
-	attrMu  sync.RWMutex
-	attr    Attr
-	tsSaved unix.Termios
-	iCount  *serialICounter
+type unixTerm struct {
+	fd          int
+	path        string
+	attrMu      sync.RWMutex
+	attr        Attr
+	tsSaved     unix.Termios
+	serialError serialErrorState
 }
+
+var _ Term = (*unixTerm)(nil)
 
 type Attr struct {
 	ts unix.Termios
@@ -31,16 +33,16 @@ type Attr struct {
 
 type AttrSetter func(*Attr) error
 
-func Open(path string, opts ...AttrSetter) (*Term, error) {
-	t := new(Term)
-	err := t.Init(path, opts...)
-	if err != nil {
+// Open opens and configures a serial terminal.
+func Open(path string, opts ...AttrSetter) (Term, error) {
+	t := new(unixTerm)
+	if err := t.init(path, opts...); err != nil {
 		return nil, err
 	}
 	return t, nil
 }
 
-func (t *Term) Init(path string, opts ...AttrSetter) (err error) {
+func (t *unixTerm) init(path string, opts ...AttrSetter) (err error) {
 	t.path = path
 	// O_CLOEXEC is here, because we are using flock to lock.
 	// Without O_CLOEXEC, the lock would be inherited by child processes, which is probably not what is wanted.
@@ -106,7 +108,7 @@ func (t *Term) Init(path string, opts ...AttrSetter) (err error) {
 }
 
 // Change changes the attributes of the terminal after output has drained.
-func (t *Term) Change(opts ...AttrSetter) error {
+func (t *unixTerm) Change(opts ...AttrSetter) error {
 	attr := t.loadAttr()
 	for _, opt := range opts {
 		err := opt(&attr)
@@ -124,18 +126,18 @@ func (t *Term) Change(opts ...AttrSetter) error {
 	return nil
 }
 
-func (t *Term) Speed() int {
+func (t *unixTerm) Speed() int {
 	attr := t.loadAttr()
 	return attr.speed()
 }
 
-func (t *Term) loadAttr() Attr {
+func (t *unixTerm) loadAttr() Attr {
 	t.attrMu.RLock()
 	defer t.attrMu.RUnlock()
 	return t.attr
 }
 
-func (t *Term) storeAttr(attr Attr) {
+func (t *unixTerm) storeAttr(attr Attr) {
 	t.attrMu.Lock()
 	defer t.attrMu.Unlock()
 	t.attr = attr
@@ -157,7 +159,7 @@ func lock(fd int, path string) error {
 // for interoperating with programs such as gpsd that use TIOCEXCL instead, and it
 // also stops an unprivileged opener reprogramming the line as a side effect of
 // probing it.
-func (t *Term) setExclusive() error {
+func (t *unixTerm) setExclusive() error {
 	if err := t.checkNotExclusive(); err != nil {
 		return err
 	}
@@ -168,7 +170,7 @@ func (t *Term) setExclusive() error {
 // the tty rather than to our file descriptor, so closing without clearing it
 // leaves the port unopenable for as long as some other process holds the tty
 // open.
-func (t *Term) clearExclusive() error {
+func (t *unixTerm) clearExclusive() error {
 	return t.wrapErr(unix.IoctlSetInt(t.fd, unix.TIOCNXCL, 0), "ioctl(TIOCNXCL)")
 }
 
@@ -197,7 +199,7 @@ func NoParity(a *Attr) error {
 }
 
 // TransmitTime returns the time it takes to send a byte using the settings in Term.
-func (t *Term) TransmitTime(nBytes int) time.Duration {
+func (t *unixTerm) TransmitTime(nBytes int) time.Duration {
 	if nBytes <= 0 {
 		return 0
 	}
@@ -315,7 +317,7 @@ func (attr *Attr) readCanTimeout() bool {
 const earlyZeroRead = time.Millisecond
 const earlyZeroReadLimit = 5
 
-func (t *Term) Read(buf []byte) (n int, err error) {
+func (t *unixTerm) Read(buf []byte) (n int, err error) {
 	if len(buf) == 0 {
 		return 0, nil
 	}
@@ -356,7 +358,7 @@ func (t *Term) Read(buf []byte) (n int, err error) {
 	return 0, io.EOF
 }
 
-func (t *Term) Write(buf []byte) (int, error) {
+func (t *unixTerm) Write(buf []byte) (int, error) {
 	total := 0
 	for len(buf) > 0 {
 		// Semantics of Unix write and Go Write are not the same:
@@ -372,7 +374,7 @@ func (t *Term) Write(buf []byte) (int, error) {
 	return total, nil
 }
 
-func (t *Term) Buffered() (n int, err error) {
+func (t *unixTerm) Buffered() (n int, err error) {
 	n, err = unix.IoctlGetInt(t.fd, unix.TIOCOUTQ)
 	err = t.wrapErr(err, "ioctl(TIOCOUTQ)")
 	return
@@ -388,7 +390,14 @@ const (
 	MODEM_RI  = unix.TIOCM_RI  // Ring indicator; pin 9; in
 )
 
-func (t *Term) ModemStatus() (int, error) {
+// ModemStatusReader reads a Unix TIOCM_* encoded modem-status mask.
+type ModemStatusReader interface {
+	ModemStatus() (int, error)
+}
+
+var _ ModemStatusReader = (*unixTerm)(nil)
+
+func (t *unixTerm) ModemStatus() (int, error) {
 	status, err := unix.IoctlGetInt(t.fd, unix.TIOCMGET)
 	if err != nil {
 		return 0, t.wrapErr(err, "ioctl(TIOCMGET)")
@@ -396,11 +405,11 @@ func (t *Term) ModemStatus() (int, error) {
 	return status, nil
 }
 
-func (t *Term) Restore() error {
+func (t *unixTerm) Restore() error {
 	return t.setAttrNow(&t.tsSaved)
 }
 
-func (t *Term) Close() error {
+func (t *unixTerm) Close() error {
 	err := t.clearExclusive()
 	fd := t.fd
 	t.fd = -1
@@ -410,7 +419,7 @@ func (t *Term) Close() error {
 	return err
 }
 
-func (t *Term) Path() string {
+func (t *unixTerm) Path() string {
 	return t.path
 }
 
@@ -534,7 +543,7 @@ func (f *File) wrapErr(err error, op string) error {
 	}
 }
 
-func (t *Term) wrapErr(err error, op string) error {
+func (t *unixTerm) wrapErr(err error, op string) error {
 	if err == nil {
 		return err
 	}

--- a/gps/lib/term/term_windows.go
+++ b/gps/lib/term/term_windows.go
@@ -48,13 +48,15 @@ var baudRates = []int{
 	230400, 460800, 921600,
 }
 
-type Term struct {
+type windowsTerm struct {
 	handle        windows.Handle
 	path          string
 	attr          Attr
 	dcbSaved      windows.DCB
 	timeoutsSaved windows.CommTimeouts
 }
+
+var _ Term = (*windowsTerm)(nil)
 
 type Attr struct {
 	dcb      windows.DCB
@@ -63,16 +65,16 @@ type Attr struct {
 
 type AttrSetter func(*Attr) error
 
-func Open(path string, opts ...AttrSetter) (*Term, error) {
-	t := new(Term)
-	err := t.Init(path, opts...)
-	if err != nil {
+// Open opens and configures a serial terminal.
+func Open(path string, opts ...AttrSetter) (Term, error) {
+	t := new(windowsTerm)
+	if err := t.init(path, opts...); err != nil {
 		return nil, err
 	}
 	return t, nil
 }
 
-func (t *Term) Init(path string, opts ...AttrSetter) (err error) {
+func (t *windowsTerm) init(path string, opts ...AttrSetter) (err error) {
 	t.path = path
 	name, err := windows.UTF16PtrFromString(normalizeCOM(path))
 	if err != nil {
@@ -162,7 +164,7 @@ func normalizeCOM(path string) string {
 }
 
 // Change changes the attributes of the terminal after output has drained.
-func (t *Term) Change(opts ...AttrSetter) error {
+func (t *windowsTerm) Change(opts ...AttrSetter) error {
 	attr := t.attr
 	for _, opt := range opts {
 		err := opt(&attr)
@@ -185,7 +187,7 @@ func (t *Term) Change(opts ...AttrSetter) error {
 	return nil
 }
 
-func (t *Term) Read(buf []byte) (int, error) {
+func (t *windowsTerm) Read(buf []byte) (int, error) {
 	if len(buf) == 0 {
 		return 0, nil
 	}
@@ -208,7 +210,7 @@ func (t *Term) Read(buf []byte) (int, error) {
 	return int(n), nil
 }
 
-func (t *Term) Write(buf []byte) (int, error) {
+func (t *windowsTerm) Write(buf []byte) (int, error) {
 	total := 0
 	for len(buf) > 0 {
 		var n uint32
@@ -222,7 +224,7 @@ func (t *Term) Write(buf []byte) (int, error) {
 	return total, nil
 }
 
-func (t *Term) Buffered() (int, error) {
+func (t *windowsTerm) Buffered() (int, error) {
 	var errs uint32
 	var stat windows.ComStat
 	err := windows.ClearCommError(t.handle, &errs, &stat)
@@ -232,17 +234,17 @@ func (t *Term) Buffered() (int, error) {
 	return int(stat.CBOutQue), nil
 }
 
-func (t *Term) Flush() error {
+func (t *windowsTerm) Flush() error {
 	err := windows.PurgeComm(t.handle, windows.PURGE_RXCLEAR|windows.PURGE_TXCLEAR)
 	return t.wrapErr(err, "PurgeComm")
 }
 
 // Drain blocks until all pending output has been transmitted.
-func (t *Term) Drain() error {
+func (t *windowsTerm) Drain() error {
 	return t.wrapErr(windows.FlushFileBuffers(t.handle), "FlushFileBuffers")
 }
 
-func (t *Term) Restore() error {
+func (t *windowsTerm) Restore() error {
 	err := windows.SetCommState(t.handle, &t.dcbSaved)
 	if err != nil {
 		return t.wrapErr(err, "SetCommState")
@@ -251,22 +253,22 @@ func (t *Term) Restore() error {
 	return t.wrapErr(err, "SetCommTimeouts")
 }
 
-func (t *Term) Close() error {
+func (t *windowsTerm) Close() error {
 	h := t.handle
 	t.handle = windows.InvalidHandle
 	return t.wrapErr(windows.CloseHandle(h), "close")
 }
 
-func (t *Term) Path() string {
+func (t *windowsTerm) Path() string {
 	return t.path
 }
 
-func (t *Term) Speed() int {
+func (t *windowsTerm) Speed() int {
 	return int(t.attr.dcb.BaudRate)
 }
 
 // TransmitTime returns the time it takes to send nBytes at the current speed.
-func (t *Term) TransmitTime(nBytes int) time.Duration {
+func (t *windowsTerm) TransmitTime(nBytes int) time.Duration {
 	if nBytes <= 0 {
 		return 0
 	}
@@ -290,14 +292,14 @@ func (attr *Attr) byteTransmitTime() time.Duration {
 
 // DevKind on Windows returns DevUnknown. The plan allows best-effort
 // classification via registry lookup; that is not yet implemented.
-func (t *Term) DevKind() DevKind {
+func (t *windowsTerm) DevKind() DevKind {
 	return DevUnknown
 }
 
 // readError returns a *Error describing serial errors reported by
 // ClearCommError, or nil if none. Windows does not expose per-category
 // counters, so Error.Counts is always nil.
-func (t *Term) readError() *Error {
+func (t *windowsTerm) readError() *Error {
 	var errs uint32
 	var stat windows.ComStat
 	if err := windows.ClearCommError(t.handle, &errs, &stat); err != nil {
@@ -325,7 +327,7 @@ func (t *Term) readError() *Error {
 	return &Error{Path: t.path, Flags: flags}
 }
 
-func (t *Term) wrapErr(err error, op string) error {
+func (t *windowsTerm) wrapErr(err error, op string) error {
 	if err == nil {
 		return nil
 	}
@@ -360,7 +362,7 @@ func (f *File) Buffered() (int, error) {
 
 // OpenFallback opens a non-serial GPS input, such as a named pipe used as a
 // replay sink, as an asynchronous *os.File. It skips the GetCommState/
-// SetCommState setup a COM port needs (and that fails on a pipe; see Init).
+// SetCommState setup a COM port needs (and that fails on a pipe; see init).
 // The handle is opened FILE_FLAG_OVERLAPPED so os.NewFile associates it with
 // the Go runtime poller, giving Read the SetReadDeadline support the scan loop
 // relies on (Go 1.25+). It is classified DevFIFO, so writes are rejected at

--- a/gps/lib/term/types.go
+++ b/gps/lib/term/types.go
@@ -3,8 +3,25 @@ package term
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 )
+
+// Term is a configurable serial terminal.
+type Term interface {
+	io.ReadWriteCloser
+
+	Path() string
+	Buffered() (int, error)
+	Change(...AttrSetter) error
+	Speed() int
+	TransmitTime(int) time.Duration
+	DevKind() DevKind
+	Flush() error
+	Drain() error
+	Restore() error
+}
 
 // ErrNotATTY is returned when a device does not support termios.
 // Callers can check for it with errors.Is.

--- a/plan/term-interface.md
+++ b/plan/term-interface.md
@@ -45,8 +45,8 @@ concern.
 
 ## Public interface
 
-Define `Term` in a build-independent file as the common, required terminal
-surface:
+Define `Term` in the existing build-independent `types.go` as the common,
+required terminal surface:
 
 ```go
 type Term interface {
@@ -72,12 +72,11 @@ example because `ModemStatus` is deliberately absent from `Term`. Functions,
 fields, and variables that explicitly name `*term.Term` change to `term.Term`;
 a pointer to an interface is never used.
 
-The build-tagged `openTerm` function also returns `(Term, error)`, not a
-concrete pointer. This is required to preserve nil-on-error semantics. A
-wrapper must not directly return the multi-value result of a constructor whose
-first result is `*unixTerm` or `*windowsTerm`: converting a nil concrete
-pointer to `Term` would produce a non-nil interface. Every failure path returns
-a literal `nil` interface.
+The platform-specific `Open` functions also return `(Term, error)`, not a
+concrete pointer. Each allocates its concrete implementation, calls its private
+`init` method, and explicitly returns `nil, err` when initialization fails.
+This preserves nil-on-error semantics: converting a nil `*unixTerm` or
+`*windowsTerm` directly to `Term` would produce a non-nil interface.
 
 `Attr` and `AttrSetter` remain platform-specific opaque configuration
 machinery. The refactoring does not attempt to give Unix `Termios` and Windows
@@ -127,10 +126,11 @@ Both have compile-time assertions that they implement `Term`. Their methods
 retain the current public method names because those methods satisfy the
 interface; their implementation-only helpers remain private.
 
-The constructors allocate and initialize the appropriate concrete type and
-return it as `Term`. The current exported `Init` method becomes an unexported
-constructor helper. There is no meaningful zero value for an interface-backed
-terminal, and the repository has no caller of `Init` other than `Open`.
+The platform-specific `Open` functions allocate and initialize the appropriate
+concrete type and return it as `Term`. The current exported `Init` method
+becomes the private `init` constructor helper. There is no meaningful zero
+value for an interface-backed terminal, and the repository has no caller of
+`Init` other than `Open`.
 
 ### Unix platform state
 
@@ -156,23 +156,26 @@ Platform-specific `Flush`, `Drain`, attribute ioctls, exclusivity checks, baud
 handling, and `DevKind` classification remain in their current build-tagged
 files with receivers changed to the appropriate private concrete type.
 
-### Open selection
+### Platform construction
 
-Separate public construction from native implementation construction:
+Each platform implements the public constructor directly. For example, the
+Unix implementation is:
 
 ```go
 func Open(path string, opts ...AttrSetter) (Term, error) {
-	return openTerm(path, opts)
+	t := new(unixTerm)
+	if err := t.init(path, opts...); err != nil {
+		return nil, err
+	}
+	return t, nil
 }
 ```
 
-`openTerm` has the same `(Term, error)` signature, is selected by platform
-build tags, and initially constructs exactly the native terminal used today.
-Keeping selection at the interface boundary allows a platform to select
-another genuine `Term` implementation later without turning `unixTerm` into a
-union of unrelated backends. A concrete initialization error is converted to
-`return nil, err` before returning through the interface, avoiding a typed-nil
-result.
+The Windows implementation follows the same pattern with `windowsTerm`.
+Platform file selection provides the appropriate `Open`; there is no separate
+build-independent wrapper or `openTerm` layer. A concrete initialization error
+is converted to `return nil, err` before returning through the interface,
+avoiding a typed-nil result.
 
 Opening errors retain their current behavior, including `ErrNotATTY`, device
 locking errors, and restoration/cleanup after partial initialization.
@@ -215,23 +218,23 @@ Speed changes, transmit-time calculations, flush, drain, and restoration then
 operate on any full terminal implementation. FIFO and non-termios fallbacks
 continue to return `nil` from this assertion and retain their current behavior.
 
-Update comments that currently equate "terminal" or "TTY" with
-`*term.Term`; the distinction is capability-based after this change.
+Update comment references from `*term.Term` to `term.Term` where required by
+the type change; otherwise retain the existing terminology.
 
 ## Source organization
 
-- Put the public `Term` interface and public `Open` entry point in a new
-  build-independent file. Only capability interfaces with portable contracts
-  belong there.
-- Keep `term.go` under its existing `!windows` build tag. It retains `Attr`,
-  `AttrSetter`, the attribute setters and speed helpers, the Unix modem
-  constants and `ModemStatusReader`, `File`, `openFallback`, and the existing
-  Unix implementation code. Rename the concrete type and all its receivers to
-  `unixTerm`, rename `Init` to an unexported initialization helper, and replace
-  its exported `Open` with the build-tagged `openTerm` returning `Term`.
+- Put the public `Term` interface in the existing build-independent `types.go`
+  alongside the other build-independent public types. Keep platform-specific
+  capability interfaces in their build-tagged files.
+- Rename `term.go` to `term_unix.go` and keep its existing `!windows` build
+  tag. It retains `Attr`, `AttrSetter`, the attribute setters and speed helpers,
+  the Unix modem constants and `ModemStatusReader`, `File`, `openFallback`, and
+  the existing Unix implementation code. Rename the concrete type and all its
+  receivers to `unixTerm`, rename `Init` to the private `init` helper, and
+  change its exported `Open` to return `Term`.
 - Rename the concrete type and receivers in `term_windows.go` to
-  `windowsTerm`; retain the Windows `Attr` machinery there and replace its
-  exported `Open` with the Windows `openTerm` returning `Term`.
+  `windowsTerm`; retain the Windows `Attr` machinery there, rename `Init` to
+  the private `init` helper, and change its exported `Open` to return `Term`.
 - Update the Linux, BSD, Darwin, and FreeBSD receiver declarations and tests
   to use the private Unix type.
 - Keep fallback file types separate from the full terminal implementations.
@@ -246,7 +249,7 @@ This is intentionally a source-level API change for callers that explicitly
 use `*term.Term`, construct `term.Term{}`, or call `Init`. In-tree use is
 limited to `gpsio`, `pollpps`, package methods, an internal Darwin test, and
 `term_linux_test.go`. All are updated in the same commit. The Linux test calls
-`openTerm`, asserts that the returned `Term` is a `*unixTerm`, and uses that
+`Open`, asserts that the returned `Term` is a `*unixTerm`, and uses that
 concrete value for its package-internal file-descriptor checks.
 
 The return-type change also affects callers that infer the result but then use


### PR DESCRIPTION
`term.Term` named two unrelated concrete structs, one per platform. Callers writing `*term.Term` were naming whichever struct their build selected, and `gpsio.SerialConn` distinguished a terminal from a fallback by asserting exactly that type, so no other terminal transport could participate as a peer implementation.

- `Term` becomes an interface in `types.go`; the concrete types become the private `unixTerm` and `windowsTerm`, each with a compile-time assertion.
- `Open` on both platforms returns `(Term, error)` and returns a literal `nil` on failure, so an initialization error is never a typed-nil interface. The exported `Init`, which had no caller outside `Open`, becomes the private `init`.
- `ModemStatus` stays out of `Term` (its `int` is a Unix `TIOCM_*` mask with no portable meaning) and moves to the `ModemStatusReader` capability interface; `pollpps` asserts for it.
- `gpsio` gates speed change, transmit time, flush, drain, and restore on a `term.Term` assertion instead of a concrete pointer; fallbacks keep returning `nil`.
- The Linux `*serialICounter` field, which needed a dummy type on the BSDs, becomes a platform-defined `serialErrorState` value.
- `term.go` is renamed `term_unix.go`, and `plan/term-interface.md` is updated to match the implemented structure.

Includes the plan commit, which was not yet on `master` at `origin`.

Builds and vets clean on linux/amd64, linux/arm, windows/amd64, freebsd/amd64 and darwin/arm64; `go test ./...` passes.