### PR TITLE
gpiomem: read a Raspberry Pi GPIO's level from the controller registers

### DIFF
--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -162,7 +162,7 @@ These packages are reusable libraries for GPS processing. They are in the librar
 
 `gps/lib/kpps` provides low-level access to kernel PPS sources using the RFC 2783 data model. It is currently implemented on Linux.
 
-`gps/lib/gpiomem` reads the level of a Raspberry Pi GPIO directly from the GPIO controller's registers, mapped read-only through the gpiomem device, identifying the SoC from the device tree. It is Linux-only and does not configure the pin.
+`gps/lib/gpiomem` reads the level of a Raspberry Pi GPIO directly from the GPIO controller's registers through the gpiomem device. It is Linux-only.
 
 `gps/lib/serialenum` enumerates serial ports with human-readable display names and composite numeric USB vendor/product IDs. On Linux it reads sysfs and includes top-level `/dev` aliases in display labels without opening device nodes; other platforms use go.bug.st/serial/enumerator.
 

--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -162,6 +162,8 @@ These packages are reusable libraries for GPS processing. They are in the librar
 
 `gps/lib/kpps` provides low-level access to kernel PPS sources using the RFC 2783 data model. It is currently implemented on Linux.
 
+`gps/lib/gpiomem` reads the level of a Raspberry Pi GPIO directly from the GPIO controller's registers, mapped read-only through the gpiomem device, identifying the SoC from the device tree. It is Linux-only and does not configure the pin.
+
 `gps/lib/serialenum` enumerates serial ports with human-readable display names and composite numeric USB vendor/product IDs. On Linux it reads sysfs and includes top-level `/dev` aliases in display labels without opening device nodes; other platforms use go.bug.st/serial/enumerator.
 
 `gps/lib/decconv` converts between base-10 decimal strings and int64 scaled integers without floating point. It is used for exact parsing and formatting of physical quantities like angles and lengths.

--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -162,7 +162,7 @@ These packages are reusable libraries for GPS processing. They are in the librar
 
 `gps/lib/kpps` provides low-level access to kernel PPS sources using the RFC 2783 data model. It is currently implemented on Linux.
 
-`gps/lib/gpiomem` reads the level of a Raspberry Pi GPIO directly from the GPIO controller's registers through the gpiomem device. It is Linux-only.
+`gps/lib/gpiomem` reads the level of a Raspberry Pi GPIO directly from the GPIO controller's registers through the gpiomem device. It is built for 64-bit Linux only.
 
 `gps/lib/serialenum` enumerates serial ports with human-readable display names and composite numeric USB vendor/product IDs. On Linux it reads sysfs and includes top-level `/dev` aliases in display labels without opening device nodes; other platforms use go.bug.st/serial/enumerator.
 

--- a/gps/lib/gpiomem/gpiomem.go
+++ b/gps/lib/gpiomem/gpiomem.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && arm64
 
 // Package gpiomem reads the level of a Raspberry Pi GPIO directly from the
 // GPIO controller's registers, mapped read-only through the gpiomem device
@@ -6,16 +6,14 @@
 // bus transaction, taking about a microsecond on a Raspberry Pi 5, which makes
 // it suitable for polling for a pulse edge. The package does not configure
 // the GPIO: it must already be an input, as the pps-gpio overlay or pinctrl
-// makes it.
+// makes it. It is built for 64-bit Linux only.
 package gpiomem
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"sync/atomic"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -32,35 +30,6 @@ type model struct {
 	reg    func(gpio int) (offset int, bit uint)
 }
 
-// models lists the supported SoCs. Only 64-bit SoCs are listed: the package
-// is used on arm64 only.
-var models = []model{
-	{soc: "brcm,bcm2712", device: "/dev/gpiomem0", length: 0x30000, count: 54, reg: rp1Reg},
-	{soc: "brcm,bcm2711", device: "/dev/gpiomem", length: 0x1000, count: 58, reg: bcm283xReg},
-	{soc: "brcm,bcm2837", device: "/dev/gpiomem", length: 0x1000, count: 54, reg: bcm283xReg},
-}
-
-// bcm283xReg locates a GPIO in the BCM2835 family's level registers: 32
-// GPIOs per register, the first at 0x34.
-func bcm283xReg(gpio int) (int, uint) {
-	return 0x34 + 4*(gpio/32), uint(gpio % 32)
-}
-
-// rp1Reg locates a GPIO in the RP1's level registers on the Raspberry Pi
-// 5. The GPIOs are in three banks of 28, 6 and 20; each bank's registers are
-// 0x4000 apart, with bank 0's level register at 0x10008.
-func rp1Reg(gpio int) (int, uint) {
-	bank, base := 0, 0
-	if gpio >= 34 {
-		bank, base = 2, 34
-	} else if gpio >= 28 {
-		bank, base = 1, 28
-	}
-	return 0x10008 + bank*0x4000, uint(gpio - base)
-}
-
-const compatiblePath = "/proc/device-tree/compatible"
-
 // Pin is a mapped GPIO whose level can be read.
 type Pin struct {
 	mapping []byte
@@ -68,6 +37,8 @@ type Pin struct {
 	mask    uint32
 	device  string
 }
+
+const compatiblePath = "/proc/device-tree/compatible"
 
 // Open maps the registers of the GPIO controller that the device tree
 // identifies and returns a reader for the level of GPIO gpio.
@@ -83,7 +54,7 @@ func Open(gpio int) (*Pin, error) {
 	if gpio < 0 || gpio >= m.count {
 		return nil, fmt.Errorf("GPIO %d is out of range; %s has GPIOs 0 to %d", gpio, m.soc, m.count-1)
 	}
-	f, err := os.OpenFile(m.device, os.O_RDONLY|syscall.O_SYNC, 0)
+	f, err := os.OpenFile(m.device, os.O_RDONLY|unix.O_SYNC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +65,15 @@ func Open(gpio int) (*Pin, error) {
 	}
 	offset, bit := m.reg(gpio)
 	return &Pin{mapping: b, level: (*uint32)(unsafe.Pointer(&b[offset])), mask: 1 << bit, device: m.device}, nil
+}
+
+// models lists the supported SoCs. The 32-bit-only BCM2835 and BCM2836
+// share the BCM283x layout but are left out until the package is built for
+// 32-bit systems.
+var models = []model{
+	{soc: "brcm,bcm2712", device: "/dev/gpiomem0", length: 0x30000, count: 54, reg: rp1Reg},
+	{soc: "brcm,bcm2711", device: "/dev/gpiomem", length: 0x1000, count: 58, reg: bcm283xReg},
+	{soc: "brcm,bcm2837", device: "/dev/gpiomem", length: 0x1000, count: 54, reg: bcm283xReg},
 }
 
 // modelFor finds the supported SoC among the device tree's NUL-separated
@@ -109,6 +89,26 @@ func modelFor(compatible []byte) (model, bool) {
 	return model{}, false
 }
 
+// bcm283xReg locates a GPIO in the BCM2835 family's level registers: 32
+// GPIOs per register, the first at 0x34.
+func bcm283xReg(gpio int) (int, uint) {
+	return 0x34 + 4*(gpio/32), uint(gpio % 32)
+}
+
+// rp1Reg locates a GPIO in the RP1's RIO_IN registers on the Raspberry Pi
+// 5, the register the kernel's pinctrl-rp1 driver reads for a GPIO's
+// level. The GPIOs are in three banks of 28, 6 and 20; each bank's
+// registers are 0x4000 apart, with bank 0's RIO_IN at 0x10008.
+func rp1Reg(gpio int) (int, uint) {
+	bank, base := 0, 0
+	if gpio >= 34 {
+		bank, base = 2, 34
+	} else if gpio >= 28 {
+		bank, base = 1, 28
+	}
+	return 0x10008 + bank*0x4000, uint(gpio - base)
+}
+
 // High reports whether the GPIO currently reads high.
 func (p *Pin) High() bool {
 	return atomic.LoadUint32(p.level)&p.mask != 0
@@ -119,10 +119,12 @@ func (p *Pin) Device() string {
 	return p.device
 }
 
-// Close unmaps the registers.
+// Close unmaps the registers. It must not be called while High may still
+// run: High has no guard, so a read after Close faults. Calling Close twice
+// is a programmer error and panics.
 func (p *Pin) Close() error {
 	if p.mapping == nil {
-		return errors.New("gpiomem: already closed")
+		panic("gpiomem: Pin closed twice")
 	}
 	err := unix.Munmap(p.mapping)
 	p.mapping = nil

--- a/gps/lib/gpiomem/gpiomem.go
+++ b/gps/lib/gpiomem/gpiomem.go
@@ -1,0 +1,130 @@
+//go:build linux
+
+// Package gpiomem reads the level of a Raspberry Pi GPIO directly from the
+// GPIO controller's registers, mapped read-only through the gpiomem device
+// that Raspberry Pi OS provides for user-space register access. A read is one
+// bus transaction, taking about a microsecond on a Raspberry Pi 5, which makes
+// it suitable for polling for a pulse edge. The package does not configure
+// the GPIO: it must already be an input, as the pps-gpio overlay or pinctrl
+// makes it.
+package gpiomem
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// A model describes the GPIO controller of a Raspberry Pi SoC: the device
+// that maps its registers, the length to map, the number of GPIOs, and the
+// location of a GPIO's level bit within the mapping.
+type model struct {
+	soc    string // the SoC's compatible string in the device tree
+	device string
+	length int
+	count  int
+	level  func(gpio int) (offset int, bit uint)
+}
+
+// models lists the supported SoCs. Only 64-bit SoCs are listed: the package
+// is used on arm64 only.
+var models = []model{
+	{soc: "brcm,bcm2712", device: "/dev/gpiomem0", length: 0x30000, count: 54, level: rp1Level},
+	{soc: "brcm,bcm2711", device: "/dev/gpiomem", length: 0x1000, count: 58, level: bcm283xLevel},
+	{soc: "brcm,bcm2837", device: "/dev/gpiomem", length: 0x1000, count: 54, level: bcm283xLevel},
+}
+
+// bcm283xLevel locates a GPIO in the BCM2835 family's level registers: 32
+// GPIOs per register, the first at 0x34.
+func bcm283xLevel(gpio int) (int, uint) {
+	return 0x34 + 4*(gpio/32), uint(gpio % 32)
+}
+
+// rp1Level locates a GPIO in the RP1's level registers on the Raspberry Pi
+// 5. The GPIOs are in three banks of 28, 6 and 20; each bank's registers are
+// 0x4000 apart, with bank 0's level register at 0x10008.
+func rp1Level(gpio int) (int, uint) {
+	bank, base := 0, 0
+	if gpio >= 34 {
+		bank, base = 2, 34
+	} else if gpio >= 28 {
+		bank, base = 1, 28
+	}
+	return 0x10008 + bank*0x4000, uint(gpio - base)
+}
+
+const compatiblePath = "/proc/device-tree/compatible"
+
+// Pin is a mapped GPIO whose level can be read.
+type Pin struct {
+	mapping []byte
+	level   *uint32
+	mask    uint32
+	device  string
+}
+
+// Open maps the registers of the GPIO controller that the device tree
+// identifies and returns a reader for the level of GPIO gpio.
+func Open(gpio int) (*Pin, error) {
+	compatible, err := os.ReadFile(compatiblePath)
+	if err != nil {
+		return nil, err
+	}
+	m, ok := modelFor(compatible)
+	if !ok {
+		return nil, fmt.Errorf("%s: no supported SoC in %q", compatiblePath, compatible)
+	}
+	if gpio < 0 || gpio >= m.count {
+		return nil, fmt.Errorf("GPIO %d is out of range; %s has GPIOs 0 to %d", gpio, m.soc, m.count-1)
+	}
+	f, err := os.OpenFile(m.device, os.O_RDONLY|syscall.O_SYNC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	b, err := unix.Mmap(int(f.Fd()), 0, m.length, unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("mapping %s: %w", m.device, err)
+	}
+	offset, bit := m.level(gpio)
+	return &Pin{mapping: b, level: (*uint32)(unsafe.Pointer(&b[offset])), mask: 1 << bit, device: m.device}, nil
+}
+
+// modelFor finds the supported SoC among the device tree's NUL-separated
+// compatible strings.
+func modelFor(compatible []byte) (model, bool) {
+	for _, s := range bytes.Split(compatible, []byte{0}) {
+		for _, m := range models {
+			if string(s) == m.soc {
+				return m, true
+			}
+		}
+	}
+	return model{}, false
+}
+
+// High reports whether the GPIO currently reads high.
+func (p *Pin) High() bool {
+	return atomic.LoadUint32(p.level)&p.mask != 0
+}
+
+// Device returns the path of the gpiomem device the GPIO is read through.
+func (p *Pin) Device() string {
+	return p.device
+}
+
+// Close unmaps the registers.
+func (p *Pin) Close() error {
+	if p.mapping == nil {
+		return errors.New("gpiomem: already closed")
+	}
+	err := unix.Munmap(p.mapping)
+	p.mapping = nil
+	return err
+}

--- a/gps/lib/gpiomem/gpiomem.go
+++ b/gps/lib/gpiomem/gpiomem.go
@@ -29,27 +29,27 @@ type model struct {
 	device string
 	length int
 	count  int
-	level  func(gpio int) (offset int, bit uint)
+	reg    func(gpio int) (offset int, bit uint)
 }
 
 // models lists the supported SoCs. Only 64-bit SoCs are listed: the package
 // is used on arm64 only.
 var models = []model{
-	{soc: "brcm,bcm2712", device: "/dev/gpiomem0", length: 0x30000, count: 54, level: rp1Level},
-	{soc: "brcm,bcm2711", device: "/dev/gpiomem", length: 0x1000, count: 58, level: bcm283xLevel},
-	{soc: "brcm,bcm2837", device: "/dev/gpiomem", length: 0x1000, count: 54, level: bcm283xLevel},
+	{soc: "brcm,bcm2712", device: "/dev/gpiomem0", length: 0x30000, count: 54, reg: rp1Reg},
+	{soc: "brcm,bcm2711", device: "/dev/gpiomem", length: 0x1000, count: 58, reg: bcm283xReg},
+	{soc: "brcm,bcm2837", device: "/dev/gpiomem", length: 0x1000, count: 54, reg: bcm283xReg},
 }
 
-// bcm283xLevel locates a GPIO in the BCM2835 family's level registers: 32
+// bcm283xReg locates a GPIO in the BCM2835 family's level registers: 32
 // GPIOs per register, the first at 0x34.
-func bcm283xLevel(gpio int) (int, uint) {
+func bcm283xReg(gpio int) (int, uint) {
 	return 0x34 + 4*(gpio/32), uint(gpio % 32)
 }
 
-// rp1Level locates a GPIO in the RP1's level registers on the Raspberry Pi
+// rp1Reg locates a GPIO in the RP1's level registers on the Raspberry Pi
 // 5. The GPIOs are in three banks of 28, 6 and 20; each bank's registers are
 // 0x4000 apart, with bank 0's level register at 0x10008.
-func rp1Level(gpio int) (int, uint) {
+func rp1Reg(gpio int) (int, uint) {
 	bank, base := 0, 0
 	if gpio >= 34 {
 		bank, base = 2, 34
@@ -92,7 +92,7 @@ func Open(gpio int) (*Pin, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mapping %s: %w", m.device, err)
 	}
-	offset, bit := m.level(gpio)
+	offset, bit := m.reg(gpio)
 	return &Pin{mapping: b, level: (*uint32)(unsafe.Pointer(&b[offset])), mask: 1 << bit, device: m.device}, nil
 }
 

--- a/gps/lib/gpiomem/gpiomem_test.go
+++ b/gps/lib/gpiomem/gpiomem_test.go
@@ -1,25 +1,31 @@
-//go:build linux
+//go:build linux && arm64
 
 package gpiomem
 
 import "testing"
 
 func TestModelFor(t *testing.T) {
-	m, ok := modelFor([]byte("raspberrypi,5-model-b\x00brcm,bcm2712\x00"))
-	if !ok || m.soc != "brcm,bcm2712" {
-		t.Errorf("modelFor(Pi 5) = %v, %v; want bcm2712", m.soc, ok)
-	}
-	if _, ok := modelFor([]byte("brcm,bcm2835\x00")); ok {
-		t.Error("modelFor(bcm2835) found a model; want unsupported")
+	for _, tc := range []struct {
+		compatible string
+		expectSoC  string
+		expectOK   bool
+	}{
+		{"raspberrypi,5-model-b\x00brcm,bcm2712\x00", "brcm,bcm2712", true},
+		{"raspberrypi,4-model-b\x00brcm,bcm2711\x00", "brcm,bcm2711", true},
+		{"brcm,bcm2835\x00", "", false},
+	} {
+		if m, ok := modelFor([]byte(tc.compatible)); ok != tc.expectOK || m.soc != tc.expectSoC {
+			t.Errorf("modelFor(%q) = %q, %v; want %q, %v", tc.compatible, m.soc, ok, tc.expectSoC, tc.expectOK)
+		}
 	}
 }
 
 func TestReg(t *testing.T) {
 	for _, tc := range []struct {
-		reg        func(int) (int, uint)
-		gpio       int
-		wantOffset int
-		wantBit    uint
+		reg          func(int) (int, uint)
+		gpio         int
+		expectOffset int
+		expectBit    uint
 	}{
 		{bcm283xReg, 18, 0x34, 18},
 		{bcm283xReg, 40, 0x38, 8},
@@ -27,8 +33,8 @@ func TestReg(t *testing.T) {
 		{rp1Reg, 30, 0x14008, 2},
 		{rp1Reg, 40, 0x18008, 6},
 	} {
-		if offset, bit := tc.reg(tc.gpio); offset != tc.wantOffset || bit != tc.wantBit {
-			t.Errorf("reg(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.wantOffset, tc.wantBit)
+		if offset, bit := tc.reg(tc.gpio); offset != tc.expectOffset || bit != tc.expectBit {
+			t.Errorf("reg(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.expectOffset, tc.expectBit)
 		}
 	}
 }

--- a/gps/lib/gpiomem/gpiomem_test.go
+++ b/gps/lib/gpiomem/gpiomem_test.go
@@ -14,20 +14,20 @@ func TestModelFor(t *testing.T) {
 	}
 }
 
-func TestLevel(t *testing.T) {
+func TestReg(t *testing.T) {
 	for _, tc := range []struct {
-		level      func(int) (int, uint)
+		reg        func(int) (int, uint)
 		gpio       int
 		wantOffset int
 		wantBit    uint
 	}{
-		{bcm283xLevel, 18, 0x34, 18},
-		{bcm283xLevel, 40, 0x38, 8},
-		{rp1Level, 18, 0x10008, 18},
-		{rp1Level, 30, 0x14008, 2},
-		{rp1Level, 40, 0x18008, 6},
+		{bcm283xReg, 18, 0x34, 18},
+		{bcm283xReg, 40, 0x38, 8},
+		{rp1Reg, 18, 0x10008, 18},
+		{rp1Reg, 30, 0x14008, 2},
+		{rp1Reg, 40, 0x18008, 6},
 	} {
-		if offset, bit := tc.level(tc.gpio); offset != tc.wantOffset || bit != tc.wantBit {
+		if offset, bit := tc.reg(tc.gpio); offset != tc.wantOffset || bit != tc.wantBit {
 			t.Errorf("level(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.wantOffset, tc.wantBit)
 		}
 	}

--- a/gps/lib/gpiomem/gpiomem_test.go
+++ b/gps/lib/gpiomem/gpiomem_test.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package gpiomem
+
+import "testing"
+
+func TestModelFor(t *testing.T) {
+	m, ok := modelFor([]byte("raspberrypi,5-model-b\x00brcm,bcm2712\x00"))
+	if !ok || m.soc != "brcm,bcm2712" {
+		t.Errorf("modelFor(Pi 5) = %v, %v; want bcm2712", m.soc, ok)
+	}
+	if _, ok := modelFor([]byte("brcm,bcm2835\x00")); ok {
+		t.Error("modelFor(bcm2835) found a model; want unsupported")
+	}
+}
+
+func TestLevel(t *testing.T) {
+	for _, tc := range []struct {
+		level      func(int) (int, uint)
+		gpio       int
+		wantOffset int
+		wantBit    uint
+	}{
+		{bcm283xLevel, 18, 0x34, 18},
+		{bcm283xLevel, 40, 0x38, 8},
+		{rp1Level, 18, 0x10008, 18},
+		{rp1Level, 30, 0x14008, 2},
+		{rp1Level, 40, 0x18008, 6},
+	} {
+		if offset, bit := tc.level(tc.gpio); offset != tc.wantOffset || bit != tc.wantBit {
+			t.Errorf("level(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.wantOffset, tc.wantBit)
+		}
+	}
+}

--- a/gps/lib/gpiomem/gpiomem_test.go
+++ b/gps/lib/gpiomem/gpiomem_test.go
@@ -28,7 +28,7 @@ func TestReg(t *testing.T) {
 		{rp1Reg, 40, 0x18008, 6},
 	} {
 		if offset, bit := tc.reg(tc.gpio); offset != tc.wantOffset || bit != tc.wantBit {
-			t.Errorf("level(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.wantOffset, tc.wantBit)
+			t.Errorf("reg(%d) = %#x, %d; want %#x, %d", tc.gpio, offset, bit, tc.wantOffset, tc.wantBit)
 		}
 	}
 }


### PR DESCRIPTION
Locating a PPS edge by polling needs to read a GPIO's level in about a microsecond, which no kernel interface offers: the GPIO character device's ioctl costs several microseconds and cannot be used at all while pps-gpio owns the line. Raspberry Pi OS provides the gpiomem device for user-space access to the GPIO controller's registers.

This adds `gps/lib/gpiomem`, which identifies the SoC from `/proc/device-tree/compatible`, maps the gpiomem device read-only and reads the level bit with an atomic load. The Pi 5 (RP1), Pi 4 (BCM2711) and Pi 3 (BCM2837) layouts are all verified by polling a PPS signal on 64-bit systems. The package does not configure the pin, which must already be an input, as the pps-gpio overlay makes it.

It is the platform layer for the daemon's polled GPIO PPS source (#460, plan/gpio-poll.md) and for the bias estimate planned for `satpulsetool pps` (plan/pps-tool.md), and has no users in this PR. It prepares for #460.