### PR TITLE
serialpps: add a PPS polarity option

### DIFF
--- a/configs/config-schema.json
+++ b/configs/config-schema.json
@@ -62,6 +62,10 @@
             "pin": {
               "type": "string",
               "enum": ["cts", "dcd", "dsr", "ri"]
+            },
+            "invertPolarity": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": ["pin"]

--- a/docs/man/satpulse.toml.5.md
+++ b/docs/man/satpulse.toml.5.md
@@ -82,6 +82,9 @@ It can have the following keys:
   cannot be used when `interface` in the `[phc]` table is configured;
   the pulse must be at least a few milliseconds wide, and narrow pulses can take longer to detect;
   the common receiver default of 100 ms works well, and microsecond-width pulses are not supported
+* `pps.invertPolarity` - a boolean saying whether to invert the usual PPS pulse polarity;
+  set this to `true` if detected edges trail the start of the second by the pulse width (typically 0.1 s);
+  the default is `false`
 
 Example using PPS on CTS:
 

--- a/docs/man/satpulsetool-serial.1.md
+++ b/docs/man/satpulsetool-serial.1.md
@@ -8,6 +8,7 @@ satpulsetool-serial - examine serial ports
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-a**\|**\-\-all**] [**\-d**\|**\-\-serial\-device** *path*]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-i**\|**\-\-info**] [**\-j**\|**\-\-jsonl**]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-p**\|**\-\-pps\-pin** **cts**\|**dcd**\|**dsr**\|**ri**]\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\-I**\|**\-\-invert\-polarity**]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-m**\|**\-\-pps\-method** **poll**\|**wait**\|**kernel**]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-\-poll\-pre\-warm** *seconds*]\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\-\-max\-wakeup\-latency** *microseconds*]\
@@ -46,6 +47,11 @@ Otherwise, the default operation is to discover the available serial ports and s
 **\-p**, **\-\-pps\-pin** **cts**\|**dcd**\|**dsr**\|**ri**
 : Detect PPS edges on the specified modem-control pin.
 This causes speed detection not to be performed.
+
+**\-I**, **\-\-invert\-polarity**
+: Invert the usual PPS pulse polarity.
+Use this if detected edges trail the start of the second by the pulse width (typically 0.1 s).
+Requires **\-p**.
 
 **\-m**, **\-\-pps\-method** **poll**\|**wait**\|**kernel**
 : Controls how the operating system is used to detect modem status changes that mark pulse edges:

--- a/gps/app/serialpps/poll.go
+++ b/gps/app/serialpps/poll.go
@@ -513,11 +513,10 @@ func classify(prev, cur reading, w Wiring, deadline time.Time) (clockReading, bo
 	return clockReading{}, !cur.poll.midpoint().mono.Before(deadline)
 }
 
-// inPulse reports whether the state was observed during a pulse. The pulse's
-// electrically rising leading edge reaches the host inverted through the TTL
-// driver chain, so the flag reads deasserted during the pulse.
+// inPulse reports whether the state was observed during a pulse, as
+// selected by the wiring's polarity.
 func inPulse(s gpsio.ModemControlPinState, w Wiring) bool {
-	return !s.Asserted(w.Pin)
+	return s.Asserted(w.Pin) == w.Polarity.Asserted()
 }
 
 func halfCeil(d time.Duration) time.Duration {

--- a/gps/app/serialpps/serialpps.go
+++ b/gps/app/serialpps/serialpps.go
@@ -64,10 +64,39 @@ type ChangeWaiter interface {
 	WaitModemControlPinChange(context.Context, gpsio.ModemControlPin, gpsio.PPSMethod) (gpsio.ModemControlPinChange, int, error)
 }
 
+// Polarity identifies which flag transition is the on-time PPS edge.
+//
+// In RS-232 signalling, the voltage level that represents logic 0 on a
+// data line is the same level that asserts a control line, and drivers
+// apply the logic-to-voltage mapping uniformly to data and control
+// lines. A control line driven from a logic-level signal is therefore
+// asserted at logic 0 and deasserted at logic 1. A PPS pulse is
+// active-high, so the flag reads deasserted while the pulse is active,
+// and the on-time leading edge is the flag deasserting. This holds both
+// for native RS-232 ports and for TTL-to-USB adapters, whose flag
+// inputs are likewise active-low. PolarityDeassert names this normal
+// convention and is the zero value.
+//
+// PolarityAssert is for wiring where the pulse instead asserts the
+// flag, which shows up as detected edges trailing the start of the
+// second by the pulse width (typically 0.1 s).
+type Polarity int
+
+const (
+	PolarityDeassert Polarity = iota
+	PolarityAssert
+)
+
+// Asserted reports whether the flag is asserted while the pulse is active.
+func (p Polarity) Asserted() bool {
+	return p == PolarityAssert
+}
+
 // Wiring describes how the PPS pulse is represented on the serial port's
 // modem-control inputs.
 type Wiring struct {
-	Pin gpsio.ModemControlPin
+	Pin      gpsio.ModemControlPin
+	Polarity Polarity
 }
 
 // Detect sends candidate edges for the pulse described by w. An unspecified
@@ -120,9 +149,8 @@ func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, metho
 
 // Wait sends settled candidate edges from modem-control change notifications,
 // using the wait or kernel method. The backend timestamps each unambiguous
-// transition, so these candidates have no polling uncertainty. The pulse's
-// electrically rising leading edge reaches the host inverted through the TTL
-// driver chain, so the pin reads deasserted during the pulse.
+// transition, so these candidates have no polling uncertainty. The leading
+// edge is the transition into the pulse, as selected by w.Polarity.
 func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method gpsio.PPSMethod, ceCh chan<- CandidateEdge) error {
 	for {
 		change, missed, err := r.WaitModemControlPinChange(ctx, w.Pin, method)
@@ -135,7 +163,7 @@ func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method
 		if missed > 0 {
 			lg.Debug("serial PPS transitions not observed", "atLeast", missed)
 		}
-		if !change.Asserted {
+		if change.Asserted == w.Polarity.Asserted() {
 			ce := CandidateEdge{
 				Edge:    Edge{Timestamp: change.Timestamp, TRead: change.TRead},
 				Settled: true,

--- a/gps/app/serialpps/serialpps_test.go
+++ b/gps/app/serialpps/serialpps_test.go
@@ -84,6 +84,34 @@ func TestWait(t *testing.T) {
 	}
 }
 
+func TestWaitInvertedPolarity(t *testing.T) {
+	tRead := time.Now()
+	timestamp := tRead.Add(time.Millisecond)
+	w := &testChangeWaiter{next: make(chan testWaitResult, 2)}
+	// With PolarityAssert the pulse asserts the flag, so the deasserted
+	// transition is a trailing edge and the asserted one is published.
+	w.next <- testWaitResult{change: gpsio.ModemControlPinChange{Timestamp: timestamp.Add(-time.Second), TRead: tRead.Add(-time.Second)}}
+	w.next <- testWaitResult{change: gpsio.ModemControlPinChange{Timestamp: timestamp, TRead: tRead, Asserted: true}}
+	candidates := make(chan CandidateEdge, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Wait(ctx, testLog, w, Wiring{Pin: gpsio.ModemCTS, Polarity: PolarityAssert}, gpsio.PPSMethodWait, candidates)
+	}()
+	select {
+	case candidate := <-candidates:
+		if candidate.Timestamp != timestamp || candidate.TRead != tRead {
+			t.Fatalf("Wait edge = %+v, want the asserting transition", candidate.Edge)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not emit the asserting edge")
+	}
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait error = %v, want context.Canceled", err)
+	}
+}
+
 func TestWaitContextCancellation(t *testing.T) {
 	w := &testChangeWaiter{next: make(chan testWaitResult), entered: make(chan struct{}, 1)}
 	candidates := make(chan CandidateEdge, 1)

--- a/time/app/daemon/config.go
+++ b/time/app/daemon/config.go
@@ -60,7 +60,8 @@ type SerialConfig struct {
 }
 
 type SerialPPSConfig struct {
-	Pin string `toml:"pin"`
+	Pin            string `toml:"pin"`
+	InvertPolarity bool   `toml:"invertPolarity"`
 }
 
 type SampleConfig struct {
@@ -251,6 +252,16 @@ func (cfg *Config) Validate(lg *slog.Logger) error {
 		return &configError{err: err}
 	}
 	return nil
+}
+
+// wiring is the pulse wiring the table describes.
+func (cfg SerialPPSConfig) wiring() serialpps.Wiring {
+	pin, _ := cfg.modemControlPin() // checked by Config.Validate
+	w := serialpps.Wiring{Pin: pin}
+	if cfg.InvertPolarity {
+		w.Polarity = serialpps.PolarityAssert
+	}
+	return w
 }
 
 func (cfg SerialPPSConfig) modemControlPin() (gpsio.ModemControlPin, error) {

--- a/time/app/daemon/config_test.go
+++ b/time/app/daemon/config_test.go
@@ -183,6 +183,16 @@ func TestSerialPPSConfig(t *testing.T) {
 	}
 }
 
+func TestSerialPPSConfigInvertPolarity(t *testing.T) {
+	cfg, err := readConfig(strings.NewReader("[serial.pps]\npin = \"cts\"\ninvertPolarity = true"))
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
+	if cfg.Serial.PPS == nil || !cfg.Serial.PPS.InvertPolarity {
+		t.Fatalf("serial PPS config = %+v, want inverted polarity", cfg.Serial.PPS)
+	}
+}
+
 func TestSerialPPSConfigRejectsPHC(t *testing.T) {
 	cfg, err := readConfig(strings.NewReader(`
 [serial.pps]

--- a/time/app/daemon/daemon.go
+++ b/time/app/daemon/daemon.go
@@ -349,14 +349,13 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 				lg.Info("limited CPU wakeup latency", "max", max.Truncate(wakeup.LatencyResolution))
 			}
 		}
-		pin, _ := cfg.Serial.PPS.modemControlPin() // checked by Config.Validate
 		spGen = serialpps.NewGenerator(cfg.Sample.Serial.PPS)
 		ch := make(chan serialpps.CandidateEdge, 1)
 		spCh = ch
 		wg.Go(func() {
 			defer close(ch)
 			lg.Debug("serial PPS goroutine started", "pin", cfg.Serial.PPS.Pin)
-			if err := serialpps.Detect(ctx, lg, conn, serialpps.Wiring{Pin: pin}, cfg.Sample.Serial.PPS, ch, nil); err != nil && ctx.Err() == nil {
+			if err := serialpps.Detect(ctx, lg, conn, cfg.Serial.PPS.wiring(), cfg.Sample.Serial.PPS, ch, nil); err != nil && ctx.Err() == nil {
 				lg.Error("serial PPS detection failed", "pin", cfg.Serial.PPS.Pin, "err", err)
 				cancel(fmt.Errorf("serial PPS detection failed on %s: %w", cfg.Serial.PPS.Pin, err))
 			}

--- a/time/app/serialcmd/serialcmd.go
+++ b/time/app/serialcmd/serialcmd.go
@@ -34,6 +34,7 @@ type flagVars struct {
 	info                bool
 	ppsSet              bool
 	ppsPin              gpsio.ModemControlPin
+	invertPolarity      bool
 	ppsMethod           gpsio.PPSMethod
 	pollPreWarm         float64
 	maxWakeupLatency    time.Duration
@@ -109,7 +110,8 @@ func Cmd(logWriter io.Writer, logLevel slog.Level, progName, cmdName string, arg
 }
 
 const summary = `[-h|--help] [-a|--all | -d|--serial-device path] [-i|--info]
-              [-p|--pps-pin pin] [-m|--pps-method method] [--poll-pre-warm seconds]
+              [-p|--pps-pin pin] [-I|--invert-polarity] [-m|--pps-method method]
+              [--poll-pre-warm seconds]
               [--max-wakeup-latency microseconds] [--packet-log path]
               [-s|--device-speed bps]
               [-t|--timeout seconds] [-j|--jsonl]`
@@ -127,6 +129,7 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 	flags.StringVarP(&v.device, "serial-device", "d", "", "operate on the serial port at `path`")
 	flags.BoolVarP(&v.info, "info", "i", false, "show information about serial ports without opening them")
 	flags.StringVarP(&ppsPinName, "pps-pin", "p", "", "detect PPS edges on the modem-control input `pin` (cts, dcd, dsr, or ri)")
+	flags.BoolVarP(&v.invertPolarity, "invert-polarity", "I", false, "invert the usual PPS pulse polarity, for edges that trail the start of the second by the pulse width")
 	flags.StringVarP(&ppsMethodName, "pps-method", "m", "", "force the PPS edge detection `method` (poll, wait, or kernel)")
 	flags.Float64Var(&v.pollPreWarm, "poll-pre-warm", 0, "busy-wait `seconds` before each poll window, for hosts whose reads slow down while idle")
 	flags.Float64Var(&maxWakeupLatencyMicros, "max-wakeup-latency", 0, "limit CPU wakeup latency to `microseconds` while detecting PPS")
@@ -210,12 +213,16 @@ func parseFlags(cmdName string, args []string) (v flagVars, help bool, usageFunc
 		err = fmt.Errorf("--packet-log must not be empty")
 		return
 	}
-	if v.info && (v.ppsSet || methodSet || preWarmSet || v.maxWakeupLatencySet || v.deviceSpeedSet || timeoutSet || packetLogSet) {
-		err = fmt.Errorf("--info cannot be combined with --pps-pin, --pps-method, --poll-pre-warm, --max-wakeup-latency, --device-speed, --timeout, or --packet-log")
+	if v.info && (v.ppsSet || v.invertPolarity || methodSet || preWarmSet || v.maxWakeupLatencySet || v.deviceSpeedSet || timeoutSet || packetLogSet) {
+		err = fmt.Errorf("--info cannot be combined with --pps-pin, --invert-polarity, --pps-method, --poll-pre-warm, --max-wakeup-latency, --device-speed, --timeout, or --packet-log")
 		return
 	}
 	if v.ppsSet && !deviceSet && !v.all {
 		err = fmt.Errorf("--pps-pin requires --serial-device or --all")
+		return
+	}
+	if v.invertPolarity && !v.ppsSet {
+		err = fmt.Errorf("--invert-polarity requires --pps-pin")
 		return
 	}
 	if methodSet && !v.ppsSet {
@@ -434,9 +441,9 @@ func monitorPPS(ctx context.Context, lg *slog.Logger, v flagVars) error {
 	defer cancel(nil)
 	pr := &edgePrinter{out: os.Stdout, jsonl: v.jsonl, withDevice: v.all, cancel: cancel}
 	if v.all {
-		return scanPPSPorts(ctx, lg, v.ppsPin, v.ppsConfig(), pr)
+		return scanPPSPorts(ctx, lg, v.wiring(), v.ppsConfig(), pr)
 	}
-	result := monitorDevice(ctx, lg, v.device, v.deviceSpeed, v.ppsPin, v.ppsConfig(), v.packetLog, pr)
+	result := monitorDevice(ctx, lg, v.device, v.deviceSpeed, v.wiring(), v.ppsConfig(), v.packetLog, pr)
 	if code := result.exitCode(); code != 0 {
 		return commandError{msg: result.description(), code: code}
 	}
@@ -449,7 +456,16 @@ func (v flagVars) ppsConfig() serialpps.Config {
 	return serialpps.Config{Method: v.ppsMethod, PollPreWarm: v.pollPreWarm}
 }
 
-func scanPPSPorts(ctx context.Context, lg *slog.Logger, pin gpsio.ModemControlPin, ppsCfg serialpps.Config, pr *edgePrinter) error {
+// wiring is the pulse wiring the PPS flags describe.
+func (v flagVars) wiring() serialpps.Wiring {
+	w := serialpps.Wiring{Pin: v.ppsPin}
+	if v.invertPolarity {
+		w.Polarity = serialpps.PolarityAssert
+	}
+	return w
+}
+
+func scanPPSPorts(ctx context.Context, lg *slog.Logger, w serialpps.Wiring, ppsCfg serialpps.Config, pr *edgePrinter) error {
 	ports, err := serialenum.List()
 	if err != nil {
 		return err
@@ -458,7 +474,7 @@ func scanPPSPorts(ctx context.Context, lg *slog.Logger, pin gpsio.ModemControlPi
 		return commandError{msg: "no serial ports found", code: 2}
 	}
 	monitor := func(ctx context.Context, lg *slog.Logger, device string) ppsResult {
-		return monitorDevice(ctx, lg, device, 0, pin, ppsCfg, "", pr)
+		return monitorDevice(ctx, lg, device, 0, w, ppsCfg, "", pr)
 	}
 	return monitorPortList(ctx, lg, ports, monitor, os.Stderr)
 }
@@ -526,9 +542,9 @@ const (
 )
 
 // monitorDevice opens device and prints the timestamp of each PPS edge
-// detected on pin, keeping the receive side drained so receiver traffic
-// cannot stall the port.
-func monitorDevice(ctx context.Context, lg *slog.Logger, device string, speed int, pin gpsio.ModemControlPin, ppsCfg serialpps.Config, packetLogPath string, pr *edgePrinter) (result ppsResult) {
+// detected on the wired pin, keeping the receive side drained so receiver
+// traffic cannot stall the port.
+func monitorDevice(ctx context.Context, lg *slog.Logger, device string, speed int, w serialpps.Wiring, ppsCfg serialpps.Config, packetLogPath string, pr *edgePrinter) (result ppsResult) {
 	result.device = device
 	conn, _, err := gpsio.OpenSerial(device, speed)
 	if err != nil {
@@ -541,7 +557,7 @@ func monitorDevice(ctx context.Context, lg *slog.Logger, device string, speed in
 		closeDevice(lg, conn, device, &result.failure)
 		return
 	}
-	result.edges, err = detectEdges(ctx, lg, conn, pin, device, ppsCfg, pr)
+	result.edges, err = detectEdges(ctx, lg, conn, w, device, ppsCfg, pr)
 	if err != nil {
 		result.failure = serialPPS.describeError(err)
 	}
@@ -611,7 +627,7 @@ type ppsConn interface {
 	serialpps.StateReader
 }
 
-func detectEdges(parent context.Context, lg *slog.Logger, conn ppsConn, pin gpsio.ModemControlPin, device string, ppsCfg serialpps.Config, pr *edgePrinter) (int, error) {
+func detectEdges(parent context.Context, lg *slog.Logger, conn ppsConn, w serialpps.Wiring, device string, ppsCfg serialpps.Config, pr *edgePrinter) (int, error) {
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
@@ -622,7 +638,7 @@ func detectEdges(parent context.Context, lg *slog.Logger, conn ppsConn, pin gpsi
 		stats = nil
 	}
 	go func() {
-		err := serialpps.Detect(ctx, lg, conn, serialpps.Wiring{Pin: pin}, ppsCfg, edges, stats)
+		err := serialpps.Detect(ctx, lg, conn, w, ppsCfg, edges, stats)
 		stats.Log(lg)
 		errCh <- err
 	}()

--- a/time/app/serialcmd/serialcmd_test.go
+++ b/time/app/serialcmd/serialcmd_test.go
@@ -44,6 +44,7 @@ func TestParseFlags(t *testing.T) {
 		{name: "pps with packet log and timeout", args: []string{"-p", "dsr", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl", "-t", "30"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemDSR, packetLog: "capture.jsonl", timeout: 30 * time.Second}},
 		{name: "pps until interrupted", args: []string{"-p", "cts", "-t", "0", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS}},
 		{name: "pps JSONL", args: []string{"-j", "-p", "cts", "-a"}, want: flagVars{jsonl: true, all: true, ppsSet: true, ppsPin: gpsio.ModemCTS, timeout: defaultPPSTimeout}},
+		{name: "pps inverted polarity", args: []string{"-p", "cts", "--invert-polarity", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, invertPolarity: true, timeout: defaultPPSTimeout}},
 		{name: "pps by polling", args: []string{"-p", "cts", "-m", "poll", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, ppsMethod: gpsio.PPSMethodPoll, timeout: defaultPPSTimeout}},
 		{name: "pps by waiting", args: []string{"-p", "cts", "--pps-method", "wait", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemCTS, ppsMethod: gpsio.PPSMethodWait, timeout: defaultPPSTimeout}},
 		{name: "pps with kernel timestamps", args: []string{"-p", "dcd", "--pps-method", "kernel", "-d", "/dev/ttyS0"}, want: flagVars{device: "/dev/ttyS0", ppsSet: true, ppsPin: gpsio.ModemDCD, ppsMethod: gpsio.PPSMethodKernel, timeout: defaultPPSTimeout}},
@@ -56,6 +57,7 @@ func TestParseFlags(t *testing.T) {
 		{name: "info and packet log", args: []string{"-i", "-d", "/dev/ttyS0", "--packet-log", "capture.jsonl"}, wantErr: true},
 		{name: "info and timeout", args: []string{"-i", "-d", "/dev/ttyS0", "-t", "1"}, wantErr: true},
 		{name: "info and pps", args: []string{"-i", "-p", "cts", "-d", "/dev/ttyS0"}, wantErr: true},
+		{name: "invert polarity without pps", args: []string{"--invert-polarity", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "method without pps", args: []string{"-m", "poll", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "invalid method", args: []string{"-p", "cts", "-m", "sideband", "-d", "/dev/ttyS0"}, wantErr: true},
 		{name: "wakeup latency without pps", args: []string{"--max-wakeup-latency", "10", "-d", "/dev/ttyS0"}, wantErr: true},
@@ -333,7 +335,7 @@ func TestDetectEdgesAutomaticKernelMethod(t *testing.T) {
 	}, 1)
 	go func() {
 		pr := &edgePrinter{out: output}
-		count, err := detectEdges(ctx, lg, conn, gpsio.ModemCTS, "", serialpps.Config{}, pr)
+		count, err := detectEdges(ctx, lg, conn, serialpps.Wiring{Pin: gpsio.ModemCTS}, "", serialpps.Config{}, pr)
 		result <- struct {
 			count int
 			err   error
@@ -372,7 +374,7 @@ func TestDetectEdgesForcedPollingSkipsWaitBackend(t *testing.T) {
 	lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
-	count, err := detectEdges(ctx, lg, conn, gpsio.ModemCTS, "", serialpps.Config{Method: gpsio.PPSMethodPoll}, &edgePrinter{out: io.Discard})
+	count, err := detectEdges(ctx, lg, conn, serialpps.Wiring{Pin: gpsio.ModemCTS}, "", serialpps.Config{Method: gpsio.PPSMethodPoll}, &edgePrinter{out: io.Discard})
 	if err != nil || count != 0 {
 		t.Fatalf("detectEdges = %d, %v; want 0, nil", count, err)
 	}


### PR DESCRIPTION
The detection backends hard-coded the usual pulse polarity, in which the flag reads deasserted while the pulse is active and the on-time leading edge is the flag deasserting. A unit whose pulse instead asserts the flag had every pulse timestamped at its trailing edge, so detected edges trailed the start of the second by the pulse width.

This adds a `Polarity` field to `serialpps.Wiring`, with the usual convention as the zero value, and selects the published transition from it in the wait and poll backends; the kernel watch already captures both transitions. The option is `pps.invertPolarity` in the `[serial]` table and `-I`/`--invert-polarity` on `satpulsetool serial`.

Validated on real hardware with a receiver whose pulse asserts CTS: without the option, edges were detected at +0.100 s past the top of the second; with it, the wait and poll methods both detect edges at the top of the second.