### PR TITLE
wakeup: limit latency during serial PPS

### DIFF
--- a/configs/config-schema.json
+++ b/configs/config-schema.json
@@ -91,6 +91,11 @@
                   "exclusiveMaximum": 1,
                   "default": 0.8
                 },
+                "maxWakeupLatency": {
+                  "description": "Maximum CPU wakeup latency while serial PPS is active (microseconds)",
+                  "type": "number",
+                  "minimum": 0
+                },
                 "method": {
                   "description": "PPS edge detection method: poll, wait, or kernel; omit for automatic selection",
                   "type": "string",

--- a/configs/satpulse.toml
+++ b/configs/satpulse.toml
@@ -28,6 +28,9 @@ speed = 9600
 #[sample.serial.pps]
 #delayUncertainty = 0.005
 #maxDelay = 0.8
+# Uncomment to limit CPU wakeup latency while serial PPS is active.
+# The value is in microseconds; 0 is maximally strict.
+#maxWakeupLatency = 10
 
 [gps]
 # Uncomment to configure the GPS (changes are not persistent across GPS reboots)

--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -110,7 +110,7 @@ These packages are reusable libraries for GPS processing. They are in the librar
 
 `gps/lib/check` validates struct fields against constraints specified in struct tags using reflection. It supports numeric types with comparison operators (`>`, `>=`, `<`, `<=`) and recursively validates nested structs.
 
-`gps/lib/wakeup` requests operating-system limits on latency added when CPUs wake from idle. On Linux, a request is represented by an open `/dev/cpu_dma_latency` file descriptor and remains active until its returned closer is closed.
+`gps/lib/wakeup` requests operating-system limits on latency added when CPUs wake from idle. It is Linux-dependent.
 
 `gps/lib/ubxbin` translates binary packets in the UBX protocol to and from Go structs.
 

--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -110,6 +110,8 @@ These packages are reusable libraries for GPS processing. They are in the librar
 
 `gps/lib/check` validates struct fields against constraints specified in struct tags using reflection. It supports numeric types with comparison operators (`>`, `>=`, `<`, `<=`) and recursively validates nested structs.
 
+`gps/lib/wakeup` requests operating-system limits on latency added when CPUs wake from idle. On Linux, a request is represented by an open `/dev/cpu_dma_latency` file descriptor and remains active until its returned closer is closed.
+
 `gps/lib/ubxbin` translates binary packets in the UBX protocol to and from Go structs.
 
 `gps/lib/ubxcfgval` handles the 9th generation UBX format for configuration data that is payload for UBX-CFG-VALGET/VALSET messages.

--- a/docs/man/satpulse.toml.5.md
+++ b/docs/man/satpulse.toml.5.md
@@ -106,7 +106,7 @@ It can have the following keys:
 * `maxDelay` - the maximum accepted inferred delay from the pulse to its post-pulse message, in seconds;
   the default is 0.8
 * `maxWakeupLatency` - optionally limits CPU wakeup latency while serial PPS is active, in microseconds; `0` is maximally strict;
-  currently supported only on Linux; failure to apply the limit is logged as a warning
+  currently supported only on Linux
 * `method` - controls how the operating system is used to detect modem status changes that mark pulse edges:
   `"kernel"` means the kernel timestamps the time of a status change;
   `"wait"` means the kernel notifies the application of a status change;

--- a/docs/man/satpulse.toml.5.md
+++ b/docs/man/satpulse.toml.5.md
@@ -105,6 +105,8 @@ It can have the following keys:
   the inferred delay may be this far below zero; the default is 0.005
 * `maxDelay` - the maximum accepted inferred delay from the pulse to its post-pulse message, in seconds;
   the default is 0.8
+* `maxWakeupLatency` - optionally limits CPU wakeup latency while serial PPS is active, in microseconds; `0` is maximally strict;
+  currently supported only on Linux; failure to apply the limit is logged as a warning
 * `method` - controls how the operating system is used to detect modem status changes that mark pulse edges:
   `"kernel"` means the kernel timestamps the time of a status change;
   `"wait"` means the kernel notifies the application of a status change;

--- a/docs/man/satpulsetool-serial.1.md
+++ b/docs/man/satpulsetool-serial.1.md
@@ -55,7 +55,7 @@ When this option is omitted, the best available method is used.
 Requires **\-p**.
 
 **\-\-max\-wakeup\-latency** *microseconds*
-: Limit CPU wakeup latency while detecting PPS; `0` is maximally strict. Currently supported only on Linux; failure to apply the limit is logged as a warning. Requires **\-p**.
+: Limit CPU wakeup latency while detecting PPS; `0` is maximally strict. Currently supported only on Linux. Requires **\-p**.
 
 **\-\-packet\-log** *path*
 : Write a log of packets received to *path*.

--- a/docs/man/satpulsetool-serial.1.md
+++ b/docs/man/satpulsetool-serial.1.md
@@ -9,6 +9,7 @@ satpulsetool-serial - examine serial ports
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-i**\|**\-\-info**] [**\-j**\|**\-\-jsonl**]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-p**\|**\-\-pps\-pin** **cts**\|**dcd**\|**dsr**\|**ri**]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-m**\|**\-\-pps\-method** **poll**\|**wait**\|**kernel**]\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-\-max\-wakeup\-latency** *microseconds*]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-s**\|**\-\-device\-speed** *bps*] [**\-t**\|**\-\-timeout** *seconds*]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-\-packet\-log** *path*]
 
@@ -52,6 +53,9 @@ This causes speed detection not to be performed.
 **poll** means the application continually asks for the current status.
 When this option is omitted, the best available method is used.
 Requires **\-p**.
+
+**\-\-max\-wakeup\-latency** *microseconds*
+: Limit CPU wakeup latency while detecting PPS; `0` is maximally strict. Currently supported only on Linux; failure to apply the limit is logged as a warning. Requires **\-p**.
 
 **\-\-packet\-log** *path*
 : Write a log of packets received to *path*.

--- a/gps/app/serialpps/config.go
+++ b/gps/app/serialpps/config.go
@@ -3,11 +3,13 @@ package serialpps
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
 	"github.com/jclark/satpulse/gps/lib/check"
+	"github.com/jclark/satpulse/gps/lib/wakeup"
 )
 
 // Config controls how serial PPS edges are detected and associated with
@@ -21,6 +23,9 @@ type Config struct {
 	MaxDelay float64 `toml:"maxDelay" check:">0,<1" comment:"Maximum post-pulse message delay (s)"`
 	// Method selects how edges are detected; unspecified means automatic.
 	Method gpsio.PPSMethod `toml:"method" comment:"PPS edge detection method: poll, wait, or kernel; omit for automatic selection"`
+	// MaxWakeupLatency optionally limits latency added when a CPU wakes from
+	// idle while serial PPS is active.
+	MaxWakeupLatency *float64 `toml:"maxWakeupLatency" comment:"Maximum CPU wakeup latency while serial PPS is active (microseconds)"`
 }
 
 // DefaultConfig returns the default serial PPS sampling configuration.
@@ -42,6 +47,11 @@ func (cfg Config) Validate() error {
 	if cfg.Method < 0 || cfg.Method > gpsio.PPSMethodKernel {
 		msgs = append(msgs, fmt.Sprintf("method: invalid value %d", int(cfg.Method)))
 	}
+	if cfg.MaxWakeupLatency != nil {
+		if _, err := wakeupLatencyDuration(*cfg.MaxWakeupLatency); err != nil {
+			msgs = append(msgs, "maxWakeupLatency: "+err.Error())
+		}
+	}
 	switch len(msgs) {
 	case 0:
 		return nil
@@ -51,6 +61,27 @@ func (cfg Config) Validate() error {
 		msgs = append([]string{"errors in sample.serial.pps table:"}, msgs...)
 		return errors.New(strings.Join(msgs, "\n\t"))
 	}
+}
+
+func wakeupLatencyDuration(microseconds float64) (time.Duration, error) {
+	if math.IsNaN(microseconds) || math.IsInf(microseconds, 0) {
+		return 0, fmt.Errorf("must be finite, got %g", microseconds)
+	}
+	if microseconds < 0 {
+		return 0, fmt.Errorf("must not be negative, got %g", microseconds)
+	}
+	if microseconds >= float64(math.MaxInt64)/float64(time.Microsecond) {
+		return 0, fmt.Errorf("is too large, got %g", microseconds)
+	}
+	resolution := float64(wakeup.LatencyResolution) / float64(time.Microsecond)
+	if microseconds > 0 && microseconds < resolution {
+		return 0, fmt.Errorf("must be 0 or at least %g microseconds on this platform, got %g", resolution, microseconds)
+	}
+	d := time.Duration(math.Round(microseconds * float64(time.Microsecond)))
+	if microseconds > 0 && d == 0 {
+		return 0, fmt.Errorf("is too small to represent, got %g", microseconds)
+	}
+	return d, nil
 }
 
 func seconds(s float64) time.Duration {

--- a/gps/app/serialpps/config_test.go
+++ b/gps/app/serialpps/config_test.go
@@ -1,13 +1,16 @@
 package serialpps
 
 import (
+	"math"
 	"strings"
 	"testing"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/lib/wakeup"
 )
 
 func TestConfig(t *testing.T) {
+	floatPtr := func(v float64) *float64 { return &v }
 	tests := []struct {
 		name    string
 		cfg     Config
@@ -18,7 +21,15 @@ func TestConfig(t *testing.T) {
 		{name: "poll method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodPoll}},
 		{name: "wait method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodWait}},
 		{name: "kernel method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodKernel}},
+		{name: "zero wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(0)}},
+		{name: "minimum wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(wakeup.LatencyResolution.Seconds() * 1e6)}},
+		{name: "fractional wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(10.5)}},
 		{name: "invalid method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodKernel + 1}, errText: "method"},
+		{name: "negative wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(-1)}, errText: "maxWakeupLatency"},
+		{name: "sub-resolution wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(wakeup.LatencyResolution.Seconds() * 1e6 / 2)}, errText: "maxWakeupLatency"},
+		{name: "NaN wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(math.NaN())}, errText: "maxWakeupLatency"},
+		{name: "infinite wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(math.Inf(1))}, errText: "maxWakeupLatency"},
+		{name: "overflowing wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(1e20)}, errText: "maxWakeupLatency"},
 		{name: "negative uncertainty", cfg: Config{DelayUncertainty: -0.001, MaxDelay: 0.8}, errText: "delayUncertainty"},
 		{name: "zero maximum", cfg: Config{DelayUncertainty: 0.005}, errText: "maxDelay"},
 		{name: "one-second interval", cfg: Config{DelayUncertainty: 0.2, MaxDelay: 0.8}, errText: "delayUncertainty + maxDelay"},

--- a/gps/lib/wakeup/wakeup.go
+++ b/gps/lib/wakeup/wakeup.go
@@ -1,0 +1,2 @@
+// Package wakeup requests limits on latency added when CPUs wake from idle.
+package wakeup

--- a/gps/lib/wakeup/wakeup_linux.go
+++ b/gps/lib/wakeup/wakeup_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package wakeup
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+const (
+	// LatencyResolution is the resolution of wakeup latency limits on Linux.
+	LatencyResolution = time.Microsecond
+	cpuDMALatencyPath = "/dev/cpu_dma_latency"
+	maxLatencyMicros  = 1<<31 - 1
+)
+
+// RequestLatencyLimit requests that CPU idle-state exit add no more than max
+// to wakeup latency. The request remains active until the returned closer is
+// closed. Linux represents the request in whole microseconds, so max is
+// rounded down to LatencyResolution.
+func RequestLatencyLimit(max time.Duration) (io.Closer, error) {
+	return requestLatencyLimit(cpuDMALatencyPath, max)
+}
+
+func requestLatencyLimit(path string, max time.Duration) (io.Closer, error) {
+	if max < 0 {
+		return nil, fmt.Errorf("wakeup latency limit must not be negative: %v", max)
+	}
+	micros := max / LatencyResolution
+	if micros > maxLatencyMicros {
+		return nil, fmt.Errorf("wakeup latency limit is too large: %v", max)
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	var value [4]byte
+	binary.NativeEndian.PutUint32(value[:], uint32(micros))
+	n, err := f.Write(value[:])
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("setting wakeup latency limit: %w", err)
+	}
+	if n != len(value) {
+		_ = f.Close()
+		return nil, fmt.Errorf("setting wakeup latency limit: %w", io.ErrShortWrite)
+	}
+	return f, nil
+}

--- a/gps/lib/wakeup/wakeup_linux_test.go
+++ b/gps/lib/wakeup/wakeup_linux_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package wakeup
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRequestLatencyLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		max  time.Duration
+		want uint32
+	}{
+		{name: "zero", max: 0, want: 0},
+		{name: "sub-resolution", max: time.Nanosecond, want: 0},
+		{name: "exact", max: 10 * time.Microsecond, want: 10},
+		{name: "floor", max: 10*time.Microsecond + 999*time.Nanosecond, want: 10},
+		{name: "maximum", max: maxLatencyMicros * time.Microsecond, want: maxLatencyMicros},
+		{name: "maximum floor", max: maxLatencyMicros*time.Microsecond + 999*time.Nanosecond, want: maxLatencyMicros},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "cpu_dma_latency")
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			req, err := requestLatencyLimit(path, tc.max)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := req.Close(); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 4 {
+				t.Fatalf("request length = %d, want 4", len(got))
+			}
+			if value := binary.NativeEndian.Uint32(got); value != tc.want {
+				t.Errorf("request = %d, want %d", value, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequestLatencyLimitRejectsOutOfRange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cpu_dma_latency")
+	for _, max := range []time.Duration{-1, (maxLatencyMicros + 1) * time.Microsecond} {
+		if _, err := requestLatencyLimit(path, max); err == nil {
+			t.Errorf("requestLatencyLimit(%v) returned nil error", max)
+		}
+	}
+}
+
+func TestRequestLatencyLimitOpenError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing")
+	if _, err := requestLatencyLimit(path, time.Microsecond); err == nil {
+		t.Fatal("requestLatencyLimit returned nil error for missing device")
+	}
+}

--- a/gps/lib/wakeup/wakeup_other.go
+++ b/gps/lib/wakeup/wakeup_other.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package wakeup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// LatencyResolution is the smallest positive time.Duration. Wakeup latency
+// limiting is not yet supported on this platform.
+const LatencyResolution = time.Nanosecond
+
+var errNotSupported = fmt.Errorf("wakeup latency limiting: %w", errors.ErrUnsupported)
+
+// RequestLatencyLimit reports that wakeup latency limiting is not yet
+// supported on this platform.
+func RequestLatencyLimit(time.Duration) (io.Closer, error) {
+	return nil, errNotSupported
+}

--- a/gps/lib/wakeup/wakeup_other_test.go
+++ b/gps/lib/wakeup/wakeup_other_test.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package wakeup
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestUnsupported(t *testing.T) {
+	if LatencyResolution != time.Nanosecond {
+		t.Errorf("LatencyResolution = %v, want %v", LatencyResolution, time.Nanosecond)
+	}
+	if _, err := RequestLatencyLimit(0); !errors.Is(err, errors.ErrUnsupported) {
+		t.Errorf("RequestLatencyLimit error = %v, want errors.ErrUnsupported", err)
+	}
+}

--- a/time/app/daemon/config_test.go
+++ b/time/app/daemon/config_test.go
@@ -232,12 +232,16 @@ func TestSerialPPSSampleConfig(t *testing.T) {
 	if got := cfg.Sample.Serial.PPS.MaxDelay; got != 0.8 {
 		t.Errorf("default maxDelay = %v, want 0.8", got)
 	}
+	if got := cfg.Sample.Serial.PPS.MaxWakeupLatency; got != nil {
+		t.Errorf("default maxWakeupLatency = %v, want nil", got)
+	}
 
 	cfg, err := readConfig(strings.NewReader(`
 [sample.serial.pps]
 method = "kernel"
 delayUncertainty = 0.01
 maxDelay = 0.7
+maxWakeupLatency = 10
 `))
 	if err != nil {
 		t.Fatal(err)
@@ -251,8 +255,22 @@ maxDelay = 0.7
 	if got := cfg.Sample.Serial.PPS.Method; got != gpsio.PPSMethodKernel {
 		t.Errorf("configured method = %v, want %v", got, gpsio.PPSMethodKernel)
 	}
+	if got := cfg.Sample.Serial.PPS.MaxWakeupLatency; got == nil || *got != 10 {
+		t.Errorf("configured maxWakeupLatency = %v, want 10", got)
+	}
 	if err := cfg.Validate(slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
 		t.Fatalf("Validate: %v", err)
+	}
+
+	cfg, err = readConfig(strings.NewReader(`
+[sample.serial.pps]
+maxWakeupLatency = 0
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Sample.Serial.PPS.MaxWakeupLatency; got == nil || *got != 0 {
+		t.Errorf("explicit zero maxWakeupLatency = %v, want pointer to zero", got)
 	}
 }
 

--- a/time/app/daemon/daemon.go
+++ b/time/app/daemon/daemon.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/jclark/satpulse/gps/app/stream"
 	"github.com/jclark/satpulse/gps/gpsprot"
 	"github.com/jclark/satpulse/gps/gpsreg"
+	"github.com/jclark/satpulse/gps/lib/wakeup"
 	"github.com/jclark/satpulse/gps/ptime"
 	"github.com/jclark/satpulse/gps/scan"
 	"github.com/jclark/satpulse/time/internal/gpsevent"
@@ -143,6 +146,17 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 	if speed == 0 {
 		speed = cfgSpeed
 	}
+	// The request is acquired immediately before serial PPS detection starts.
+	// Register its cleanup here so it runs after the worker-wait and serial-port
+	// cleanup registered below.
+	var wakeupLatencyLimit io.Closer
+	defer func() {
+		if wakeupLatencyLimit != nil {
+			if err := wakeupLatencyLimit.Close(); err != nil {
+				lg.Warn("cannot release CPU wakeup latency limit", "err", err)
+			}
+		}
+	}()
 
 	// During normal shutdown, the worker-wait defer registered below runs
 	// first, so the serial PPS poller stops before the connection is closed.
@@ -325,6 +339,16 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 	var spCh <-chan serialpps.CandidateEdge
 	var spGen *serialpps.Generator
 	if cfg.Serial.PPS != nil {
+		if configuredMax := cfg.Sample.Serial.PPS.MaxWakeupLatency; configuredMax != nil {
+			max := time.Duration(math.Round(*configuredMax * float64(time.Microsecond)))
+			req, err := wakeup.RequestLatencyLimit(max)
+			if err != nil {
+				lg.Warn("cannot limit CPU wakeup latency", "max", max, "err", err)
+			} else {
+				wakeupLatencyLimit = req
+				lg.Info("limited CPU wakeup latency", "max", max.Truncate(wakeup.LatencyResolution))
+			}
+		}
 		pin, _ := cfg.Serial.PPS.modemControlPin() // checked by Config.Validate
 		spGen = serialpps.NewGenerator(cfg.Sample.Serial.PPS)
 		ch := make(chan serialpps.CandidateEdge, 1)

--- a/time/app/serialcmd/serialcmd.go
+++ b/time/app/serialcmd/serialcmd.go
@@ -22,23 +22,26 @@ import (
 	"github.com/jclark/satpulse/gps/gpsreg"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
 	"github.com/jclark/satpulse/gps/lib/term"
+	"github.com/jclark/satpulse/gps/lib/wakeup"
 	"github.com/jclark/satpulse/gps/ptime"
 	"github.com/jclark/satpulse/gps/scan"
 	"github.com/spf13/pflag"
 )
 
 type flagVars struct {
-	all            bool
-	device         string
-	info           bool
-	ppsSet         bool
-	ppsPin         gpsio.ModemControlPin
-	ppsMethod      gpsio.PPSMethod
-	packetLog      string
-	deviceSpeed    int
-	deviceSpeedSet bool
-	timeout        time.Duration
-	jsonl          bool
+	all                 bool
+	device              string
+	info                bool
+	ppsSet              bool
+	ppsPin              gpsio.ModemControlPin
+	ppsMethod           gpsio.PPSMethod
+	maxWakeupLatency    time.Duration
+	maxWakeupLatencySet bool
+	packetLog           string
+	deviceSpeed         int
+	deviceSpeedSet      bool
+	timeout             time.Duration
+	jsonl               bool
 }
 
 type commandError struct {
@@ -105,7 +108,8 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 }
 
 const summary = `[-h|--help] [-a|--all | -d|--serial-device path] [-i|--info]
-              [-p|--pps-pin pin] [-m|--pps-method method] [--packet-log path]
+              [-p|--pps-pin pin] [-m|--pps-method method]
+              [--max-wakeup-latency microseconds] [--packet-log path]
               [-s|--device-speed bps]
               [-t|--timeout seconds] [-j|--jsonl]`
 
@@ -115,6 +119,7 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	flags := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
 	flags.SortFlags = false
 	var ppsPinName, ppsMethodName string
+	var maxWakeupLatencyMicros float64
 	var timeoutSec float64
 	flags.BoolVarP(&help, "help", "h", false, "show usage help for the serial command")
 	flags.BoolVarP(&v.all, "all", "a", false, "operate on all discovered serial ports")
@@ -122,6 +127,7 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	flags.BoolVarP(&v.info, "info", "i", false, "show information about serial ports without opening them")
 	flags.StringVarP(&ppsPinName, "pps-pin", "p", "", "detect PPS edges on the modem-control input `pin` (cts, dcd, dsr, or ri)")
 	flags.StringVarP(&ppsMethodName, "pps-method", "m", "", "force the PPS edge detection `method` (poll, wait, or kernel)")
+	flags.Float64Var(&maxWakeupLatencyMicros, "max-wakeup-latency", 0, "limit CPU wakeup latency to `microseconds` while detecting PPS")
 	flags.StringVar(&v.packetLog, "packet-log", "", "write received packets to a JSON Lines log at `path`")
 	flags.IntVarP(&v.deviceSpeed, "device-speed", "s", 0, "set the serial port speed to `bps` (0 uses the current speed)")
 	flags.Float64VarP(&timeoutSec, "timeout", "t", 0, "stop detecting PPS edges or capturing packets after `seconds` (0 = until interrupted)")
@@ -139,6 +145,7 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	timeoutSet := flags.Lookup("timeout").Changed
 	packetLogSet := flags.Lookup("packet-log").Changed
 	methodSet := flags.Lookup("pps-method").Changed
+	v.maxWakeupLatencySet = flags.Lookup("max-wakeup-latency").Changed
 	v.ppsSet = flags.Lookup("pps-pin").Changed
 	if v.ppsSet {
 		v.ppsPin, err = parsePin(ppsPinName)
@@ -149,6 +156,12 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	if methodSet {
 		if v.ppsMethod, err = gpsio.ParsePPSMethod(ppsMethodName); err != nil {
 			err = fmt.Errorf("--pps-method must be one of poll, wait, or kernel")
+			return
+		}
+	}
+	if v.maxWakeupLatencySet {
+		v.maxWakeupLatency, err = parseWakeupLatency(maxWakeupLatencyMicros)
+		if err != nil {
 			return
 		}
 	}
@@ -184,8 +197,8 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 		err = fmt.Errorf("--packet-log must not be empty")
 		return
 	}
-	if v.info && (v.ppsSet || methodSet || v.deviceSpeedSet || timeoutSet || packetLogSet) {
-		err = fmt.Errorf("--info cannot be combined with --pps-pin, --pps-method, --device-speed, --timeout, or --packet-log")
+	if v.info && (v.ppsSet || methodSet || v.maxWakeupLatencySet || v.deviceSpeedSet || timeoutSet || packetLogSet) {
+		err = fmt.Errorf("--info cannot be combined with --pps-pin, --pps-method, --max-wakeup-latency, --device-speed, --timeout, or --packet-log")
 		return
 	}
 	if v.ppsSet && !deviceSet && !v.all {
@@ -194,6 +207,10 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	}
 	if methodSet && !v.ppsSet {
 		err = fmt.Errorf("--pps-method requires --pps-pin")
+		return
+	}
+	if v.maxWakeupLatencySet && !v.ppsSet {
+		err = fmt.Errorf("--max-wakeup-latency requires --pps-pin")
 		return
 	}
 	if timeoutSet && !v.ppsSet && !(v.deviceSpeedSet && packetLogSet) {
@@ -222,6 +239,27 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 		v.all = true
 	}
 	return
+}
+
+func parseWakeupLatency(microseconds float64) (time.Duration, error) {
+	if math.IsNaN(microseconds) || math.IsInf(microseconds, 0) {
+		return 0, fmt.Errorf("--max-wakeup-latency must be finite")
+	}
+	if microseconds < 0 {
+		return 0, fmt.Errorf("--max-wakeup-latency must not be negative")
+	}
+	if microseconds >= float64(math.MaxInt64)/float64(time.Microsecond) {
+		return 0, fmt.Errorf("--max-wakeup-latency is too large")
+	}
+	resolution := float64(wakeup.LatencyResolution) / float64(time.Microsecond)
+	if microseconds > 0 && microseconds < resolution {
+		return 0, fmt.Errorf("--max-wakeup-latency must be 0 or at least %g microseconds on this platform", resolution)
+	}
+	d := time.Duration(math.Round(microseconds * float64(time.Microsecond)))
+	if microseconds > 0 && d == 0 {
+		return 0, fmt.Errorf("--max-wakeup-latency is too small to represent")
+	}
+	return d, nil
 }
 
 func parsePin(name string) (gpsio.ModemControlPin, error) {
@@ -357,6 +395,19 @@ type ppsResult struct {
 }
 
 func monitorPPS(ctx context.Context, lg *slog.Logger, v flagVars) error {
+	if v.maxWakeupLatencySet {
+		req, err := wakeup.RequestLatencyLimit(v.maxWakeupLatency)
+		if err != nil {
+			lg.Warn("cannot limit CPU wakeup latency", "max", v.maxWakeupLatency, "err", err)
+		} else {
+			lg.Info("limited CPU wakeup latency", "max", v.maxWakeupLatency.Truncate(wakeup.LatencyResolution))
+			defer func() {
+				if err := req.Close(); err != nil {
+					lg.Warn("cannot release CPU wakeup latency limit", "err", err)
+				}
+			}()
+		}
+	}
 	if v.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, v.timeout)

--- a/time/app/serialcmd/serialcmd_test.go
+++ b/time/app/serialcmd/serialcmd_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jclark/satpulse/gps/app/serialpps"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
 	"github.com/jclark/satpulse/gps/lib/term"
+	"github.com/jclark/satpulse/gps/lib/wakeup"
 	"github.com/jclark/satpulse/gps/scan"
 )
 
@@ -46,6 +47,8 @@ func TestParseFlags(t *testing.T) {
 		{name: "pps by polling", args: []string{"-p", "cts", "-m", "poll", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, ppsMethod: gpsio.PPSMethodPoll, timeout: defaultPPSTimeout}},
 		{name: "pps by waiting", args: []string{"-p", "cts", "--pps-method", "wait", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, ppsMethod: gpsio.PPSMethodWait, timeout: defaultPPSTimeout}},
 		{name: "pps with kernel timestamps", args: []string{"-p", "dcd", "--pps-method", "kernel", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemDCD, ppsMethod: gpsio.PPSMethodKernel, timeout: defaultPPSTimeout}},
+		{name: "pps with wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "10.5", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, maxWakeupLatency: 10*time.Microsecond + 500*time.Nanosecond, maxWakeupLatencySet: true, timeout: defaultPPSTimeout}},
+		{name: "pps with zero wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "0", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, maxWakeupLatencySet: true, timeout: defaultPPSTimeout}},
 		{name: "help", args: []string{"-h"}, wantHelp: true},
 		{name: "positional port", args: []string{"/dev/ttyS0"}, wantErr: true},
 		{name: "all and device", args: []string{"-a", "-d", "/dev/ttyS0"}, wantErr: true},
@@ -55,6 +58,12 @@ func TestParseFlags(t *testing.T) {
 		{name: "info and pps", args: []string{"-i", "-p", "cts", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "method without pps", args: []string{"-m", "poll", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "invalid method", args: []string{"-p", "cts", "-m", "sideband", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "wakeup latency without pps", args: []string{"--max-wakeup-latency", "10", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "negative wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "-1", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "NaN wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "NaN", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "infinite wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "+Inf", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "overflowing wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "1e20", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "under-resolution wakeup latency", args: []string{"-p", "cts", "--max-wakeup-latency", "1e-10", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "pps without target", args: []string{"-p", "cts"}, wantErr: true},
 		{name: "pps invalid pin", args: []string{"-p", "rts", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "pps value required", args: []string{"--pps-pin", "-d", "/dev/ttyS0"}, wantErr: true},
@@ -89,6 +98,16 @@ func TestParseFlags(t *testing.T) {
 				t.Errorf("flags = %+v, want %+v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseWakeupLatencyResolution(t *testing.T) {
+	resolution := wakeup.LatencyResolution.Seconds() * 1e6
+	if _, err := parseWakeupLatency(resolution / 2); err == nil {
+		t.Fatal("parseWakeupLatency accepted a positive value below LatencyResolution")
+	}
+	if got, err := parseWakeupLatency(resolution); err != nil || got != wakeup.LatencyResolution {
+		t.Fatalf("parseWakeupLatency(LatencyResolution) = %v, %v", got, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `gps/lib/wakeup`, a small OS abstraction for fd-held CPU wakeup-latency requests, with a Linux implementation that opens `/dev/cpu_dma_latency`, writes the bound in whole microseconds, and returns the open file as an `io.Closer`; the kernel drops the request when the fd closes, including on process exit
- add an opt-in `sample.serial.pps.maxWakeupLatency` key, in microseconds, held for as long as `satpulsed` runs serial PPS detection
- add a matching `--max-wakeup-latency` option to `satpulsetool serial`, which requires `--pps-pin` and cannot be combined with `--info`
- validate the requested value at parse time in both entry points: reject negative, non-finite, and out-of-range values, and reject a positive value below the platform's `LatencyResolution` so an explicit sub-microsecond bound is not silently turned into the maximally strict request
- treat an explicit `0` as meaningful and maximally strict, forbidding all idle states
- stub the package on non-Linux platforms, where `RequestLatencyLimit` returns an `errors.ErrUnsupported` error

## Why

On an idle x86 machine, CPU idle-state exit latency dominates serial PPS timestamp offsets: the CPU servicing the UART interrupt has to leave a deep C-state first, and the wait method pays a second exit when the blocked thread's CPU wakes. Measured on a 16550A port with the kernel method while validating #411, the offset was +107 us mean / 56 us stdev when idle, collapsing to +32 us / 1.7 us with the CPU latency PM QoS bound held at 0. That dwarfs the difference between the detection methods, so holding the bound for the lifetime of serial PPS detection is what makes the kernel method's precision reachable on an otherwise idle machine.

## User impact

Nothing changes unless the key or the option is set: with `maxWakeupLatency` absent, `satpulsed` does not touch power management and there is no default constraint. `/dev/cpu_dma_latency` is root-only, so `satpulsetool serial --max-wakeup-latency` has to be run as root; the man page says so. On machines whose kernel exposes no idle states, holding the request is a harmless no-op.

A request that cannot be taken is logged as a warning and serial PPS detection continues; the same warning covers non-Linux platforms, where the request fails with `errors.ErrUnsupported`.

## Validation

- `make test`

Fixes #416
