### PR TITLE
Add a FreeBSD rc.d service script for satpulsed

### DIFF
--- a/configs/satpulsed.rc.freebsd
+++ b/configs/satpulsed.rc.freebsd
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# FreeBSD rc.d service script for satpulsed. Install it as
+# /usr/local/etc/rc.d/satpulsed, mode 755:
+#
+#   install -m 755 satpulsed.rc.freebsd /usr/local/etc/rc.d/satpulsed
+#
+# and create the unprivileged user it runs as, in the dialer group so
+# that it can open the serial ports:
+#
+#   pw useradd satpulse -c "SatPulse daemon" -d /nonexistent \
+#       -s /usr/sbin/nologin -G dialer
+#
+# Then enable and start the service:
+#
+#   sysrc satpulsed_enable=YES
+#   service satpulsed start
+#
+# The plain satpulsed service reads its serial device from
+# /usr/local/etc/satpulse.toml. To run one daemon per receiver instead,
+# link the script once per serial port; the port name after "satpulsed_"
+# selects the device and the configuration file:
+#
+#   ln -s satpulsed /usr/local/etc/rc.d/satpulsed_cuaU0
+#   sysrc satpulsed_cuaU0_enable=YES
+#   service satpulsed_cuaU0 start
+#
+# runs satpulsed with --serial-device /dev/cuaU0 and the first of
+# /usr/local/etc/satpulse.d/cuaU0.toml and /usr/local/etc/satpulse.toml
+# that exists.
+#
+# rc.conf variables, where NAME is satpulsed or satpulsed_<port>:
+#
+# NAME_enable (bool):    Set to "YES" to enable the service. Default "NO".
+# NAME_user (str):       User to run satpulsed as. Default "satpulse".
+# NAME_configfile (str): Configuration files to pass with -f; satpulsed
+#                        uses the first one that exists. Default as
+#                        described above.
+# NAME_logfile (str):    Log file for satpulsed output.
+#                        Default "/var/log/NAME.log".
+
+# PROVIDE: satpulsed
+# REQUIRE: NETWORKING DAEMON cleanvar devfs
+# BEFORE: ntpd
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+case "$0" in
+/etc/rc*)
+	# During boot and shutdown $0 is the rc driver script; the name of
+	# this script, or of the symlink it was reached by, is in $_file.
+	name="$_file"
+	;;
+*)
+	name="$0"
+	;;
+esac
+name="${name##*/}"
+port="${name#satpulsed}"
+port="${port#_}"
+
+rcvar="${name}_enable"
+
+load_rc_config "$name"
+
+eval ": \${${name}_enable:=NO}"
+eval ": \${${name}_user:=satpulse}"
+eval ": \${${name}_logfile:=/var/log/${name}.log}"
+if [ -n "$port" ]; then
+	eval ": \${${name}_configfile:=\"/usr/local/etc/satpulse.d/${port}.toml /usr/local/etc/satpulse.toml\"}"
+	device_args="--serial-device /dev/${port}"
+else
+	eval ": \${${name}_configfile:=/usr/local/etc/satpulse.toml}"
+	device_args=""
+fi
+
+eval _user="\$${name}_user"
+eval _logfile="\$${name}_logfile"
+eval _configfiles="\$${name}_configfile"
+config_args=""
+for f in $_configfiles; do
+	config_args="$config_args -f $f"
+done
+
+pidfile="/var/run/${name}.pid"
+command="/usr/sbin/daemon"
+command_args="-f -R 5 -P ${pidfile} -o ${_logfile} \
+    /usr/local/sbin/satpulsed --wait ${device_args} ${config_args}"
+
+start_precmd="satpulsed_precmd"
+
+# daemon(8) runs as ${name}_user, which cannot create files in /var/run
+# or /var/log, so pre-create its supervisor pidfile and log file.
+satpulsed_precmd()
+{
+	[ -e "${pidfile}" ] || install -o "${_user}" -m 644 /dev/null "${pidfile}"
+	[ -e "${_logfile}" ] || install -o "${_user}" -m 640 /dev/null "${_logfile}"
+}
+
+run_rc_command "$1"

--- a/docs/_includes/NEWS.md
+++ b/docs/_includes/NEWS.md
@@ -75,6 +75,7 @@ _Not yet released_
 - The `pulseEdge` event type in the JSONL event log has been renamed to `phcPulseEdge`, because SatPulse now supports two different kinds of pulse edge: PHC-timestamped and system-clock-timestamped. (#402)
 - A new `SATPULSE_VENDORS` environment variable gives the possible vendors of the connected GPS receiver; it can be overridden by the `--vendor` option of `satpulsetool` and `satpulsewb` and by `satpulsed`'s `[gps]` `vendor` key. (#392)
 - Building from source now uses `make` on macOS and FreeBSD as well as Linux, replacing the `unix-build.sh` script. `make install` works there too, installing under `/usr/local` by default, or under a prefix given by `prefix=`. (#420)
+- `satpulsed` can run as a FreeBSD service: `configs/satpulsed.rc.freebsd` is an rc.d script that runs it unprivileged under daemon(8) supervision, with one instance per serial port via symlinks. (#426)
 
 ## Changes in 0.2
 


### PR DESCRIPTION
satpulsed runs in the foreground and logs to stdout, so the script (`configs/satpulsed.rc.freebsd`, installed as `/usr/local/etc/rc.d/satpulsed`) starts it under daemon(8), which supplies supervision with restart, the supervisor pidfile that rc tracks, and log capture. It runs unprivileged by default: rc.subr starts it as a `satpulse` user via the standard `${name}_user` mechanism, with a precmd pre-creating the pidfile and log file, the node_exporter port's pattern. Nothing in the serial+SHM path needs root: a dialer-group user can open the cua devices, issue the RFC 2783 ioctls, and publish the SHM segments ntpd reads.

The plain satpulsed service reads the serial device from `/usr/local/etc/satpulse.toml`. Multiple receivers use the openvpn port symlink pattern: a link named `satpulsed_cuaU0` runs an instance with `--serial-device /dev/cuaU0` and the first of `/usr/local/etc/satpulse.d/cuaU0.toml` and `/usr/local/etc/satpulse.toml` that exists. The script is not installed by make, since Makefile.unix carries nothing variant-specific; its header documents the install steps, and a FreeBSD port can install it properly later.

Verified on FreeBSD 15.1: start, status and stop as the satpulse user with a u-blox receiver feeding kernel-timestamped PPS over SHM to the base ntpd, and a symlinked per-port instance; the boot-time invocation path is untested.

Part of #426.