### PR TITLE
Rework the satpulsetool serial command interface

### DIFF
--- a/cmd/satpulsetool/satpulsetool.go
+++ b/cmd/satpulsetool/satpulsetool.go
@@ -103,7 +103,7 @@ var descriptions = []struct {
 	name, desc string
 }{
 	{"gps", "configure a GPS device"},
-	{"serial", "list serial ports and detect their speeds"},
+	{"serial", "examine serial ports"},
 	{"sdp", "control software-defined pins on PTP hardware clocks"},
 	{"syncsim", "run clock synchronization simulation"},
 	{"ubxsim", "run u-blox receiver simulation"},

--- a/docs/_includes/NEWS.md
+++ b/docs/_includes/NEWS.md
@@ -57,7 +57,7 @@ _Not yet released_
 
 ### Other satpulsetool improvements
 
-- `satpulsetool` has a new `serial` command, which describes serial ports without opening them, and with `--detect-speed` detects the speed of a connected GNSS receiver from its output, on a selected port or on all discovered ports in parallel. Descriptions support JSON Lines output; detection can record wrong-speed input in a packet log. (#326, #394)
+- `satpulsetool` has a new `serial` command, which examines serial ports: it can discover the available serial ports, show information about a port without opening it, detect the speed of a connected GPS receiver, and log received packets. (#326, #394, #408)
 - `satpulsetool` has a new `pack` command, which reads a JSONL packet log and writes selected packets as a packet byte stream corresponding to the original packet contents. It can filter by packet `tag` and `msg`, and can preserve inter-packet timing for FIFO-based replay. (#247)
 - `satpulsetool` has a new `scan` command, which reads a raw GPS packet byte stream and writes a JSONL packet log that can be decoded with `satpulsetool annotate`. (#246)
 - `satpulsetool ntrip` has a new `--nmea-send-pos` option that takes `lat,lon[,hgt]` and sends a synthesized NMEA GGA sentence to the caster on connect, for Virtual Reference Station casters such as u-blox PointPerfect that need the client's position before they will stream. A companion `--nmea-send-interval` option sets the re-send period for casters that require a periodic GGA (default 5 seconds, matching the daemon; 0 sends once). (#325)

--- a/docs/man/satpulsetool-serial.1.md
+++ b/docs/man/satpulsetool-serial.1.md
@@ -1,29 +1,58 @@
 # NAME
 
-satpulsetool-serial - describe serial ports and detect GPS receiver serial speeds
+satpulsetool-serial - examine serial ports
 
 # SYNOPSIS
 
 **satpulsetool** [*global options*] **serial** [**\-h**\|**\-\-help**]\
-&nbsp;&nbsp;&nbsp;&nbsp;[**\-j**\|**\-\-jsonl**] [**\-s**\|**\-\-detect\-speed**]\
-&nbsp;&nbsp;&nbsp;&nbsp;[**\-\-packet\-log** *path*] [*port*]
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-a**\|**\-\-all**] [**\-d**\|**\-\-serial\-device** *path*]\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-i**\|**\-\-info**] [**\-j**\|**\-\-jsonl**]\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-s**\|**\-\-device\-speed** *bps*] [**\-t**\|**\-\-timeout** *seconds*]\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-\-packet\-log** *path*]
 
 # DESCRIPTION
 
-The **satpulsetool** **serial** command reports on the serial ports of the host.
-By default it discovers all serial ports and prints a line describing each discovered port on standard output;
-it does not open the serial ports.
-If the *port* argument is supplied, it describes only the specified port.
+The **satpulsetool** **serial** command can perform the following operations related to serial ports:
+
+* detect the speed of a connected GPS receiver by trying to read data from the serial port at different speeds;
+* discover the available serial ports;
+* show information about a serial port without opening it (this is useful mainly with USB serial ports);
+* log packets received from a serial port.
+
+With the **\-d** option, it operates on a single specified serial port.
+With the **\-a** option, it discovers serial ports and operates on all the discovered ports.
+When either the **\-d** or **\-a** option is specified, the default operation is speed detection.
+Otherwise, the default operation is to discover the available serial ports and show information about them.
 
 # OPTIONS
 
 **\-h**, **\-\-help**
 : Show usage help for the **serial** command.
 
-**\-s**, **\-\-detect\-speed**
-: Detect the speed of a connected GPS receiver from the data being emitted by the receiver.
-If the *port* argument is supplied, it detects the speed of only that port and prints its speed on standard output.
-Otherwise, it detects the speed of all discovered ports in parallel and prints a line for each port.
+**\-a**, **\-\-all**
+: Discover the available serial ports and perform operations on all discovered ports.
+
+**\-d**, **\-\-serial\-device** *path*
+: Operate on the specified serial port.
+
+**\-i**, **\-\-info**
+: Show information about serial ports without opening or reading from them.
+
+**\-\-packet\-log** *path*
+: Write a log of packets received to *path*.
+The log is in JSON lines format.
+Requires **\-d**.
+
+**\-s**, **\-\-device\-speed** *bps*
+: Set the speed of the serial port.
+This causes speed detection not to be performed.
+A speed of 0 uses the current speed of the serial port.
+Requires **\-d** and **\-\-packet\-log**.
+
+**\-t**, **\-\-timeout** *seconds*
+: Stop capturing packets after *seconds*.
+The default is 0, meaning capture until interrupted.
+Requires **\-d**, **\-s** and **\-\-packet\-log**.
 
 **\-j**, **\-\-jsonl**
 : Write output in JSON Lines format.
@@ -32,11 +61,6 @@ for a USB port a `usb` object with numeric `vid` and `pid` fields,
 for a port with a USB serial number a `serial` string,
 and, for a port with aliases, an `aliases` array of paths.
 A detected speed object has a `device` string and a numeric `speed`.
-
-**\-\-packet\-log** *path*
-: Log to *path* a description of the packets received while detecting, including those received at the wrong speed.
-The log is in `.jsonl` (JSON lines) format.
-Requires **\-\-detect\-speed** and a *port*.
 
 # EXIT STATUS
 
@@ -47,7 +71,7 @@ Requires **\-\-detect\-speed** and a *port*.
 : Error
 
 **2**
-: No data found: no serial ports found, the *port* selector matched no discovered port, or no output received from the device
+: No data found: no serial ports found, the **\-d** *path* matched no discovered port, no output received from the device, or no packets captured
 
 # EXAMPLES
 
@@ -59,21 +83,33 @@ List the serial ports as JSON Lines:
 
     satpulsetool serial --jsonl
 
-Describe one port:
+Show information about one port:
 
-    satpulsetool serial /dev/ttyUSB0
+    satpulsetool serial -i -d /dev/ttyUSB0
 
 Detect the speed of a receiver:
 
-    satpulsetool serial -s /dev/ttyUSB0
+    satpulsetool serial -d /dev/ttyUSB0
 
 Detect the speed of every serial port:
 
-    satpulsetool serial --detect-speed
+    satpulsetool serial -a
+
+Detect the speed of a receiver, logging the packets received during detection:
+
+    satpulsetool serial -d /dev/ttyUSB0 --packet-log capture.jsonl
+
+Capture packets for 30 seconds at 38400 bits per second:
+
+    satpulsetool serial -d /dev/ttyUSB0 -s 38400 -t 30 --packet-log capture.jsonl
+
+Capture packets at the port's current speed until interrupted:
+
+    satpulsetool serial -d /dev/ttyUSB0 -s 0 --packet-log capture.jsonl
 
 Show receiver information at the detected speed:
 
-    satpulsetool gps -d /dev/ttyUSB0 -s $(satpulsetool serial -s /dev/ttyUSB0) --show-receiver
+    satpulsetool gps -d /dev/ttyUSB0 -s $(satpulsetool serial -d /dev/ttyUSB0) --show-receiver
 
 # SEE ALSO
 

--- a/docs/man/satpulsetool.1.md
+++ b/docs/man/satpulsetool.1.md
@@ -18,7 +18,7 @@ The *command* must be one of the following.
 : Configure and control the GPS receiver.
 
 **serial**
-: Describe serial ports and detect receiver speeds.
+: Examine serial ports.
 
 **sdp**
 : Manage Software Defined Pins (SDPs) of PTP Hardware Clocks (PHCs)

--- a/internal/serialcmd/serialcmd.go
+++ b/internal/serialcmd/serialcmd.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,12 +21,14 @@ import (
 	"github.com/jclark/satpulse/gps/gpsreg"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
 	"github.com/jclark/satpulse/gps/lib/term"
+	"github.com/jclark/satpulse/gps/ptime"
 	"github.com/jclark/satpulse/gps/scan"
 	"github.com/spf13/pflag"
 )
 
 const (
-	summary        = `[-h|--help] [-j|--jsonl] [-s|--detect-speed] [--packet-log path] [port]`
+	summary = `[-h|--help] [-j|--jsonl] [-i|--info] [-a|--all | -d|--serial-device path]
+              [-s|--device-speed bps] [-t|--timeout seconds] [--packet-log path]`
 	tryDuration    = 1250 * time.Millisecond
 	silentTryLimit = 5
 )
@@ -40,11 +44,22 @@ func (e commandError) ExitCode() int { return e.code }
 func (e commandError) Quiet() bool   { return e.quiet }
 
 type flags struct {
-	jsonl     bool
-	detect    bool
-	packetLog string
-	port      string
+	jsonl          bool
+	info           bool
+	all            bool
+	device         string
+	deviceSpeed    int
+	deviceSpeedSet bool
+	packetLog      string
+	timeout        time.Duration
 }
+
+type serialOperation uint8
+
+const (
+	serialDetect serialOperation = iota
+	serialCapture
+)
 
 type printer interface {
 	Print(*os.File) error
@@ -53,11 +68,19 @@ type printer interface {
 type portInfo serialenum.Port
 
 func (info *portInfo) Print(f *os.File) error {
-	if info.Serial == "" {
-		_, err := fmt.Fprintln(f, info.Display)
-		return err
+	var b strings.Builder
+	fmt.Fprintf(&b, "device=%s", info.Device)
+	if info.USB != (serialenum.USBID{}) {
+		fmt.Fprintf(&b, " vid=%04x pid=%04x", info.USB.VID, info.USB.PID)
 	}
-	_, err := fmt.Fprintf(f, "%s serial=%q\n", info.Display, info.Serial)
+	if info.Serial != "" {
+		fmt.Fprintf(&b, " serial=%q", info.Serial)
+	}
+	for _, alias := range info.Aliases {
+		fmt.Fprintf(&b, " alias=%s", alias)
+	}
+	fmt.Fprintf(&b, " display=%q", info.Display)
+	_, err := fmt.Fprintln(f, b.String())
 	return err
 }
 
@@ -99,48 +122,110 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 		return usageFunc(progName), nil
 	}
 	lg := cmd.NewDefaultLogger(logWriter, logLevel)
-	if !cfg.detect {
-		return "", enumerate(os.Stdout, cfg.jsonl, cfg.port)
+	if cfg.info {
+		return "", enumerate(os.Stdout, cfg.jsonl, cfg.device)
 	}
 	ctx, cancel := cmd.CancelOnSignal(context.Background(), lg)
 	defer cancel()
-	if cfg.port != "" {
-		result := probeDevice(ctx, lg, cfg.port, cfg.packetLog)
-		if ctx.Err() != nil {
-			return "", commandError{msg: "interrupted", code: 1}
-		}
+	if cfg.all {
+		return "", scanPorts(ctx, lg, cfg.jsonl)
+	}
+	if cfg.deviceSpeedSet {
+		result := captureDevice(ctx, lg, cfg.device, cfg.deviceSpeed, cfg.packetLog, cfg.timeout)
 		if code := result.exitCode(); code != 0 {
 			return "", commandError{msg: result.description(), code: code}
 		}
-		info := speedInfo{Device: result.device, Speed: result.detection.Speed}
-		return "", printInfo(os.Stdout, &info, cfg.jsonl)
+		return "", nil
 	}
-	return "", scanPorts(ctx, lg, cfg.jsonl)
+	result := probeDevice(ctx, lg, cfg.device, cfg.packetLog)
+	if ctx.Err() != nil {
+		return "", commandError{msg: "interrupted", code: 1}
+	}
+	if code := result.exitCode(); code != 0 {
+		return "", commandError{msg: result.description(), code: code}
+	}
+	info := speedInfo{Device: result.device, Speed: result.detection.Speed}
+	return "", printInfo(os.Stdout, &info, cfg.jsonl)
 }
 
 func parseFlags(cmdName string, args []string) (cfg flags, help bool, usageFunc func(string) string, err error) {
 	fs := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
+	var timeoutSec float64
 	fs.BoolVarP(&cfg.jsonl, "jsonl", "j", false, "output in JSON Lines format instead of human-readable text")
-	fs.BoolVarP(&cfg.detect, "detect-speed", "s", false, "detect receiver speeds instead of describing ports")
+	fs.BoolVarP(&cfg.info, "info", "i", false, "describe target ports without opening them")
+	fs.BoolVarP(&cfg.all, "all", "a", false, "select all discovered serial ports")
+	fs.StringVarP(&cfg.device, "serial-device", "d", "", "select the serial device at `path`")
+	fs.IntVarP(&cfg.deviceSpeed, "device-speed", "s", 0, "set the serial device speed in `bps` (0 keeps the current speed)")
+	fs.Float64VarP(&timeoutSec, "timeout", "t", 0, "capture packets for `seconds` (0 = until interrupted)")
 	fs.StringVar(&cfg.packetLog, "packet-log", "", "write received packets and speed changes to a JSONL file")
 	fs.BoolVarP(&help, "help", "h", false, "show usage help for the serial command")
 	usageFunc = cmd.UsageFunc(cmdName, summary, fs)
 	if err = fs.Parse(args); err != nil || help {
 		return
 	}
-	if fs.NArg() > 1 {
-		err = fmt.Errorf("expected at most one serial port argument")
+	if fs.NArg() != 0 {
+		err = fmt.Errorf("serial command does not accept positional arguments")
 		return
 	}
-	if fs.NArg() == 1 {
-		cfg.port = fs.Arg(0)
-		if cfg.port == "" {
-			err = fmt.Errorf("serial port must not be empty")
+	deviceSet := fs.Lookup("serial-device").Changed
+	cfg.deviceSpeedSet = fs.Lookup("device-speed").Changed
+	timeoutSet := fs.Lookup("timeout").Changed
+	packetLogSet := fs.Lookup("packet-log").Changed
+	if deviceSet && cfg.device == "" {
+		err = fmt.Errorf("--serial-device must not be empty")
+		return
+	}
+	if cfg.all && deviceSet {
+		err = fmt.Errorf("--all cannot be combined with --serial-device")
+		return
+	}
+	if cfg.deviceSpeedSet && cfg.deviceSpeed < 0 {
+		err = fmt.Errorf("--device-speed must not be negative")
+		return
+	}
+	if timeoutSet {
+		switch {
+		case math.IsNaN(timeoutSec) || math.IsInf(timeoutSec, 0):
+			err = fmt.Errorf("--timeout must be finite")
+			return
+		case timeoutSec < 0:
+			err = fmt.Errorf("--timeout must not be negative")
+			return
+		case timeoutSec >= float64(math.MaxInt64)/float64(time.Second):
+			err = fmt.Errorf("--timeout is too large")
 			return
 		}
 	}
-	if cfg.packetLog != "" && (!cfg.detect || cfg.port == "") {
-		err = fmt.Errorf("--packet-log requires --detect-speed and a port")
+	if packetLogSet && cfg.packetLog == "" {
+		err = fmt.Errorf("--packet-log must not be empty")
+		return
+	}
+	if cfg.info && (cfg.deviceSpeedSet || timeoutSet || packetLogSet) {
+		err = fmt.Errorf("--info cannot be combined with --device-speed, --timeout, or --packet-log")
+		return
+	}
+	if timeoutSet && (!cfg.deviceSpeedSet || !packetLogSet) {
+		err = fmt.Errorf("--timeout requires --device-speed and --packet-log")
+		return
+	}
+	if cfg.deviceSpeedSet && !deviceSet {
+		err = fmt.Errorf("--device-speed requires --serial-device")
+		return
+	}
+	if cfg.deviceSpeedSet && !packetLogSet {
+		err = fmt.Errorf("--device-speed requires --packet-log")
+		return
+	}
+	if packetLogSet && !deviceSet {
+		err = fmt.Errorf("--packet-log requires --serial-device")
+		return
+	}
+	if timeoutSet {
+		cfg.timeout = ptime.Seconds(timeoutSec)
+	}
+	if !deviceSet && !cfg.all {
+		cfg.info = true
+		cfg.all = true
 	}
 	return
 }
@@ -233,7 +318,7 @@ func probeDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath str
 	result.device = device
 	conn, _, err := gpsio.OpenSerial(device, 0)
 	if err != nil {
-		result.failure = describeSerialError(err)
+		result.failure = serialDetect.describeError(err)
 		return
 	}
 
@@ -242,7 +327,7 @@ func probeDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath str
 	pktLog, logFile, err := gpsio.LogPackets(lg, &wg, packetLogPath, false, formats)
 	if err != nil {
 		result.failure = "opening packet log: " + err.Error()
-		closeDevice(lg, conn, &result)
+		closeDevice(lg, conn, device, &result.failure)
 		return
 	}
 	if pktLog != nil {
@@ -267,7 +352,7 @@ func probeDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath str
 		func(tried []int) bool { return len(tried) >= silentTryLimit },
 	)
 	if err != nil {
-		result.failure = describeSerialError(err)
+		result.failure = serialDetect.describeError(err)
 	}
 
 	conn.Stop()
@@ -278,24 +363,116 @@ func probeDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath str
 	if logFile != nil {
 		logFile.Close(lg)
 	}
-	closeDevice(lg, conn, &result)
+	closeDevice(lg, conn, device, &result.failure)
 	return
 }
 
-// closeDevice closes conn, keeping the close error only when the probe
-// itself produced none. A probe that already failed has a more relevant
-// failure to report, and each port gets exactly one output line, so the two
-// cannot be combined.
-func closeDevice(lg *slog.Logger, conn *gpsio.SerialConn, result *probeResult) {
+type captureResult struct {
+	packets int
+	failure string
+}
+
+func (r captureResult) exitCode() int {
+	if r.failure != "" {
+		return 1
+	}
+	if r.packets == 0 {
+		return 2
+	}
+	return 0
+}
+
+func (r captureResult) description() string {
+	if r.failure != "" {
+		return r.failure
+	}
+	return "no output received from the device"
+}
+
+func captureDevice(ctx context.Context, lg *slog.Logger, device string, speed int, packetLogPath string, timeout time.Duration) (result captureResult) {
+	conn, _, err := gpsio.OpenSerial(device, speed)
+	if err != nil {
+		result.failure = serialCapture.describeError(err)
+		return
+	}
+
+	formats := gpsreg.CreatePacketFormats(nil)
+	var wg sync.WaitGroup
+	pktLog, logFile, err := gpsio.LogPackets(lg, &wg, packetLogPath, false, formats)
+	if err != nil {
+		result.failure = "opening packet log: " + err.Error()
+		closeDevice(lg, conn, device, &result.failure)
+		return
+	}
+	if pktLog != nil {
+		conn.SetPacketLog(pktLog)
+	}
+
+	scanCtx, cancelScan := context.WithCancel(context.Background())
+	packetCh := make(chan scan.Packet, 1)
+	wg.Go(func() { gpsio.Scan(scanCtx, lg, conn, packetCh, pktLog, formats) })
+	result.packets, err = capturePackets(ctx, lg, packetCh, timeout)
+	if err != nil {
+		result.failure = err.Error()
+	}
+
+	conn.Stop()
+	cancelScan()
+	for pkt := range packetCh {
+		if len(pkt.Data) != 0 {
+			result.packets++
+		}
+	}
+	wg.Wait()
+	if logFile != nil {
+		logFile.Close(lg)
+	}
+	closeDevice(lg, conn, device, &result.failure)
+	return
+}
+
+func capturePackets(ctx context.Context, lg *slog.Logger, packetCh <-chan scan.Packet, timeout time.Duration) (int, error) {
+	var timerC <-chan time.Time
+	if timeout == 0 {
+		lg.Info("capturing packets until interrupted")
+	} else {
+		lg.Debug("capturing packets", "duration", timeout)
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		timerC = timer.C
+	}
+	count := 0
+	for {
+		select {
+		case <-ctx.Done():
+			lg.Debug("capture interrupted")
+			return count, nil
+		case <-timerC:
+			lg.Debug("capture complete")
+			return count, nil
+		case pkt, ok := <-packetCh:
+			if !ok {
+				return count, errors.New("serial input ended unexpectedly")
+			}
+			if len(pkt.Data) != 0 {
+				count++
+			}
+		}
+	}
+}
+
+// closeDevice closes conn, keeping the close error only when the read
+// operation itself produced none. An existing failure is more relevant.
+func closeDevice(lg *slog.Logger, conn *gpsio.SerialConn, device string, failure *string) {
 	closeErr := conn.Close()
 	if closeErr == nil {
 		return
 	}
-	if result.failure == "" {
-		result.failure = closeErr.Error()
+	if *failure == "" {
+		*failure = closeErr.Error()
 		return
 	}
-	lg.Debug("closing the serial device failed after an unsuccessful probe", "device", result.device, "error", closeErr)
+	lg.Debug("closing the serial device failed after an unsuccessful read", "device", device, "error", closeErr)
 }
 
 func scanPorts(ctx context.Context, lg *slog.Logger, jsonl bool) error {
@@ -361,7 +538,7 @@ func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port,
 	return commandError{msg: "serial scan did not detect a device", code: bestCode, quiet: true}
 }
 
-func describeSerialError(err error) string {
+func (op serialOperation) describeError(err error) string {
 	switch {
 	case errors.Is(err, context.Canceled):
 		return "interrupted"
@@ -369,7 +546,7 @@ func describeSerialError(err error) string {
 		return "permission denied; add this user to the serial-port access group (usually dialout)"
 	case isLocked(err):
 		return "device is locked by another process"
-	case errors.Is(err, term.ErrNotATTY):
+	case op == serialDetect && errors.Is(err, term.ErrNotATTY):
 		return "speed detection requires a serial device"
 	default:
 		return err.Error()

--- a/internal/serialcmd/serialcmd.go
+++ b/internal/serialcmd/serialcmd.go
@@ -26,9 +26,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const summary = `[-h|--help] [-a|--all | -d|--serial-device path] [-i|--info]
+              [--packet-log path] [-s|--device-speed bps] [-t|--timeout seconds]
+              [-j|--jsonl]`
+
 const (
-	summary = `[-h|--help] [-j|--jsonl] [-i|--info] [-a|--all | -d|--serial-device path]
-              [-s|--device-speed bps] [-t|--timeout seconds] [--packet-log path]`
 	tryDuration    = 1250 * time.Millisecond
 	silentTryLimit = 5
 )
@@ -43,15 +45,15 @@ func (e commandError) Error() string { return e.msg }
 func (e commandError) ExitCode() int { return e.code }
 func (e commandError) Quiet() bool   { return e.quiet }
 
-type flags struct {
-	jsonl          bool
-	info           bool
+type flagVars struct {
 	all            bool
 	device         string
+	info           bool
+	packetLog      string
 	deviceSpeed    int
 	deviceSpeedSet bool
-	packetLog      string
 	timeout        time.Duration
+	jsonl          bool
 }
 
 type serialOperation uint8
@@ -114,7 +116,7 @@ func printInfo(f *os.File, info printer, jsonl bool) error {
 
 // Cmd executes the serial subcommand.
 func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, args []string) (usage string, err error) {
-	cfg, help, usageFunc, err := parseFlags(cmdName, args)
+	v, help, usageFunc, err := parseFlags(cmdName, args)
 	if err != nil {
 		return usageFunc(progName), err
 	}
@@ -122,22 +124,22 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 		return usageFunc(progName), nil
 	}
 	lg := cmd.NewDefaultLogger(logWriter, logLevel)
-	if cfg.info {
-		return "", enumerate(os.Stdout, cfg.jsonl, cfg.device)
+	if v.info {
+		return "", enumerate(os.Stdout, v.jsonl, v.device)
 	}
 	ctx, cancel := cmd.CancelOnSignal(context.Background(), lg)
 	defer cancel()
-	if cfg.all {
-		return "", scanPorts(ctx, lg, cfg.jsonl)
+	if v.all {
+		return "", scanPorts(ctx, lg, v.jsonl)
 	}
-	if cfg.deviceSpeedSet {
-		result := captureDevice(ctx, lg, cfg.device, cfg.deviceSpeed, cfg.packetLog, cfg.timeout)
+	if v.deviceSpeedSet {
+		result := captureDevice(ctx, lg, v.device, v.deviceSpeed, v.packetLog, v.timeout)
 		if code := result.exitCode(); code != 0 {
 			return "", commandError{msg: result.description(), code: code}
 		}
 		return "", nil
 	}
-	result := probeDevice(ctx, lg, cfg.device, cfg.packetLog)
+	result := detectDevice(ctx, lg, v.device, v.packetLog)
 	if ctx.Err() != nil {
 		return "", commandError{msg: "interrupted", code: 1}
 	}
@@ -145,41 +147,42 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 		return "", commandError{msg: result.description(), code: code}
 	}
 	info := speedInfo{Device: result.device, Speed: result.detection.Speed}
-	return "", printInfo(os.Stdout, &info, cfg.jsonl)
+	return "", printInfo(os.Stdout, &info, v.jsonl)
 }
 
-func parseFlags(cmdName string, args []string) (cfg flags, help bool, usageFunc func(string) string, err error) {
-	fs := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
+func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc func(string) string, err error) {
+	flags := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
+	flags.SortFlags = false
 	var timeoutSec float64
-	fs.BoolVarP(&cfg.jsonl, "jsonl", "j", false, "output in JSON Lines format instead of human-readable text")
-	fs.BoolVarP(&cfg.info, "info", "i", false, "describe target ports without opening them")
-	fs.BoolVarP(&cfg.all, "all", "a", false, "select all discovered serial ports")
-	fs.StringVarP(&cfg.device, "serial-device", "d", "", "select the serial device at `path`")
-	fs.IntVarP(&cfg.deviceSpeed, "device-speed", "s", 0, "set the serial device speed in `bps` (0 keeps the current speed)")
-	fs.Float64VarP(&timeoutSec, "timeout", "t", 0, "capture packets for `seconds` (0 = until interrupted)")
-	fs.StringVar(&cfg.packetLog, "packet-log", "", "write received packets and speed changes to a JSONL file")
-	fs.BoolVarP(&help, "help", "h", false, "show usage help for the serial command")
-	usageFunc = cmd.UsageFunc(cmdName, summary, fs)
-	if err = fs.Parse(args); err != nil || help {
+	flags.BoolVarP(&help, "help", "h", false, "show usage help for the serial command")
+	flags.BoolVarP(&v.all, "all", "a", false, "operate on all discovered serial ports")
+	flags.StringVarP(&v.device, "serial-device", "d", "", "operate on the serial port at `path`")
+	flags.BoolVarP(&v.info, "info", "i", false, "show information about serial ports without opening them")
+	flags.StringVar(&v.packetLog, "packet-log", "", "write received packets to a JSON Lines log at `path`")
+	flags.IntVarP(&v.deviceSpeed, "device-speed", "s", 0, "set the serial port speed to `bps` (0 uses the current speed)")
+	flags.Float64VarP(&timeoutSec, "timeout", "t", 0, "stop capturing packets after `seconds` (0 = until interrupted)")
+	flags.BoolVarP(&v.jsonl, "jsonl", "j", false, "write output in JSON Lines format")
+	usageFunc = cmd.UsageFunc(cmdName, summary, flags)
+	if err = flags.Parse(args); err != nil || help {
 		return
 	}
-	if fs.NArg() != 0 {
+	if flags.NArg() != 0 {
 		err = fmt.Errorf("serial command does not accept positional arguments")
 		return
 	}
-	deviceSet := fs.Lookup("serial-device").Changed
-	cfg.deviceSpeedSet = fs.Lookup("device-speed").Changed
-	timeoutSet := fs.Lookup("timeout").Changed
-	packetLogSet := fs.Lookup("packet-log").Changed
-	if deviceSet && cfg.device == "" {
+	deviceSet := flags.Lookup("serial-device").Changed
+	v.deviceSpeedSet = flags.Lookup("device-speed").Changed
+	timeoutSet := flags.Lookup("timeout").Changed
+	packetLogSet := flags.Lookup("packet-log").Changed
+	if deviceSet && v.device == "" {
 		err = fmt.Errorf("--serial-device must not be empty")
 		return
 	}
-	if cfg.all && deviceSet {
+	if v.all && deviceSet {
 		err = fmt.Errorf("--all cannot be combined with --serial-device")
 		return
 	}
-	if cfg.deviceSpeedSet && cfg.deviceSpeed < 0 {
+	if v.deviceSpeedSet && v.deviceSpeed < 0 {
 		err = fmt.Errorf("--device-speed must not be negative")
 		return
 	}
@@ -196,23 +199,23 @@ func parseFlags(cmdName string, args []string) (cfg flags, help bool, usageFunc 
 			return
 		}
 	}
-	if packetLogSet && cfg.packetLog == "" {
+	if packetLogSet && v.packetLog == "" {
 		err = fmt.Errorf("--packet-log must not be empty")
 		return
 	}
-	if cfg.info && (cfg.deviceSpeedSet || timeoutSet || packetLogSet) {
+	if v.info && (v.deviceSpeedSet || timeoutSet || packetLogSet) {
 		err = fmt.Errorf("--info cannot be combined with --device-speed, --timeout, or --packet-log")
 		return
 	}
-	if timeoutSet && (!cfg.deviceSpeedSet || !packetLogSet) {
+	if timeoutSet && (!v.deviceSpeedSet || !packetLogSet) {
 		err = fmt.Errorf("--timeout requires --device-speed and --packet-log")
 		return
 	}
-	if cfg.deviceSpeedSet && !deviceSet {
+	if v.deviceSpeedSet && !deviceSet {
 		err = fmt.Errorf("--device-speed requires --serial-device")
 		return
 	}
-	if cfg.deviceSpeedSet && !packetLogSet {
+	if v.deviceSpeedSet && !packetLogSet {
 		err = fmt.Errorf("--device-speed requires --packet-log")
 		return
 	}
@@ -221,11 +224,11 @@ func parseFlags(cmdName string, args []string) (cfg flags, help bool, usageFunc 
 		return
 	}
 	if timeoutSet {
-		cfg.timeout = ptime.Seconds(timeoutSec)
+		v.timeout = ptime.Seconds(timeoutSec)
 	}
-	if !deviceSet && !cfg.all {
-		cfg.info = true
-		cfg.all = true
+	if !deviceSet && !v.all {
+		v.info = true
+		v.all = true
 	}
 	return
 }
@@ -283,13 +286,13 @@ func printPorts(f *os.File, ports []serialenum.Port, jsonl bool) error {
 	return nil
 }
 
-type probeResult struct {
+type detectResult struct {
 	device    string
 	detection gpsio.DetectResult
 	failure   string
 }
 
-func (r probeResult) exitCode() int {
+func (r detectResult) exitCode() int {
 	if r.failure != "" {
 		return 1
 	}
@@ -302,9 +305,9 @@ func (r probeResult) exitCode() int {
 	return 1
 }
 
-// description explains an unsuccessful probe: either why detection could not
+// description explains an unsuccessful detection: either why detection could not
 // run, or what the device did instead of producing a speed.
-func (r probeResult) description() string {
+func (r detectResult) description() string {
 	if r.failure != "" {
 		return r.failure
 	}
@@ -314,7 +317,7 @@ func (r probeResult) description() string {
 	return "output was received, but no known GNSS protocol was validated at a candidate speed"
 }
 
-func probeDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath string) (result probeResult) {
+func detectDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath string) (result detectResult) {
 	result.device = device
 	conn, _, err := gpsio.OpenSerial(device, 0)
 	if err != nil {
@@ -483,18 +486,18 @@ func scanPorts(ctx context.Context, lg *slog.Logger, jsonl bool) error {
 	if len(ports) == 0 {
 		return commandError{msg: "no serial ports found", code: 2}
 	}
-	return scanPortList(ctx, lg, ports, probeDevice, os.Stdout, os.Stderr, jsonl)
+	return scanPortList(ctx, lg, ports, detectDevice, os.Stdout, os.Stderr, jsonl)
 }
 
-type probeFunc func(context.Context, *slog.Logger, string, string) probeResult
+type detectFunc func(context.Context, *slog.Logger, string, string) detectResult
 
-func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port, probe probeFunc, stdout *os.File, stderr io.Writer, jsonl bool) error {
-	resultCh := make(chan probeResult, len(ports))
+func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port, detect detectFunc, stdout *os.File, stderr io.Writer, jsonl bool) error {
+	resultCh := make(chan detectResult, len(ports))
 	var wg sync.WaitGroup
 	for _, port := range ports {
 		device := port.Device
 		wg.Go(func() {
-			resultCh <- probe(ctx, lg.With("device", device), device, "")
+			resultCh <- detect(ctx, lg.With("device", device), device, "")
 		})
 	}
 	go func() {
@@ -517,7 +520,7 @@ func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port,
 		if code == 2 && bestCode != 0 {
 			bestCode = 2
 		}
-		// An interrupt fails every probe still running, so describing each one
+		// An interrupt fails every detection still running, so describing each one
 		// would bury the interrupt in noise.
 		if ctx.Err() != nil {
 			continue

--- a/internal/serialcmd/serialcmd.go
+++ b/internal/serialcmd/serialcmd.go
@@ -148,6 +148,9 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 		case timeoutSec >= float64(math.MaxInt64)/float64(time.Second):
 			err = fmt.Errorf("--timeout is too large")
 			return
+		case timeoutSec > 0 && ptime.Seconds(timeoutSec) == 0:
+			err = fmt.Errorf("--timeout is too small")
+			return
 		}
 	}
 	if packetLogSet && v.packetLog == "" {

--- a/internal/serialcmd/serialcmd.go
+++ b/internal/serialcmd/serialcmd.go
@@ -26,25 +26,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const summary = `[-h|--help] [-a|--all | -d|--serial-device path] [-i|--info]
-              [--packet-log path] [-s|--device-speed bps] [-t|--timeout seconds]
-              [-j|--jsonl]`
-
-const (
-	tryDuration    = 1250 * time.Millisecond
-	silentTryLimit = 5
-)
-
-type commandError struct {
-	msg   string
-	code  int
-	quiet bool
-}
-
-func (e commandError) Error() string { return e.msg }
-func (e commandError) ExitCode() int { return e.code }
-func (e commandError) Quiet() bool   { return e.quiet }
-
 type flagVars struct {
 	all            bool
 	device         string
@@ -56,34 +37,21 @@ type flagVars struct {
 	jsonl          bool
 }
 
-type serialOperation uint8
-
-const (
-	serialDetect serialOperation = iota
-	serialCapture
-)
-
-type printer interface {
-	Print(*os.File) error
+type commandError struct {
+	msg   string
+	code  int
+	quiet bool
 }
 
-type portInfo serialenum.Port
+type captureResult struct {
+	packets int
+	failure string
+}
 
-func (info *portInfo) Print(f *os.File) error {
-	var b strings.Builder
-	fmt.Fprintf(&b, "device=%s", info.Device)
-	if info.USB != (serialenum.USBID{}) {
-		fmt.Fprintf(&b, " vid=%04x pid=%04x", info.USB.VID, info.USB.PID)
-	}
-	if info.Serial != "" {
-		fmt.Fprintf(&b, " serial=%q", info.Serial)
-	}
-	for _, alias := range info.Aliases {
-		fmt.Fprintf(&b, " alias=%s", alias)
-	}
-	fmt.Fprintf(&b, " display=%q", info.Display)
-	_, err := fmt.Fprintln(f, b.String())
-	return err
+type detectResult struct {
+	device    string
+	detection gpsio.DetectResult
+	failure   string
 }
 
 type speedInfo struct {
@@ -91,27 +59,6 @@ type speedInfo struct {
 	Speed  int    `json:"speed"`
 
 	printDevice bool
-}
-
-func (info *speedInfo) Print(f *os.File) error {
-	if !info.printDevice {
-		_, err := fmt.Fprintln(f, info.Speed)
-		return err
-	}
-	_, err := fmt.Fprintf(f, "%s %d\n", info.Device, info.Speed)
-	return err
-}
-
-func printInfo(f *os.File, info printer, jsonl bool) error {
-	if !jsonl {
-		return info.Print(f)
-	}
-	b, err := json.Marshal(info)
-	if err != nil {
-		return fmt.Errorf("encoding serial output: %w", err)
-	}
-	_, err = fmt.Fprintln(f, string(b))
-	return err
 }
 
 // Cmd executes the serial subcommand.
@@ -149,6 +96,10 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 	info := speedInfo{Device: result.device, Speed: result.detection.Speed}
 	return "", printInfo(os.Stdout, &info, v.jsonl)
 }
+
+const summary = `[-h|--help] [-a|--all | -d|--serial-device path] [-i|--info]
+              [--packet-log path] [-s|--device-speed bps] [-t|--timeout seconds]
+              [-j|--jsonl]`
 
 func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc func(string) string, err error) {
 	flags := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
@@ -276,6 +227,8 @@ func matchPort(ports []serialenum.Port, path string) (serialenum.Port, bool) {
 	return serialenum.Port{}, false
 }
 
+type portInfo serialenum.Port
+
 func printPorts(f *os.File, ports []serialenum.Port, jsonl bool) error {
 	for _, port := range ports {
 		info := portInfo(port)
@@ -286,111 +239,117 @@ func printPorts(f *os.File, ports []serialenum.Port, jsonl bool) error {
 	return nil
 }
 
-type detectResult struct {
-	device    string
-	detection gpsio.DetectResult
-	failure   string
+func (info *portInfo) Print(f *os.File) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "device=%s", info.Device)
+	if info.USB != (serialenum.USBID{}) {
+		fmt.Fprintf(&b, " vid=%04x pid=%04x", info.USB.VID, info.USB.PID)
+	}
+	if info.Serial != "" {
+		fmt.Fprintf(&b, " serial=%q", info.Serial)
+	}
+	for _, alias := range info.Aliases {
+		fmt.Fprintf(&b, " alias=%s", alias)
+	}
+	fmt.Fprintf(&b, " display=%q", info.Display)
+	_, err := fmt.Fprintln(f, b.String())
+	return err
 }
 
-func (r detectResult) exitCode() int {
-	if r.failure != "" {
-		return 1
+func (info *speedInfo) Print(f *os.File) error {
+	if !info.printDevice {
+		_, err := fmt.Fprintln(f, info.Speed)
+		return err
 	}
-	switch r.detection.Outcome {
-	case gpsio.DetectFound:
-		return 0
-	case gpsio.DetectSilent:
-		return 2
-	}
-	return 1
+	_, err := fmt.Fprintf(f, "%s %d\n", info.Device, info.Speed)
+	return err
 }
 
-// description explains an unsuccessful detection: either why detection could not
-// run, or what the device did instead of producing a speed.
-func (r detectResult) description() string {
-	if r.failure != "" {
-		return r.failure
-	}
-	if r.detection.Outcome == gpsio.DetectSilent {
-		return "no output received from the device"
-	}
-	return "output was received, but no known GNSS protocol was validated at a candidate speed"
+type printer interface {
+	Print(*os.File) error
 }
 
-func detectDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath string) (result detectResult) {
-	result.device = device
-	conn, _, err := gpsio.OpenSerial(device, 0)
+func printInfo(f *os.File, info printer, jsonl bool) error {
+	if !jsonl {
+		return info.Print(f)
+	}
+	b, err := json.Marshal(info)
 	if err != nil {
-		result.failure = serialDetect.describeError(err)
-		return
+		return fmt.Errorf("encoding serial output: %w", err)
 	}
+	_, err = fmt.Fprintln(f, string(b))
+	return err
+}
 
-	formats := gpsreg.CreatePacketFormats(nil)
+func scanPorts(ctx context.Context, lg *slog.Logger, jsonl bool) error {
+	ports, err := serialenum.List()
+	if err != nil {
+		return err
+	}
+	if len(ports) == 0 {
+		return commandError{msg: "no serial ports found", code: 2}
+	}
+	return scanPortList(ctx, lg, ports, detectDevice, os.Stdout, os.Stderr, jsonl)
+}
+
+type detectFunc func(context.Context, *slog.Logger, string, string) detectResult
+
+func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port, detect detectFunc, stdout *os.File, stderr io.Writer, jsonl bool) error {
+	resultCh := make(chan detectResult, len(ports))
 	var wg sync.WaitGroup
-	pktLog, logFile, err := gpsio.LogPackets(lg, &wg, packetLogPath, false, formats)
-	if err != nil {
-		result.failure = "opening packet log: " + err.Error()
-		closeDevice(lg, conn, device, &result.failure)
-		return
+	for _, port := range ports {
+		device := port.Device
+		wg.Go(func() {
+			resultCh <- detect(ctx, lg.With("device", device), device, "")
+		})
 	}
-	if pktLog != nil {
-		conn.SetPacketLog(pktLog)
-	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
 
-	// Detection owns signal cancellation: DetectSpeed honors ctx itself. The
-	// scan worker gets a context of its own so that Ctrl-C cannot close the
-	// packet channel under the window DetectSpeed is still consuming.
-	scanCtx, cancelScan := context.WithCancel(context.Background())
-	packetCh := make(chan scan.Packet, 1)
-	wg.Go(func() { gpsio.Scan(scanCtx, lg, conn, packetCh, pktLog, formats) })
-
-	result.detection, err = gpsio.DetectSpeed(
-		ctx,
-		lg,
-		packetCh,
-		conn,
-		gpsreg.CreatePacketProcessors(nil),
-		gpsio.DefaultSpeedList(),
-		tryDuration,
-		func(tried []int) bool { return len(tried) >= silentTryLimit },
-	)
-	if err != nil {
-		result.failure = serialDetect.describeError(err)
+	bestCode := 1
+	var outputErr error
+	for result := range resultCh {
+		code := result.exitCode()
+		if code == 0 {
+			bestCode = 0
+			info := speedInfo{Device: result.device, Speed: result.detection.Speed, printDevice: true}
+			if err := printInfo(stdout, &info, jsonl); err != nil && outputErr == nil {
+				outputErr = err
+			}
+			continue
+		}
+		if code == 2 && bestCode != 0 {
+			bestCode = 2
+		}
+		// An interrupt fails every detection still running, so describing each one
+		// would bury the interrupt in noise.
+		if ctx.Err() != nil {
+			continue
+		}
+		if _, err := fmt.Fprintf(stderr, "%s: %s\n", result.device, result.description()); err != nil && outputErr == nil {
+			outputErr = err
+		}
 	}
-
-	conn.Stop()
-	cancelScan()
-	for range packetCh {
+	if outputErr != nil {
+		return commandError{msg: fmt.Sprintf("writing serial scan output: %v", outputErr), code: 1}
 	}
-	wg.Wait()
-	if logFile != nil {
-		logFile.Close(lg)
+	if ctx.Err() != nil {
+		return commandError{msg: "serial scan interrupted", code: 1, quiet: true}
 	}
-	closeDevice(lg, conn, device, &result.failure)
-	return
+	if bestCode == 0 {
+		return nil
+	}
+	return commandError{msg: "serial scan did not detect a device", code: bestCode, quiet: true}
 }
 
-type captureResult struct {
-	packets int
-	failure string
-}
+type serialOperation uint8
 
-func (r captureResult) exitCode() int {
-	if r.failure != "" {
-		return 1
-	}
-	if r.packets == 0 {
-		return 2
-	}
-	return 0
-}
-
-func (r captureResult) description() string {
-	if r.failure != "" {
-		return r.failure
-	}
-	return "no output received from the device"
-}
+const (
+	serialDetect serialOperation = iota
+	serialCapture
+)
 
 func captureDevice(ctx context.Context, lg *slog.Logger, device string, speed int, packetLogPath string, timeout time.Duration) (result captureResult) {
 	conn, _, err := gpsio.OpenSerial(device, speed)
@@ -464,6 +423,106 @@ func capturePackets(ctx context.Context, lg *slog.Logger, packetCh <-chan scan.P
 	}
 }
 
+func (r captureResult) exitCode() int {
+	if r.failure != "" {
+		return 1
+	}
+	if r.packets == 0 {
+		return 2
+	}
+	return 0
+}
+
+func (r captureResult) description() string {
+	if r.failure != "" {
+		return r.failure
+	}
+	return "no output received from the device"
+}
+
+const (
+	tryDuration    = 1250 * time.Millisecond
+	silentTryLimit = 5
+)
+
+func detectDevice(ctx context.Context, lg *slog.Logger, device, packetLogPath string) (result detectResult) {
+	result.device = device
+	conn, _, err := gpsio.OpenSerial(device, 0)
+	if err != nil {
+		result.failure = serialDetect.describeError(err)
+		return
+	}
+
+	formats := gpsreg.CreatePacketFormats(nil)
+	var wg sync.WaitGroup
+	pktLog, logFile, err := gpsio.LogPackets(lg, &wg, packetLogPath, false, formats)
+	if err != nil {
+		result.failure = "opening packet log: " + err.Error()
+		closeDevice(lg, conn, device, &result.failure)
+		return
+	}
+	if pktLog != nil {
+		conn.SetPacketLog(pktLog)
+	}
+
+	// Detection owns signal cancellation: DetectSpeed honors ctx itself. The
+	// scan worker gets a context of its own so that Ctrl-C cannot close the
+	// packet channel under the window DetectSpeed is still consuming.
+	scanCtx, cancelScan := context.WithCancel(context.Background())
+	packetCh := make(chan scan.Packet, 1)
+	wg.Go(func() { gpsio.Scan(scanCtx, lg, conn, packetCh, pktLog, formats) })
+
+	result.detection, err = gpsio.DetectSpeed(
+		ctx,
+		lg,
+		packetCh,
+		conn,
+		gpsreg.CreatePacketProcessors(nil),
+		gpsio.DefaultSpeedList(),
+		tryDuration,
+		func(tried []int) bool { return len(tried) >= silentTryLimit },
+	)
+	if err != nil {
+		result.failure = serialDetect.describeError(err)
+	}
+
+	conn.Stop()
+	cancelScan()
+	for range packetCh {
+	}
+	wg.Wait()
+	if logFile != nil {
+		logFile.Close(lg)
+	}
+	closeDevice(lg, conn, device, &result.failure)
+	return
+}
+
+func (r detectResult) exitCode() int {
+	if r.failure != "" {
+		return 1
+	}
+	switch r.detection.Outcome {
+	case gpsio.DetectFound:
+		return 0
+	case gpsio.DetectSilent:
+		return 2
+	}
+	return 1
+}
+
+// description explains an unsuccessful detection: either why detection could not
+// run, or what the device did instead of producing a speed.
+func (r detectResult) description() string {
+	if r.failure != "" {
+		return r.failure
+	}
+	if r.detection.Outcome == gpsio.DetectSilent {
+		return "no output received from the device"
+	}
+	return "output was received, but no known GNSS protocol was validated at a candidate speed"
+}
+
 // closeDevice closes conn, keeping the close error only when the read
 // operation itself produced none. An existing failure is more relevant.
 func closeDevice(lg *slog.Logger, conn *gpsio.SerialConn, device string, failure *string) {
@@ -476,69 +535,6 @@ func closeDevice(lg *slog.Logger, conn *gpsio.SerialConn, device string, failure
 		return
 	}
 	lg.Debug("closing the serial device failed after an unsuccessful read", "device", device, "error", closeErr)
-}
-
-func scanPorts(ctx context.Context, lg *slog.Logger, jsonl bool) error {
-	ports, err := serialenum.List()
-	if err != nil {
-		return err
-	}
-	if len(ports) == 0 {
-		return commandError{msg: "no serial ports found", code: 2}
-	}
-	return scanPortList(ctx, lg, ports, detectDevice, os.Stdout, os.Stderr, jsonl)
-}
-
-type detectFunc func(context.Context, *slog.Logger, string, string) detectResult
-
-func scanPortList(ctx context.Context, lg *slog.Logger, ports []serialenum.Port, detect detectFunc, stdout *os.File, stderr io.Writer, jsonl bool) error {
-	resultCh := make(chan detectResult, len(ports))
-	var wg sync.WaitGroup
-	for _, port := range ports {
-		device := port.Device
-		wg.Go(func() {
-			resultCh <- detect(ctx, lg.With("device", device), device, "")
-		})
-	}
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
-
-	bestCode := 1
-	var outputErr error
-	for result := range resultCh {
-		code := result.exitCode()
-		if code == 0 {
-			bestCode = 0
-			info := speedInfo{Device: result.device, Speed: result.detection.Speed, printDevice: true}
-			if err := printInfo(stdout, &info, jsonl); err != nil && outputErr == nil {
-				outputErr = err
-			}
-			continue
-		}
-		if code == 2 && bestCode != 0 {
-			bestCode = 2
-		}
-		// An interrupt fails every detection still running, so describing each one
-		// would bury the interrupt in noise.
-		if ctx.Err() != nil {
-			continue
-		}
-		if _, err := fmt.Fprintf(stderr, "%s: %s\n", result.device, result.description()); err != nil && outputErr == nil {
-			outputErr = err
-		}
-	}
-	if outputErr != nil {
-		return commandError{msg: fmt.Sprintf("writing serial scan output: %v", outputErr), code: 1}
-	}
-	if ctx.Err() != nil {
-		return commandError{msg: "serial scan interrupted", code: 1, quiet: true}
-	}
-	if bestCode == 0 {
-		return nil
-	}
-	return commandError{msg: "serial scan did not detect a device", code: bestCode, quiet: true}
 }
 
 func (op serialOperation) describeError(err error) string {
@@ -560,3 +556,7 @@ func isLocked(err error) bool {
 	var locked term.LockedError
 	return errors.As(err, &locked) && locked.Locked()
 }
+
+func (e commandError) Error() string { return e.msg }
+func (e commandError) ExitCode() int { return e.code }
+func (e commandError) Quiet() bool   { return e.quiet }

--- a/internal/serialcmd/serialcmd_linux_test.go
+++ b/internal/serialcmd/serialcmd_linux_test.go
@@ -33,10 +33,10 @@ func TestSelectPortSymlink(t *testing.T) {
 	}
 }
 
-// TestProbeDevicePTY covers the probe lifecycle that the detection tests below
+// TestDetectDevicePTY covers the detection lifecycle that the tests below
 // the command layer do not reach: the scan worker, the packet log's two
 // SemiClose paths, the drain of the packet channel, and the close.
-func TestProbeDevicePTY(t *testing.T) {
+func TestDetectDevicePTY(t *testing.T) {
 	master, device := openTestPTY(t)
 	logPath := filepath.Join(t.TempDir(), "capture.jsonl")
 	writeCtx, cancelWrite := context.WithCancel(context.Background())
@@ -55,15 +55,15 @@ func TestProbeDevicePTY(t *testing.T) {
 			}
 		}
 	})
-	result := probeDevice(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), device, logPath)
+	result := detectDevice(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), device, logPath)
 	cancelWrite()
 	wg.Wait()
 
 	if result.failure != "" {
-		t.Fatalf("probeDevice() failure = %q", result.failure)
+		t.Fatalf("detectDevice() failure = %q", result.failure)
 	}
 	if result.detection.Outcome != gpsio.DetectFound || result.detection.Speed == 0 {
-		t.Fatalf("probeDevice() detection = %+v, want a detected speed", result.detection)
+		t.Fatalf("detectDevice() detection = %+v, want a detected speed", result.detection)
 	}
 	if result.device != device {
 		t.Errorf("device = %q, want %q", result.device, device)

--- a/internal/serialcmd/serialcmd_linux_test.go
+++ b/internal/serialcmd/serialcmd_linux_test.go
@@ -77,6 +77,62 @@ func TestProbeDevicePTY(t *testing.T) {
 	}
 }
 
+func TestCaptureDevicePTY(t *testing.T) {
+	master, device := openTestPTY(t)
+	logPath := filepath.Join(t.TempDir(), "capture.jsonl")
+	writeCtx, cancelWrite := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		ticker := time.NewTicker(25 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-writeCtx.Done():
+				return
+			case <-ticker.C:
+				if _, err := master.Write([]byte("$GPGGA,,,,,,0,00,99.99,,,,,,*48\r\n")); err != nil {
+					return
+				}
+			}
+		}
+	})
+	result := captureDevice(
+		context.Background(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		device,
+		38400,
+		logPath,
+		100*time.Millisecond,
+	)
+	cancelWrite()
+	wg.Wait()
+	if result.failure != "" || result.packets == 0 {
+		t.Fatalf("captureDevice() = %+v, want captured packets", result)
+	}
+	pktLog, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(pktLog), "GPGGA") {
+		t.Errorf("packet log does not hold the sentence sent:\n%s", pktLog)
+	}
+}
+
+func TestCaptureDeviceNoPackets(t *testing.T) {
+	_, device := openTestPTY(t)
+	result := captureDevice(
+		context.Background(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		device,
+		0,
+		"",
+		25*time.Millisecond,
+	)
+	if code := result.exitCode(); code != 2 {
+		t.Fatalf("captureDevice() = %+v, want exit code 2", result)
+	}
+}
+
 func openTestPTY(t *testing.T) (*os.File, string) {
 	t.Helper()
 	fd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)

--- a/internal/serialcmd/serialcmd_test.go
+++ b/internal/serialcmd/serialcmd_test.go
@@ -53,6 +53,7 @@ func TestParseFlags(t *testing.T) {
 		{name: "NaN timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "NaN"}, wantErr: true},
 		{name: "infinite timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "+Inf"}, wantErr: true},
 		{name: "overflowing timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1e20"}, wantErr: true},
+		{name: "underflowing timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1e-10"}, wantErr: true},
 		{name: "empty device", args: []string{"--serial-device", ""}, wantErr: true},
 		{name: "empty packet log", args: []string{"--serial-device", "/dev/ttyS0", "--packet-log", ""}, wantErr: true},
 	} {

--- a/internal/serialcmd/serialcmd_test.go
+++ b/internal/serialcmd/serialcmd_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
 	"github.com/jclark/satpulse/gps/lib/term"
+	"github.com/jclark/satpulse/gps/scan"
 )
 
 func TestParseFlags(t *testing.T) {
@@ -23,19 +25,36 @@ func TestParseFlags(t *testing.T) {
 		wantErr  bool
 		wantHelp bool
 	}{
-		{name: "describe all"},
-		{name: "jsonl", args: []string{"-j"}, want: flags{jsonl: true}},
-		{name: "describe selected", args: []string{"/dev/ttyS0"}, want: flags{port: "/dev/ttyS0"}},
-		{name: "jsonl selected", args: []string{"-j", "/dev/ttyS0"}, want: flags{jsonl: true, port: "/dev/ttyS0"}},
-		{name: "detect all", args: []string{"-s"}, want: flags{detect: true}},
-		{name: "detect all JSONL", args: []string{"-j", "-s"}, want: flags{jsonl: true, detect: true}},
-		{name: "detect selected", args: []string{"--detect-speed", "--packet-log", "capture.jsonl", "/dev/ttyS0"}, want: flags{detect: true, packetLog: "capture.jsonl", port: "/dev/ttyS0"}},
-		{name: "detect selected JSONL", args: []string{"-j", "-s", "--packet-log", "capture.jsonl", "/dev/ttyS0"}, want: flags{jsonl: true, detect: true, packetLog: "capture.jsonl", port: "/dev/ttyS0"}},
+		{name: "default info all", want: flags{info: true, all: true}},
+		{name: "jsonl info all", args: []string{"-j"}, want: flags{jsonl: true, info: true, all: true}},
+		{name: "explicit info all", args: []string{"-i"}, want: flags{info: true, all: true}},
+		{name: "info selected", args: []string{"-i", "-d", "/dev/ttyS0"}, want: flags{info: true, device: "/dev/ttyS0"}},
+		{name: "detect all", args: []string{"-a"}, want: flags{all: true}},
+		{name: "detect selected", args: []string{"-d", "/dev/ttyS0"}, want: flags{device: "/dev/ttyS0"}},
+		{name: "detect with packet log", args: []string{"-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{device: "/dev/ttyS0", packetLog: "capture.jsonl"}},
+		{name: "capture at speed", args: []string{"-j", "-s", "38400", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{jsonl: true, device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl"}},
+		{name: "timed capture", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1.25"}, want: flags{device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl", timeout: 1250 * time.Millisecond}},
+		{name: "capture at current speed", args: []string{"-s", "0", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{device: "/dev/ttyS0", deviceSpeedSet: true, packetLog: "capture.jsonl"}},
 		{name: "help", args: []string{"-h"}, wantHelp: true},
-		{name: "too many ports", args: []string{"one", "two"}, wantErr: true},
-		{name: "packet log without detection", args: []string{"--packet-log", "capture.jsonl", "/dev/ttyS0"}, wantErr: true},
-		{name: "packet log without port", args: []string{"-s", "--packet-log", "capture.jsonl"}, wantErr: true},
-		{name: "empty port", args: []string{"--detect-speed", ""}, wantErr: true},
+		{name: "positional port", args: []string{"/dev/ttyS0"}, wantErr: true},
+		{name: "all and device", args: []string{"-a", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "info and speed", args: []string{"-i", "-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "info and packet log", args: []string{"-i", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "info and timeout", args: []string{"-i", "-d", "/dev/ttyS0", "-t", "1"}, wantErr: true},
+		{name: "speed without device", args: []string{"-s", "38400", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "speed with all", args: []string{"-a", "-s", "38400", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "speed without capture", args: []string{"-d", "/dev/ttyS0", "-s", "38400"}, wantErr: true},
+		{name: "negative speed", args: []string{"-d", "/dev/ttyS0", "-s", "-1", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "non-numeric speed", args: []string{"-d", "/dev/ttyS0", "-s", "auto", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "packet log without device", args: []string{"-a", "--packet-log", "capture.jsonl"}, wantErr: true},
+		{name: "timeout without capture", args: []string{"-d", "/dev/ttyS0", "-t", "1"}, wantErr: true},
+		{name: "timeout with detection", args: []string{"-d", "/dev/ttyS0", "--packet-log", "capture.jsonl", "-t", "1"}, wantErr: true},
+		{name: "negative timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "-1"}, wantErr: true},
+		{name: "NaN timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "NaN"}, wantErr: true},
+		{name: "infinite timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "+Inf"}, wantErr: true},
+		{name: "overflowing timeout", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1e20"}, wantErr: true},
+		{name: "empty device", args: []string{"--serial-device", ""}, wantErr: true},
+		{name: "empty packet log", args: []string{"--serial-device", "/dev/ttyS0", "--packet-log", ""}, wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, help, _, err := parseFlags("serial", tc.args)
@@ -70,6 +89,20 @@ func TestCmdUsageError(t *testing.T) {
 	}
 }
 
+func TestParseFlagsTimeoutDependencies(t *testing.T) {
+	const want = "--timeout requires --device-speed and --packet-log"
+	for _, args := range [][]string{
+		{"-d", "/dev/ttyS0", "-t", "1"},
+		{"-d", "/dev/ttyS0", "-s", "38400", "-t", "1"},
+		{"-d", "/dev/ttyS0", "--packet-log", "capture.jsonl", "-t", "1"},
+	} {
+		_, _, _, err := parseFlags("serial", args)
+		if err == nil || err.Error() != want {
+			t.Errorf("parseFlags(%q) error = %v, want %q", args, err, want)
+		}
+	}
+}
+
 func TestPrintPorts(t *testing.T) {
 	ports := []serialenum.Port{
 		{Device: "/dev/ttyS0", Display: "/dev/ttyS0"},
@@ -78,6 +111,7 @@ func TestPrintPorts(t *testing.T) {
 			Display: "/dev/ttyACM0 (/dev/gps0, u-blox gen 10)",
 			USB:     serialenum.USBID{VID: 0x1546, PID: 0x01a4},
 			Serial:  "BG02DBNX",
+			Aliases: []string{"/dev/gps0"},
 		},
 	}
 	for _, tc := range []struct {
@@ -87,12 +121,13 @@ func TestPrintPorts(t *testing.T) {
 	}{
 		{
 			name: "human",
-			want: "/dev/ttyS0\n/dev/ttyACM0 (/dev/gps0, u-blox gen 10) serial=\"BG02DBNX\"\n",
+			want: "device=/dev/ttyS0 display=\"/dev/ttyS0\"\n" +
+				"device=/dev/ttyACM0 vid=1546 pid=01a4 serial=\"BG02DBNX\" alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\"\n",
 		},
 		{
 			name:  "jsonl",
 			jsonl: true,
-			want:  "{\"device\":\"/dev/ttyS0\",\"display\":\"/dev/ttyS0\"}\n{\"device\":\"/dev/ttyACM0\",\"display\":\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\",\"usb\":{\"vid\":5446,\"pid\":420},\"serial\":\"BG02DBNX\"}\n",
+			want:  "{\"device\":\"/dev/ttyS0\",\"display\":\"/dev/ttyS0\"}\n{\"device\":\"/dev/ttyACM0\",\"display\":\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\",\"usb\":{\"vid\":5446,\"pid\":420},\"serial\":\"BG02DBNX\",\"aliases\":[\"/dev/gps0\"]}\n",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -118,9 +153,9 @@ func TestPrintPortInfo(t *testing.T) {
 		want     string
 		wantCode int
 	}{
-		{name: "all", want: "/dev/ttyS0\n/dev/ttyACM0 (/dev/gps0) serial=\"BG02DBNX\"\n"},
-		{name: "device", selector: "/dev/ttyACM0", want: "/dev/ttyACM0 (/dev/gps0) serial=\"BG02DBNX\"\n"},
-		{name: "alias", selector: "/dev/gps0", want: "/dev/ttyACM0 (/dev/gps0) serial=\"BG02DBNX\"\n"},
+		{name: "all", want: "device=/dev/ttyS0 display=\"/dev/ttyS0\"\ndevice=/dev/ttyACM0 serial=\"BG02DBNX\" alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0)\"\n"},
+		{name: "device", selector: "/dev/ttyACM0", want: "device=/dev/ttyACM0 serial=\"BG02DBNX\" alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0)\"\n"},
+		{name: "alias", selector: "/dev/gps0", want: "device=/dev/ttyACM0 serial=\"BG02DBNX\" alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0)\"\n"},
 		{name: "unmatched", selector: "/dev/ttyUSB0", wantCode: 2},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -211,19 +246,58 @@ func TestProbeResultDescription(t *testing.T) {
 	}
 }
 
-func TestDescribeSerialError(t *testing.T) {
+func TestCaptureResult(t *testing.T) {
 	for _, tc := range []struct {
+		name     string
+		result   captureResult
+		wantCode int
+		wantDesc string
+	}{
+		{name: "packets", result: captureResult{packets: 3}},
+		{name: "no packets", wantCode: 2, wantDesc: "no output received from the device"},
+		{name: "failure", result: captureResult{failure: "device is locked"}, wantCode: 1, wantDesc: "device is locked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.result.exitCode(); got != tc.wantCode {
+				t.Errorf("exitCode() = %d, want %d", got, tc.wantCode)
+			}
+			if tc.wantCode != 0 {
+				if got := tc.result.description(); got != tc.wantDesc {
+					t.Errorf("description() = %q, want %q", got, tc.wantDesc)
+				}
+			}
+		})
+	}
+}
+
+func TestCapturePacketsInputEnded(t *testing.T) {
+	packetCh := make(chan scan.Packet, 1)
+	packetCh <- scan.Packet{Data: "packet"}
+	close(packetCh)
+	count, err := capturePackets(context.Background(), slog.Default(), packetCh, time.Second)
+	if err == nil || err.Error() != "serial input ended unexpectedly" {
+		t.Fatalf("capturePackets() error = %v, want serial input ended unexpectedly", err)
+	}
+	if count != 1 {
+		t.Errorf("capturePackets() count = %d, want 1", count)
+	}
+}
+
+func TestSerialOperationDescribeError(t *testing.T) {
+	for _, tc := range []struct {
+		op   serialOperation
 		err  error
 		want string
 	}{
-		{context.Canceled, "interrupted"},
-		{fmtWrap(os.ErrPermission), "permission denied; add this user to the serial-port access group (usually dialout)"},
-		{fmtWrap(testLockedError{}), "device is locked by another process"},
-		{term.ErrNotATTY, "speed detection requires a serial device"},
-		{errors.New("gone"), "gone"},
+		{serialCapture, context.Canceled, "interrupted"},
+		{serialCapture, fmtWrap(os.ErrPermission), "permission denied; add this user to the serial-port access group (usually dialout)"},
+		{serialCapture, fmtWrap(testLockedError{}), "device is locked by another process"},
+		{serialDetect, term.ErrNotATTY, "speed detection requires a serial device"},
+		{serialCapture, term.ErrNotATTY, "not a serial device"},
+		{serialCapture, errors.New("gone"), "gone"},
 	} {
-		if got := describeSerialError(tc.err); got != tc.want {
-			t.Errorf("describeSerialError(%v) = %q, want %q", tc.err, got, tc.want)
+		if got := tc.op.describeError(tc.err); got != tc.want {
+			t.Errorf("describeError(%v) = %q, want %q", tc.err, got, tc.want)
 		}
 	}
 }

--- a/internal/serialcmd/serialcmd_test.go
+++ b/internal/serialcmd/serialcmd_test.go
@@ -21,20 +21,20 @@ func TestParseFlags(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		args     []string
-		want     flags
+		want     flagVars
 		wantErr  bool
 		wantHelp bool
 	}{
-		{name: "default info all", want: flags{info: true, all: true}},
-		{name: "jsonl info all", args: []string{"-j"}, want: flags{jsonl: true, info: true, all: true}},
-		{name: "explicit info all", args: []string{"-i"}, want: flags{info: true, all: true}},
-		{name: "info selected", args: []string{"-i", "-d", "/dev/ttyS0"}, want: flags{info: true, device: "/dev/ttyS0"}},
-		{name: "detect all", args: []string{"-a"}, want: flags{all: true}},
-		{name: "detect selected", args: []string{"-d", "/dev/ttyS0"}, want: flags{device: "/dev/ttyS0"}},
-		{name: "detect with packet log", args: []string{"-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{device: "/dev/ttyS0", packetLog: "capture.jsonl"}},
-		{name: "capture at speed", args: []string{"-j", "-s", "38400", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{jsonl: true, device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl"}},
-		{name: "timed capture", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1.25"}, want: flags{device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl", timeout: 1250 * time.Millisecond}},
-		{name: "capture at current speed", args: []string{"-s", "0", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flags{device: "/dev/ttyS0", deviceSpeedSet: true, packetLog: "capture.jsonl"}},
+		{name: "default info all", want: flagVars{info: true, all: true}},
+		{name: "jsonl info all", args: []string{"-j"}, want: flagVars{jsonl: true, info: true, all: true}},
+		{name: "explicit info all", args: []string{"-i"}, want: flagVars{info: true, all: true}},
+		{name: "info selected", args: []string{"-i", "-d", "/dev/ttyS0"}, want: flagVars{info: true, device: "/dev/ttyS0"}},
+		{name: "detect all", args: []string{"-a"}, want: flagVars{all: true}},
+		{name: "detect selected", args: []string{"-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0"}},
+		{name: "detect with packet log", args: []string{"-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flagVars{device: "/dev/ttyS0", packetLog: "capture.jsonl"}},
+		{name: "capture at speed", args: []string{"-j", "-s", "38400", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flagVars{jsonl: true, device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl"}},
+		{name: "timed capture", args: []string{"-d", "/dev/ttyS0", "-s", "38400", "--packet-log", "capture.jsonl", "-t", "1.25"}, want: flagVars{device: "/dev/ttyS0", deviceSpeed: 38400, deviceSpeedSet: true, packetLog: "capture.jsonl", timeout: 1250 * time.Millisecond}},
+		{name: "capture at current speed", args: []string{"-s", "0", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, want: flagVars{device: "/dev/ttyS0", deviceSpeedSet: true, packetLog: "capture.jsonl"}},
 		{name: "help", args: []string{"-h"}, wantHelp: true},
 		{name: "positional port", args: []string{"/dev/ttyS0"}, wantErr: true},
 		{name: "all and device", args: []string{"-a", "-d", "/dev/ttyS0"}, wantErr: true},
@@ -208,17 +208,17 @@ func TestPrintSpeedInfo(t *testing.T) {
 	}
 }
 
-func TestProbeResultExitCode(t *testing.T) {
+func TestDetectResultExitCode(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		result probeResult
+		result detectResult
 		want   int
 	}{
-		{"found", probeResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}, 0},
-		{"silent", probeResult{}, 2},
-		{"unrecognized", probeResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}}, 1},
-		{"error", probeResult{failure: "speed detection requires a serial device"}, 1},
-		{"error outranks silence", probeResult{failure: "close failed"}, 1},
+		{"found", detectResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}, 0},
+		{"silent", detectResult{}, 2},
+		{"unrecognized", detectResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}}, 1},
+		{"error", detectResult{failure: "speed detection requires a serial device"}, 1},
+		{"error outranks silence", detectResult{failure: "close failed"}, 1},
 	} {
 		if got := tc.result.exitCode(); got != tc.want {
 			t.Errorf("%s: exitCode() = %d, want %d", tc.name, got, tc.want)
@@ -226,18 +226,18 @@ func TestProbeResultExitCode(t *testing.T) {
 	}
 }
 
-func TestProbeResultDescription(t *testing.T) {
+func TestDetectResultDescription(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		result probeResult
+		result detectResult
 		want   string
 	}{
-		{"silent", probeResult{}, "no output received from the device"},
-		{"unrecognized", probeResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}},
+		{"silent", detectResult{}, "no output received from the device"},
+		{"unrecognized", detectResult{detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}},
 			"output was received, but no known GNSS protocol was validated at a candidate speed"},
-		{"described error", probeResult{failure: "speed detection requires a serial device"},
+		{"described error", detectResult{failure: "speed detection requires a serial device"},
 			"speed detection requires a serial device"},
-		{"packet log permission", probeResult{failure: "opening packet log: permission denied"},
+		{"packet log permission", detectResult{failure: "opening packet log: permission denied"},
 			"opening packet log: permission denied"},
 	} {
 		if got := tc.result.description(); got != tc.want {
@@ -311,24 +311,24 @@ func (testLockedError) Locked() bool  { return true }
 
 func TestScanPortList(t *testing.T) {
 	ports := []serialenum.Port{{Device: "detected"}, {Device: "silent"}, {Device: "error"}}
-	probe := func(_ context.Context, lg *slog.Logger, device, packetLog string) probeResult {
+	detect := func(_ context.Context, lg *slog.Logger, device, packetLog string) detectResult {
 		if packetLog != "" {
 			t.Errorf("scan packet log = %q, want empty", packetLog)
 		}
-		lg.Info("probing")
+		lg.Info("detecting")
 		switch device {
 		case "detected":
-			return probeResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}
+			return detectResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}
 		case "silent":
-			return probeResult{device: device}
+			return detectResult{device: device}
 		default:
-			return probeResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}}
+			return detectResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectUnrecognized}}
 		}
 	}
 	stdout := outputFile(t)
 	var stderr, logBuf bytes.Buffer
 	lg := slog.New(slog.NewTextHandler(&logBuf, nil))
-	if err := scanPortList(context.Background(), lg, ports, probe, stdout, &stderr, false); err != nil {
+	if err := scanPortList(context.Background(), lg, ports, detect, stdout, &stderr, false); err != nil {
 		t.Fatalf("scanPortList() error = %v, want nil because one device was detected", err)
 	}
 	if got := outputString(t, stdout); got != "detected 38400\n" {
@@ -351,11 +351,11 @@ func TestScanPortList(t *testing.T) {
 
 func TestScanPortListJSONL(t *testing.T) {
 	ports := []serialenum.Port{{Device: "/dev/ttyUSB0"}}
-	probe := func(_ context.Context, _ *slog.Logger, device, _ string) probeResult {
-		return probeResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 115200}}
+	detect := func(_ context.Context, _ *slog.Logger, device, _ string) detectResult {
+		return detectResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 115200}}
 	}
 	stdout := outputFile(t)
-	if err := scanPortList(context.Background(), slog.Default(), ports, probe, stdout, io.Discard, true); err != nil {
+	if err := scanPortList(context.Background(), slog.Default(), ports, detect, stdout, io.Discard, true); err != nil {
 		t.Fatal(err)
 	}
 	want := "{\"device\":\"/dev/ttyUSB0\",\"speed\":115200}\n"
@@ -366,13 +366,13 @@ func TestScanPortListJSONL(t *testing.T) {
 
 func TestScanPortListBestFailure(t *testing.T) {
 	ports := []serialenum.Port{{Device: "silent"}, {Device: "error"}}
-	probe := func(_ context.Context, _ *slog.Logger, device, _ string) probeResult {
+	detect := func(_ context.Context, _ *slog.Logger, device, _ string) detectResult {
 		if device == "silent" {
-			return probeResult{device: device}
+			return detectResult{device: device}
 		}
-		return probeResult{device: device, failure: "failed"}
+		return detectResult{device: device, failure: "failed"}
 	}
-	err := scanPortList(context.Background(), slog.Default(), ports, probe, outputFile(t), io.Discard, false)
+	err := scanPortList(context.Background(), slog.Default(), ports, detect, outputFile(t), io.Discard, false)
 	var cmdErr commandError
 	if !errors.As(err, &cmdErr) || cmdErr.ExitCode() != 2 || !cmdErr.Quiet() {
 		t.Fatalf("scanPortList() error = %#v, want quiet exit code 2", err)
@@ -383,14 +383,14 @@ func TestScanPortListInterruptedOverridesDetection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	ports := []serialenum.Port{{Device: "detected"}, {Device: "cancelled"}}
-	probe := func(_ context.Context, _ *slog.Logger, device, _ string) probeResult {
+	detect := func(_ context.Context, _ *slog.Logger, device, _ string) detectResult {
 		if device == "detected" {
-			return probeResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 115200}}
+			return detectResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 115200}}
 		}
-		return probeResult{device: device, failure: "interrupted"}
+		return detectResult{device: device, failure: "interrupted"}
 	}
 	var stderr bytes.Buffer
-	err := scanPortList(ctx, slog.Default(), ports, probe, outputFile(t), &stderr, false)
+	err := scanPortList(ctx, slog.Default(), ports, detect, outputFile(t), &stderr, false)
 	var cmdErr commandError
 	if !errors.As(err, &cmdErr) || cmdErr.ExitCode() != 1 || !cmdErr.Quiet() {
 		t.Fatalf("scanPortList() error = %#v, want quiet exit code 1", err)
@@ -402,14 +402,14 @@ func TestScanPortListInterruptedOverridesDetection(t *testing.T) {
 
 func TestScanPortListOutputError(t *testing.T) {
 	ports := []serialenum.Port{{Device: "detected"}}
-	probe := func(_ context.Context, _ *slog.Logger, device, _ string) probeResult {
-		return probeResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}
+	detect := func(_ context.Context, _ *slog.Logger, device, _ string) detectResult {
+		return detectResult{device: device, detection: gpsio.DetectResult{Outcome: gpsio.DetectFound, Speed: 38400}}
 	}
 	stdout := outputFile(t)
 	if err := stdout.Close(); err != nil {
 		t.Fatal(err)
 	}
-	err := scanPortList(context.Background(), slog.Default(), ports, probe, stdout, io.Discard, false)
+	err := scanPortList(context.Background(), slog.Default(), ports, detect, stdout, io.Discard, false)
 	var cmdErr commandError
 	if !errors.As(err, &cmdErr) || cmdErr.ExitCode() != 1 || cmdErr.Quiet() {
 		t.Fatalf("scanPortList() error = %#v, want non-quiet exit code 1", err)

--- a/plan/serial-cli.md
+++ b/plan/serial-cli.md
@@ -1,0 +1,184 @@
+# Revised satpulsetool serial CLI (#408)
+
+## Motivation
+
+The serial subcommand's option surface grew mode by mode and is
+inconsistent with the rest of the tool family:
+
+- The commands that open a GPS serial device (gps, satpulsewb,
+  satpulsed) name it with `-d/--serial-device` and its speed with
+  `-s/--device-speed`; serial uses a positional port and gives `-s`
+  to `--detect-speed`.
+- serial's `--speed` is a false friend: it has the semantics of gps
+  `-s/--device-speed` (the host port's speed) but the name of gps
+  `--speed` (the receiver's configured baud rate).
+- `--packet-log` works only with `--detect-speed`, although PPS
+  monitoring also drains input, and a packet log correlated with
+  edge timestamps is exactly what diagnosing a pin needs (real PPS
+  vs TX crosstalk).
+
+The revision re-letters the command to match the family and makes
+the capabilities compose.
+
+## Design rules
+
+Three rules produce the whole grammar, and each is explainable to a
+user in one sentence.
+
+1. gps talks, serial listens. serial never transmits a byte to the
+   device: it describes ports, reads what a receiver emits, and
+   polls modem-control lines. Passive packet capture is therefore
+   serial's job, guaranteed passive by the nature of the command
+   rather than (as in gps today) by which options are absent. This
+   is also what makes reading safe enough to be the default mode.
+   Capture is not merely safe in serial but at home there: it is
+   reading with the result recorded, alongside reading to detect
+   the speed and reading to time edges.
+
+2. serial is patterned on gps, not sdp. `-d/--serial-device` and
+   `-s/--device-speed` take gps's exact names and letters, and
+   naming a device performs a useful default action, as gps
+   defaults to `--show-receiver` -- except that serial listens
+   where gps talks. (`-i` colliding with sdp's `--extts` letter is
+   accepted for the same reason.)
+
+3. A target licenses opening. `-d` names one port and `-a` names
+   all discovered ports; a target is opened and read, and reading's
+   default purpose is detecting the speed of a connected receiver
+   -- the command's primary job, so it is the unmarked case. The
+   marked exception is `-i/--info`: describe the target without
+   opening it. Reading requires an explicit target; `-i`'s default
+   target is `-a`, and `-i` itself is the default when no target is
+   named, so bare `serial` lists every port without opening
+   anything.
+
+## Command surface
+
+    serial                              info on all ports (never opens)
+    serial -i -d DEV                    info on one port (never opens)
+    serial -a                           detect speed of every port
+    serial -d DEV                       detect one port's speed
+    serial -d DEV --packet-log F        detect speed, logging packets
+    serial -p cts -a                    watch CTS on every port
+    serial -p cts -d DEV -t 30          monitor PPS edges on one port
+    serial -p cts -s 38400 -d DEV --packet-log F
+                                        edges + packets at a set speed
+    serial -s 38400 -d DEV --packet-log F -t 30
+                                        passive capture, known speed
+    serial -s 0 -d DEV --packet-log F   passive capture, current speed
+
+Constraints:
+
+- Reading requires an explicit target: `-d` or `-a` (mutually
+  exclusive). `-i`'s default target is `-a`.
+- `-i` cannot be combined with `-s`, `-p`, `-t`, or `--packet-log`.
+- `-s` requires `-d`: setting the speed of every discovered port is
+  never wanted.
+- `-s` is numeric only; 0 keeps the port's current speed (the
+  existing `--speed` convention), which is the spelling for capture
+  at the current speed.
+- `-s` given with neither `-p` nor `--packet-log` is an error:
+  nothing to detect or record.
+- `-p` without `-s` leaves the speed alone: modem-line polling does
+  not need a correct baud rate, and the all-ports pin scan must not
+  autobaud every port. Detect-then-monitor is shell composition:
+  `serial -p cts -d DEV -s $(serial -d DEV)`.
+- `--packet-log` requires `-d`.
+- `-t` bounds edge monitoring (default 10 s) and capture (default:
+  until interrupted, matching `gps --capture 0`); speed detection
+  keeps its internal time budget.
+- Exit status keeps 0/1/2; a capture that logged no packets exits 2
+  by symmetry with the other "no data found" cases.
+
+## User-facing explanation
+
+The man page DESCRIPTION becomes a short story: the serial command
+reads from the serial ports of the host, and never transmits to a
+connected device. Naming a port with `-d`, or all ports with `-a`,
+opens the target and reads from it: by default this detects the
+speed of a connected GPS receiver from the data being emitted by
+the receiver; with `-p` it detects PPS edges on a modem-control
+input; with `--packet-log` it records the packets received. With
+`-i` it instead describes the target ports without opening them;
+when no target is named, it behaves as if `-i` were specified.
+
+The two new entries in house style:
+
+    -i, --info
+    : Describe the target ports without opening them.
+    The default target is -a.
+    This option is the default when neither -d nor -a is specified.
+    Cannot be combined with -s, -p, -t, or --packet-log.
+
+    -a, --all
+    : Select all discovered serial ports as the target.
+    Cannot be combined with -d.
+
+## Port listing output
+
+The human listing moves from the composed display string to one
+key=value line per port, udev/logfmt style, so VID/PID and aliases
+are visible without `-j`:
+
+    device=/dev/ttyACM0 vid=1546 pid=01a9 serial="DBENIA5X" alias=/dev/gps0 display="..."
+
+- Keys mirror the JSONL field names, except that aliases print as a
+  singular `alias=` key repeated once per alias.
+- vid/pid print as four-digit lower-case hex (lsusb convention);
+  the JSONL numbers stay numeric.
+- Values that can contain spaces are quoted; paths are bare.
+- `display=` prints the Display string verbatim. On Linux this
+  repeats the device and aliases, which is accepted: Display's
+  composition is platform-dependent and satpulsewb consumes it, so
+  there is no cross-platform decomposition to print instead.
+- The single-port speed result stays a bare number so
+  `gps -s $(serial -d DEV)` keeps working.
+- All-ports edge output gains a device prefix (edges from several
+  ports interleave), and JSONL edge objects gain a device field.
+
+## Alternatives rejected
+
+- An explicit `-r/--read` flag licensing opening, implied by `-s`
+  and `-p`: it marks the command's normal operation instead of the
+  exception -- every speed detection, the primary use, pays a flag
+  -- and it needs implication rules ("implied by -s and -p;
+  required but not caused by -t and --packet-log") that the target
+  rule makes unnecessary. It also made `-d` alone a passive
+  describe, the only `-d` in the family that does not connect.
+- `-s auto` for requesting speed detection: bare `-s` cannot
+  default to auto (a pflag optional-value flag accepts explicit
+  values only as `-s=38400`), and with detection the default
+  purpose of reading it is unnecessary; `-s` stays purely numeric.
+- `-f/--config-file`: the `[serial]` table now includes `pps.pin`,
+  so importing the file would make the command's mode depend on file
+  content, and importing only device and speed saves little typing
+  on a command whose common invocations need no device at all.
+  Checking the production wiring stays explicit:
+  `serial -p cts -d DEV -s N`.
+
+## Phasing
+
+Phase 1 (serial-cli branch): everything except `-p`. Replace the positional
+port with `-d`; add `-a` and `-i`, with reading as the normal mode
+and speed detection as its default purpose; give `-s` to
+`--device-speed`; the `--packet-log` rules, `-t`, passive capture,
+and the key=value listing. The renames of `serial -s` and the
+positional port are breaking and accepted (near-zero users). This
+lands before phase 2 so serial offers passive capture before gps
+loses it.
+
+Phase 2 (serial-cli branch): remove passive capture from gps. `--capture`
+keeps its post-configuration role; `--packet-log` plus `--capture`
+with no other action falls through to the default show-receiver
+probe, a deliberate behavior change. The "capture without probing"
+example moves from satpulsetool-gps(1) to satpulsetool-serial(1);
+skills and docs using the old idiom are updated.
+
+Phase 3 (serial-pps branch, after phases 1 and 2 have merged to
+master and master has been merged in): the PPS surface.
+`--detect-pps` becomes `-p` (long name `--pin` vs `--pps-pin` still
+undecided), requiring a target; the branch's `--speed` and
+`--timeout` are subsumed by phase 1's `-s` and `-t`; `-p` with `-a`
+scans all ports in parallel with per-port failures on stderr, exit
+2 when no port pulses; `--packet-log` composes with `-p`; edge
+output gains the device tagging described above.


### PR DESCRIPTION
Phase 1 of `plan/serial-cli.md`: everything except the PPS-pin option, which stays on the serial-pps branch.

The `serial` command's options had grown mode by mode and diverged from the rest of the tool family. It took a positional port where `gps`, `satpulsewb` and `satpulsed` take `-d/--serial-device`, gave `-s` to `--detect-speed` rather than `--device-speed`, and confined `--packet-log` to speed detection even though the command never transmits to the device and so is the natural home for passive capture.

The grammar now follows three rules: `serial` listens and never transmits; it is lettered like `gps`; and naming a target licenses opening it. `-d` names one port and `-a` names all discovered ports; either one opens and reads, whose default purpose is detecting the speed of a connected receiver. `-i/--info` is the marked exception that describes ports without opening them, and is implied when no target is named, so bare `serial` still lists every port. `-s` becomes `--device-speed` with `gps` semantics (0 keeps the port's current speed), `--packet-log` composes with either reading mode, and a new `-t/--timeout` bounds capture (default: until interrupted). `-s` requires `-d` and `--packet-log`, `-t` requires both of those, `--packet-log` requires `-d`, and `-i` excludes all three. A capture that logged no packets exits 2, by symmetry with the other "no data found" cases.

The human port listing changes from the composed display string to one key=value line per port, so VID/PID, USB serial number and aliases are visible without `-j`:

    device=/dev/ttyACM0 vid=1546 pid=01a4 serial="BG02DBNX" alias=/dev/gps0 display="/dev/ttyACM0 (/dev/gps0, u-blox gen 10)"

VID and PID print as four-digit lower-case hex per lsusb convention; the JSONL numbers stay numeric. The single-port speed result stays a bare number, so `gps -s $(serial -d DEV)` keeps working.

The renames of `serial -s` and the removal of the positional port are breaking and accepted; the command is new in the unreleased version and has near-zero users. This lands before phase 2 so `serial` offers passive capture before `gps` loses it.

The last two commits are follow-up cleanups of `internal/serialcmd`: flag parsing renamed to the dominant command style (`flagVars`, `v`, `flags`, and detect rather than probe for the passive path, so probe stays reserved for operations that write to the receiver), then a pure reordering of the file to follow the command's control flow.

Part of #408. Phase 2 (remove passive capture from `gps`) will follow on this branch; phase 3 (the PPS surface) is on serial-pps.

Testing: `make test` passes. The new grammar, the flag constraints, the key=value listing and the capture paths are covered by unit tests in `internal/serialcmd`, with the capture end-to-end tests over a pty on Linux.
