### PR TITLE
serialenum: report the USB interface number of each port

### DIFF
--- a/docs/man/satpulsetool-serial.1.md
+++ b/docs/man/satpulsetool-serial.1.md
@@ -96,6 +96,7 @@ Requires **\-p**, or **\-s** and **\-\-packet\-log**.
 A port description object has `device` and `display` strings,
 for a USB port a `usb` object with numeric `vid` and `pid` fields,
 for a port with a USB serial number a `serial` string,
+for a USB port an `interface` string with the interface number,
 and, for a port with aliases, an `aliases` array of paths.
 A detected speed object has a `device` string and a numeric `speed`.
 With **\-p**, an edge object has a `device` string, an RFC 3339 UTC timestamp `t`,

--- a/gps/lib/serialenum/serialenum.go
+++ b/gps/lib/serialenum/serialenum.go
@@ -14,11 +14,12 @@ type USBID struct {
 
 // Port describes a serial port for display in a dropdown or CLI listing.
 type Port struct {
-	Device  string   `json:"device"`            // canonical device node to open
-	Display string   `json:"display"`           // human-readable label
-	USB     USBID    `json:"usb,omitzero"`      // USB vendor and product IDs
-	Serial  string   `json:"serial,omitempty"`  // USB serial number, empty if the device publishes none
-	Aliases []string `json:"aliases,omitempty"` // symlinks to Device, sorted (Linux only)
+	Device    string   `json:"device"`              // canonical device node to open
+	Display   string   `json:"display"`             // human-readable label
+	USB       USBID    `json:"usb,omitzero"`        // USB vendor and product IDs
+	Serial    string   `json:"serial,omitempty"`    // USB serial number, empty if the device publishes none
+	Interface string   `json:"interface,omitempty"` // USB interface number as sysfs spells it ("00", "02"), empty if unknown (Linux only)
+	Aliases   []string `json:"aliases,omitempty"`   // symlinks to Device, sorted (Linux only)
 }
 
 // enumeratorDisplay preserves the display formatting used with go.bug.st's

--- a/gps/lib/serialenum/serialenum_linux.go
+++ b/gps/lib/serialenum/serialenum_linux.go
@@ -85,8 +85,9 @@ func enumerate() ([]portInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	portCount := countUSBDevicePorts(ports)
 	for i := range ports {
-		setDisplay(&ports[i])
+		setDisplay(&ports[i], portCount[ports[i].usbDeviceKey()] > 1)
 	}
 	return ports, nil
 }
@@ -136,6 +137,13 @@ func readPortInfo(portPath, devicesDir string) (portInfo, error) {
 		uevent, err := readOptionalFile(filepath.Join(dir, "uevent"))
 		if err != nil {
 			return portInfo{}, err
+		}
+		if hasUeventValue(uevent, "DEVTYPE", "usb_interface") {
+			port.Interface, err = readOptionalFile(filepath.Join(dir, "bInterfaceNumber"))
+			if err != nil {
+				return portInfo{}, fmt.Errorf("reading USB attribute bInterfaceNumber: %w", err)
+			}
+			continue
 		}
 		if !hasUeventValue(uevent, "DEVTYPE", "usb_device") {
 			continue
@@ -232,7 +240,32 @@ func filterAndCollectAliases(ports []portInfo) ([]portInfo, error) {
 	return ports, nil
 }
 
-func setDisplay(port *portInfo) {
+type usbDeviceKey struct {
+	USBID
+	serial string
+}
+
+func (port *portInfo) usbDeviceKey() usbDeviceKey {
+	return usbDeviceKey{port.USB, port.Serial}
+}
+
+// countUSBDevicePorts counts the ports of each USB device, so that the ports
+// of a multi-port device, which share VID, PID and serial, can be told apart
+// by interface number.
+func countUSBDevicePorts(ports []portInfo) map[usbDeviceKey]int {
+	count := make(map[usbDeviceKey]int)
+	for i := range ports {
+		if ports[i].USB != (USBID{}) {
+			count[ports[i].usbDeviceKey()]++
+		}
+	}
+	return count
+}
+
+// setDisplay builds the display string. multiport says that other ports in
+// the list belong to the same USB device, so the interface number is needed
+// to tell them apart.
+func setDisplay(port *portInfo, multiport bool) {
 	deviceDetail := port.product
 	tag := ubloxTag(port.USB.VID, port.USB.PID)
 	if tag != "" && tag != "u-blox" {
@@ -247,6 +280,9 @@ func setDisplay(port *portInfo) {
 	details := append([]string(nil), port.Aliases...)
 	if deviceDetail != "" {
 		details = append(details, deviceDetail)
+	}
+	if multiport && port.Interface != "" {
+		details = append(details, "if"+port.Interface)
 	}
 	if len(details) != 0 {
 		port.Display += " (" + strings.Join(details, ", ") + ")"

--- a/gps/lib/serialenum/serialenum_linux.go
+++ b/gps/lib/serialenum/serialenum_linux.go
@@ -20,8 +20,9 @@ var (
 
 type portInfo struct {
 	Port
-	name    string
-	product string
+	name      string
+	product   string
+	usbSysDir string // sysfs directory of the USB device, empty for a non-USB port
 }
 
 // List enumerates hardware serial ports using sysfs. It never opens a device
@@ -87,7 +88,7 @@ func enumerate() ([]portInfo, error) {
 	}
 	portCount := countUSBDevicePorts(ports)
 	for i := range ports {
-		setDisplay(&ports[i], portCount[ports[i].usbDeviceKey()] > 1)
+		setDisplay(&ports[i], portCount[ports[i].usbSysDir] > 1)
 	}
 	return ports, nil
 }
@@ -152,6 +153,7 @@ func readPortInfo(portPath, devicesDir string) (portInfo, error) {
 		if err := readUSBDetails(dir, &port); err != nil {
 			return portInfo{}, err
 		}
+		port.usbSysDir = dir
 		break
 	}
 	return port, nil
@@ -240,23 +242,15 @@ func filterAndCollectAliases(ports []portInfo) ([]portInfo, error) {
 	return ports, nil
 }
 
-type usbDeviceKey struct {
-	USBID
-	serial string
-}
-
-func (port *portInfo) usbDeviceKey() usbDeviceKey {
-	return usbDeviceKey{port.USB, port.Serial}
-}
-
 // countUSBDevicePorts counts the ports of each USB device, so that the ports
-// of a multi-port device, which share VID, PID and serial, can be told apart
-// by interface number.
-func countUSBDevicePorts(ports []portInfo) map[usbDeviceKey]int {
-	count := make(map[usbDeviceKey]int)
+// of a multi-port device can be told apart by interface number. The sysfs
+// device directory identifies the physical device; VID, PID and serial do not,
+// since many devices have no serial number or share a default one.
+func countUSBDevicePorts(ports []portInfo) map[string]int {
+	count := make(map[string]int)
 	for i := range ports {
-		if ports[i].USB != (USBID{}) {
-			count[ports[i].usbDeviceKey()]++
+		if ports[i].usbSysDir != "" {
+			count[ports[i].usbSysDir]++
 		}
 	}
 	return count

--- a/gps/lib/serialenum/serialenum_linux_test.go
+++ b/gps/lib/serialenum/serialenum_linux_test.go
@@ -49,16 +49,24 @@ func TestListSyntheticFilesystem(t *testing.T) {
 	acmPort := filepath.Join(acmInterface, "tty", "ttyACM0")
 	makePort(t, "ttyACM0", acmPort)
 	makeUSBDevice(t, usbDevice, "1546", "01A9", "u-blox GNSS receiver", "")
-	makeUSBInterface(t, acmInterface)
+	makeUSBInterface(t, acmInterface, "00")
+
+	multiportDevice := filepath.Join(root, "sys", "devices", "pci0000:00", "usb1", "1-9")
+	makeUSBDevice(t, multiportDevice, "152a", "8231", "Septentrio USB Device", "0100019577")
+	for _, iface := range []struct{ num, tty string }{{"00", "ttyACM1"}, {"02", "ttyACM2"}} {
+		dir := filepath.Join(multiportDevice, "1-9:1."+iface.num[1:])
+		makePort(t, iface.tty, filepath.Join(dir, "tty", iface.tty))
+		makeUSBInterface(t, dir, iface.num)
+	}
 
 	usbSerialDevice := filepath.Join(root, "sys", "devices", "pci0000:00", "usb2", "2-1")
 	usbSerialInterface := filepath.Join(usbSerialDevice, "2-1:1.0")
 	usbSerialPort := filepath.Join(usbSerialInterface, "ttyUSB0", "tty", "ttyUSB0")
 	makePort(t, "ttyUSB0", usbSerialPort)
 	makeUSBDevice(t, usbSerialDevice, "0403", "6001", "FT232R USB UART", "BG02DBNX")
-	makeUSBInterface(t, usbSerialInterface)
+	makeUSBInterface(t, usbSerialInterface, "00")
 
-	for _, name := range []string{"rfcomm0", "ttyS0", "ttyS2", "ttyAMA0", "ttyACM0", "ttyUSB0"} {
+	for _, name := range []string{"rfcomm0", "ttyS0", "ttyS2", "ttyAMA0", "ttyACM0", "ttyACM1", "ttyACM2", "ttyUSB0"} {
 		writeFile(t, filepath.Join(devDir, name), "")
 	}
 	makeLink(t, filepath.Join(devDir, "gps0"), "ttyACM0")
@@ -87,7 +95,22 @@ func TestListSyntheticFilesystem(t *testing.T) {
 				VID: 0x1546,
 				PID: 0x01a9,
 			},
-			Aliases: []string{filepath.Join(devDir, "gps0"), filepath.Join(devDir, "zz-gps")},
+			Interface: "00",
+			Aliases:   []string{filepath.Join(devDir, "gps0"), filepath.Join(devDir, "zz-gps")},
+		},
+		{
+			Device:    filepath.Join(devDir, "ttyACM1"),
+			Display:   filepath.Join(devDir, "ttyACM1") + " (Septentrio USB Device, if00)",
+			USB:       USBID{VID: 0x152a, PID: 0x8231},
+			Serial:    "0100019577",
+			Interface: "00",
+		},
+		{
+			Device:    filepath.Join(devDir, "ttyACM2"),
+			Display:   filepath.Join(devDir, "ttyACM2") + " (Septentrio USB Device, if02)",
+			USB:       USBID{VID: 0x152a, PID: 0x8231},
+			Serial:    "0100019577",
+			Interface: "02",
 		},
 		{
 			Device:  filepath.Join(devDir, "ttyAMA0"),
@@ -105,7 +128,8 @@ func TestListSyntheticFilesystem(t *testing.T) {
 				VID: 0x0403,
 				PID: 0x6001,
 			},
-			Serial: "BG02DBNX",
+			Serial:    "BG02DBNX",
+			Interface: "00",
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -169,12 +193,13 @@ func makeUSBDevice(t *testing.T, dir, vid, pid, product, serial string) {
 	}
 }
 
-func makeUSBInterface(t *testing.T, dir string) {
+func makeUSBInterface(t *testing.T, dir, num string) {
 	t.Helper()
 	mkdir(t, dir)
 	sysDir := filepath.Dir(filepath.Dir(sysClassTTYDir))
 	makeLink(t, filepath.Join(dir, "subsystem"), filepath.Join(sysDir, "bus", "usb"))
 	writeFile(t, filepath.Join(dir, "uevent"), "DEVTYPE=usb_interface\n")
+	writeFile(t, filepath.Join(dir, "bInterfaceNumber"), num+"\n")
 }
 
 func mkdir(t *testing.T, path string) {

--- a/gps/lib/serialenum/serialenum_linux_test.go
+++ b/gps/lib/serialenum/serialenum_linux_test.go
@@ -59,6 +59,14 @@ func TestListSyntheticFilesystem(t *testing.T) {
 		makeUSBInterface(t, dir, iface.num)
 	}
 
+	for _, dev := range []struct{ port, tty string }{{"3-1", "ttyUSB1"}, {"3-2", "ttyUSB2"}} {
+		dir := filepath.Join(root, "sys", "devices", "pci0000:00", "usb3", dev.port)
+		iface := filepath.Join(dir, dev.port+":1.0")
+		makePort(t, dev.tty, filepath.Join(iface, dev.tty, "tty", dev.tty))
+		makeUSBDevice(t, dir, "1a86", "7523", "USB Serial", "")
+		makeUSBInterface(t, iface, "00")
+	}
+
 	usbSerialDevice := filepath.Join(root, "sys", "devices", "pci0000:00", "usb2", "2-1")
 	usbSerialInterface := filepath.Join(usbSerialDevice, "2-1:1.0")
 	usbSerialPort := filepath.Join(usbSerialInterface, "ttyUSB0", "tty", "ttyUSB0")
@@ -66,7 +74,7 @@ func TestListSyntheticFilesystem(t *testing.T) {
 	makeUSBDevice(t, usbSerialDevice, "0403", "6001", "FT232R USB UART", "BG02DBNX")
 	makeUSBInterface(t, usbSerialInterface, "00")
 
-	for _, name := range []string{"rfcomm0", "ttyS0", "ttyS2", "ttyAMA0", "ttyACM0", "ttyACM1", "ttyACM2", "ttyUSB0"} {
+	for _, name := range []string{"rfcomm0", "ttyS0", "ttyS2", "ttyAMA0", "ttyACM0", "ttyACM1", "ttyACM2", "ttyUSB0", "ttyUSB1", "ttyUSB2"} {
 		writeFile(t, filepath.Join(devDir, name), "")
 	}
 	makeLink(t, filepath.Join(devDir, "gps0"), "ttyACM0")
@@ -129,6 +137,18 @@ func TestListSyntheticFilesystem(t *testing.T) {
 				PID: 0x6001,
 			},
 			Serial:    "BG02DBNX",
+			Interface: "00",
+		},
+		{
+			Device:    filepath.Join(devDir, "ttyUSB1"),
+			Display:   filepath.Join(devDir, "ttyUSB1") + " (USB Serial)",
+			USB:       USBID{VID: 0x1a86, PID: 0x7523},
+			Interface: "00",
+		},
+		{
+			Device:    filepath.Join(devDir, "ttyUSB2"),
+			Display:   filepath.Join(devDir, "ttyUSB2") + " (USB Serial)",
+			USB:       USBID{VID: 0x1a86, PID: 0x7523},
 			Interface: "00",
 		},
 	}

--- a/time/app/serialcmd/serialcmd.go
+++ b/time/app/serialcmd/serialcmd.go
@@ -175,6 +175,9 @@ func (info *portInfo) Print(f *os.File) error {
 	if info.Serial != "" {
 		fmt.Fprintf(&b, " serial=%q", info.Serial)
 	}
+	if info.Interface != "" {
+		fmt.Fprintf(&b, " interface=%s", info.Interface)
+	}
 	for _, alias := range info.Aliases {
 		fmt.Fprintf(&b, " alias=%s", alias)
 	}

--- a/time/app/serialcmd/serialcmd_test.go
+++ b/time/app/serialcmd/serialcmd_test.go
@@ -39,11 +39,12 @@ func TestPrintPorts(t *testing.T) {
 	ports := []serialenum.Port{
 		{Device: "/dev/ttyS0", Display: "/dev/ttyS0"},
 		{
-			Device:  "/dev/ttyACM0",
-			Display: "/dev/ttyACM0 (/dev/gps0, u-blox gen 10)",
-			USB:     serialenum.USBID{VID: 0x1546, PID: 0x01a4},
-			Serial:  "BG02DBNX",
-			Aliases: []string{"/dev/gps0"},
+			Device:    "/dev/ttyACM0",
+			Display:   "/dev/ttyACM0 (/dev/gps0, u-blox gen 10)",
+			USB:       serialenum.USBID{VID: 0x1546, PID: 0x01a4},
+			Serial:    "BG02DBNX",
+			Interface: "00",
+			Aliases:   []string{"/dev/gps0"},
 		},
 	}
 	for _, tc := range []struct {
@@ -54,12 +55,12 @@ func TestPrintPorts(t *testing.T) {
 		{
 			name: "human",
 			want: "device=/dev/ttyS0 display=\"/dev/ttyS0\"\n" +
-				"device=/dev/ttyACM0 vid=1546 pid=01a4 serial=\"BG02DBNX\" alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\"\n",
+				"device=/dev/ttyACM0 vid=1546 pid=01a4 serial=\"BG02DBNX\" interface=00 alias=/dev/gps0 display=\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\"\n",
 		},
 		{
 			name:  "jsonl",
 			jsonl: true,
-			want:  "{\"device\":\"/dev/ttyS0\",\"display\":\"/dev/ttyS0\"}\n{\"device\":\"/dev/ttyACM0\",\"display\":\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\",\"usb\":{\"vid\":5446,\"pid\":420},\"serial\":\"BG02DBNX\",\"aliases\":[\"/dev/gps0\"]}\n",
+			want:  "{\"device\":\"/dev/ttyS0\",\"display\":\"/dev/ttyS0\"}\n{\"device\":\"/dev/ttyACM0\",\"display\":\"/dev/ttyACM0 (/dev/gps0, u-blox gen 10)\",\"usb\":{\"vid\":5446,\"pid\":420},\"serial\":\"BG02DBNX\",\"interface\":\"00\",\"aliases\":[\"/dev/gps0\"]}\n",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Multi-port USB devices such as Septentrio receivers expose several CDC-ACM ports on one device, all with the same vendor ID, product ID and serial number. The port listing from `satpulsetool serial` gave no way to tell them apart, and nothing in the output could be pasted into a udev rule to pick one.

This adds an `Interface` field to `serialenum.Port` holding the interface number as sysfs spells it in `bInterfaceNumber` (`"00"`, `"02"`), which also matches udev's `ATTRS{bInterfaceNumber}` and the `-ifNN` suffix of `/dev/serial/by-id` links. On Linux, `readPortInfo` reads the attribute from the `usb_interface` directory it already walks through on the way to the `usb_device`. Other platforms leave the field empty, since go.bug.st/serial does not expose it.

`satpulsetool serial -i` prints the value as `interface=NN` and includes it in the JSONL output. When two or more listed ports share the same vendor ID, product ID and serial number, the display string gains an `ifNN` detail so the entries differ; single-port devices are displayed as before.

Output on a machine with a ZED-F9P, a Septentrio receiver and a CP2102:

```
device=/dev/ttyACM0 vid=1546 pid=01a9 interface=00 alias=/dev/gps0 display="/dev/ttyACM0 (/dev/gps0, u-blox gen 9)"
device=/dev/ttyACM1 vid=152a pid=8231 serial="0100019577" interface=00 display="/dev/ttyACM1 (Septentrio USB Device, if00)"
device=/dev/ttyACM2 vid=152a pid=8231 serial="0100019577" interface=02 display="/dev/ttyACM2 (Septentrio USB Device, if02)"
device=/dev/ttyUSB0 vid=10c4 pid=ea60 serial="0001" interface=00 display="/dev/ttyUSB0 (CP2102 USB to UART Bridge Controller)"
```
