### PR TITLE
Move the source-neutral parts of serialpps into a pps package

### DIFF
--- a/docs/internals/packages.md
+++ b/docs/internals/packages.md
@@ -72,7 +72,9 @@ These packages provide GPS orchestration and CLI infrastructure. They are in the
 
 `gps/app/session` implements an interactive session with a GPS receiver -- connect, probe, configure, send message files, monitor, disconnect -- as the application core shared by GUI shells (the Wails desktop app, `cmd/satpulsewb`). It owns the packet pipeline goroutines, delivers events to the shell through a `Sink` interface, opens its transport through an `Opener` (serial device or a running satpulsed's proxy socket, with reset operations gated off over the proxy), and reconnects and re-probes when a reset re-enumerates a USB device. It was extracted from the desktop app's `app.go`.
 
-`gps/app/serialpps` detects PPS edges on serial modem-control input lines and combines their system timestamps with recent receiver UTC messages to generate refclock samples.
+`gps/app/pps` handles PPS edges timestamped by the system clock, independently of how they are detected: it combines an edge's timestamp with recent receiver UTC messages to generate a refclock sample, and provides the adaptive polling loop that detects edges on a pin whose level can only be read, predicting each pulse and polling in a window around it.
+
+`gps/app/serialpps` detects PPS edges on serial modem-control input lines, by polling through `gps/app/pps` or by waiting for line changes, and reports them as `gps/app/pps` candidate edges.
 
 `gps/app/ubxsim` implements a hardware-free fake u-blox receiver for smoke-testing configuration wiring. It answers the configuration interface with the ACK/NAK semantics of the interface description and replays a recorded packet log as nav output gated by its own MSGOUT configuration.
 

--- a/gps/app/pps/bubble_test.go
+++ b/gps/app/pps/bubble_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package serialpps
+package pps
 
 import (
 	"testing"

--- a/gps/app/pps/bubble_windows_test.go
+++ b/gps/app/pps/bubble_windows_test.go
@@ -1,4 +1,4 @@
-package serialpps
+package pps
 
 import "testing"
 

--- a/gps/app/pps/poll.go
+++ b/gps/app/pps/poll.go
@@ -14,11 +14,36 @@ type PulseReader interface {
 	InPulse() (bool, error)
 }
 
+// PollParams tunes Poll to the cost of the reader's queries. The zero value
+// suits serial modem-status queries, which take from tens of microseconds to
+// milliseconds, and sleeps on the runtime's timers.
+type PollParams struct {
+	// InitialPolls is the number of polls across the cold-start window. It
+	// determines the initial spacing, and with it the narrowest pulse
+	// acquired promptly. The spacing scales with the window, so once it
+	// falls below the query time or MinSpacing, those pace the loop instead.
+	// Zero means 64.
+	InitialPolls int
+	// MinSpacing bounds the CPU spent when the query is very fast. Zero
+	// means 50 microseconds.
+	MinSpacing time.Duration
+	// PreWarm ends the sleep to each window open that much early and
+	// busy-waits the remainder. It is for hosts whose queries slow down
+	// severalfold while the machine idles, where only continuous work
+	// ending at the open restores full query speed; it costs that fraction
+	// of a core. Zero disables it.
+	PreWarm time.Duration
+	// Wait, if non-nil, replaces the runtime timer that sleeps until a
+	// scheduled poll. It reports whether it actually waited: false means
+	// the scheduled time was already past or nearer than it can sleep to.
+	Wait func(ctx context.Context, t time.Time) (bool, error)
+}
+
 type poller struct {
 	ctx         context.Context
 	lg          *slog.Logger
 	r           PulseReader
-	prewarm     time.Duration
+	params      PollParams
 	ceCh        chan<- CandidateEdge
 	stats       *PollStats
 	nextEdge    time.Time
@@ -35,11 +60,6 @@ type poller struct {
 // where misses occur; consecutive misses double the window, and sustained
 // loss restarts the cycle from acquisition.
 //
-// A nonzero prewarm ends the sleep to each window open that much early and
-// busy-waits the remainder. It is for hosts whose state queries slow down
-// severalfold while the machine idles, where only continuous work ending at
-// the open restores full query speed; it costs that fraction of a core.
-//
 // Candidates caught during acquisition are unsettled, including the catch
 // that completes acquisition, whose transition the "serial PPS acquired" log
 // line marks; tracking candidates are settled once the polling schedule stops
@@ -49,11 +69,17 @@ type poller struct {
 // debug level. Tracking starts, significant window changes, misses, and loss
 // are logged at info level with actual state-read counts. If stats is non-nil,
 // Poll records timing and outcome statistics in it.
-func Poll(ctx context.Context, lg *slog.Logger, r PulseReader, prewarm time.Duration, ceCh chan<- CandidateEdge, stats *PollStats) error {
+func Poll(ctx context.Context, lg *slog.Logger, r PulseReader, params PollParams, ceCh chan<- CandidateEdge, stats *PollStats) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	stats.begin()
-	p := poller{ctx: ctx, lg: lg, r: r, prewarm: prewarm, ceCh: ceCh, stats: stats}
+	if params.InitialPolls == 0 {
+		params.InitialPolls = initialPolls
+	}
+	if params.MinSpacing == 0 {
+		params.MinSpacing = minSpacing
+	}
+	p := poller{ctx: ctx, lg: lg, r: r, params: params, ceCh: ceCh, stats: stats}
 	if err := p.init(); err != nil {
 		return err
 	}
@@ -79,18 +105,15 @@ const (
 )
 
 // None of these constants encodes hardware timing; everything hardware- and
-// load-dependent is measured by the polling loop itself.
+// load-dependent is measured by the polling loop itself. initialPolls and
+// minSpacing are the PollParams defaults, suited to serial modem-status
+// queries.
 const (
-	// initialPolls is the number of polls across the cold-start window. It
-	// determines the initial spacing, and with it the narrowest pulse acquired
-	// promptly. The spacing scales with the window, so once it falls below the
-	// state-query time or minSpacing, those pace the loop instead.
 	initialPolls = 64
 	// missLimit consecutive misses declare the pulse gone: acquisition
 	// abandons its attempt, and tracking, whose window doubles toward the
 	// full period as misses accumulate, returns to acquisition.
-	missLimit = 10
-	// minSpacing bounds the CPU spent when the state query is very fast.
+	missLimit  = 10
 	minSpacing = 50 * time.Microsecond
 )
 
@@ -107,6 +130,7 @@ const (
 // phase; missLimit misses after the window narrows abandon this attempt. The
 // returned duration is the window with which tracking should begin.
 func (p *poller) acquire() (time.Duration, bool, error) {
+	initialPolls, minSpacing := time.Duration(p.params.InitialPolls), p.params.MinSpacing
 	spacing := maxWindow / initialPolls
 	misses, queryPaced := 0, 0
 	for {
@@ -189,7 +213,7 @@ type trackEvent struct {
 // control. Tests call the same track function with a simulated attempt.
 func (p *poller) track(window time.Duration) error {
 	attempt := func(window time.Duration, atFloor bool) (trackObservation, error) {
-		spacing := max(window/initialPolls, minSpacing)
+		spacing := max(window/time.Duration(p.params.InitialPolls), p.params.MinSpacing)
 		caught, predictionError, err := p.pollWindow(window, spacing, true, atFloor)
 		return trackObservation{caught: caught, predictionError: predictionError,
 			lastBracket: p.lastBracket, stateReads: p.stateReads}, err
@@ -335,7 +359,7 @@ func (p *poller) logTrackEvent(e trackEvent) {
 	}
 }
 
-// clockReading keeps adjacent readings of the clocks used by serial PPS
+// clockReading keeps adjacent readings of the clocks used by the poller
 // together. stamp is the measurement reading used for short intervals and
 // published edge timestamps; mono paces the polling loop, which must not be
 // disturbed by a step in the system clock.
@@ -359,7 +383,7 @@ type reading struct {
 }
 
 func (p *poller) init() error {
-	first, err := readState(p.ctx, p.r, time.Time{})
+	first, err := p.readState(time.Time{})
 	if err != nil {
 		return err
 	}
@@ -380,8 +404,8 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	nextEdge := p.nextEdge
 	deadline := nextEdge.Add(window / 2)
 	open := nextEdge.Add(-window / 2)
-	if p.prewarm > 0 {
-		if _, err := waitUntil(p.ctx, open.Add(-p.prewarm)); err != nil {
+	if p.params.PreWarm > 0 {
+		if _, err := p.wait(open.Add(-p.params.PreWarm)); err != nil {
 			return false, 0, err
 		}
 		for time.Now().Before(open) {
@@ -390,7 +414,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 			}
 		}
 	}
-	cur, err := readState(p.ctx, p.r, open)
+	cur, err := p.readState(open)
 	if err != nil {
 		return false, 0, err
 	}
@@ -404,7 +428,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	// excluded: it always sleeps).
 	for cur.inPulse && cur.poll.midpoint().mono.Before(deadline) {
 		prev := cur
-		cur, err = readState(p.ctx, p.r, cur.start.Add(spacing))
+		cur, err = p.readState(cur.start.Add(spacing))
 		if err != nil {
 			return false, 0, err
 		}
@@ -416,7 +440,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	missed := cur.inPulse
 	var edge clockReading
 	for !missed && edge.stamp.IsZero() {
-		cur, err = readState(p.ctx, p.r, prev.start.Add(spacing))
+		cur, err = p.readState(prev.start.Add(spacing))
 		if err != nil {
 			return false, 0, err
 		}
@@ -452,7 +476,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 			TRead:     cur.poll.end.mono,
 		},
 		Uncertainty: halfCeil(p.lastBracket),
-		Settled:     acquired && (atFloor || spacing == minSpacing || !p.slept),
+		Settled:     acquired && (atFloor || spacing == p.params.MinSpacing || !p.slept),
 	}
 	select {
 	case p.ceCh <- ce:
@@ -462,19 +486,26 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	}
 }
 
-func readState(ctx context.Context, r PulseReader, sched time.Time) (reading, error) {
-	slept, err := waitUntil(ctx, sched)
+func (p *poller) readState(sched time.Time) (reading, error) {
+	slept, err := p.wait(sched)
 	if err != nil {
 		return reading{}, err
 	}
 	start := now()
-	inPulse, err := r.InPulse()
+	inPulse, err := p.r.InPulse()
 	end := now()
 	if err != nil {
 		return reading{}, err
 	}
 	return reading{inPulse: inPulse, poll: poll{start: start, end: end}, start: start.mono,
 		sched: sched, slept: slept}, nil
+}
+
+func (p *poller) wait(t time.Time) (bool, error) {
+	if p.params.Wait != nil {
+		return p.params.Wait(p.ctx, t)
+	}
+	return waitUntil(p.ctx, t)
 }
 
 // waitUntil reports whether it actually had to wait: false means the

--- a/gps/app/pps/poll.go
+++ b/gps/app/pps/poll.go
@@ -1,19 +1,23 @@
-package serialpps
+package pps
 
 import (
 	"context"
 	"log/slog"
 	"runtime"
 	"time"
-
-	"github.com/jclark/satpulse/gps/app/gpsio"
 )
+
+// PulseReader reads whether a pin is currently in a pulse. Its query time
+// bounds the resolution of polling, so it should be as fast as the platform
+// allows.
+type PulseReader interface {
+	InPulse() (bool, error)
+}
 
 type poller struct {
 	ctx         context.Context
 	lg          *slog.Logger
-	r           StateReader
-	w           Wiring
+	r           PulseReader
 	prewarm     time.Duration
 	ceCh        chan<- CandidateEdge
 	stats       *PollStats
@@ -23,7 +27,7 @@ type poller struct {
 	stateReads  int
 }
 
-// Poll adaptively polls for the pulse described by w and sends a candidate for
+// Poll adaptively polls for the pulse read by r and sends a candidate for
 // every leading edge it catches. It repeatedly runs acquisition followed by
 // tracking. Acquisition ends when polling resolution is acquired, or restarts
 // from cold after losing the partly acquired signal. Tracking shrinks the
@@ -45,11 +49,11 @@ type poller struct {
 // debug level. Tracking starts, significant window changes, misses, and loss
 // are logged at info level with actual state-read counts. If stats is non-nil,
 // Poll records timing and outcome statistics in it.
-func Poll(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, prewarm time.Duration, ceCh chan<- CandidateEdge, stats *PollStats) error {
+func Poll(ctx context.Context, lg *slog.Logger, r PulseReader, prewarm time.Duration, ceCh chan<- CandidateEdge, stats *PollStats) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	stats.begin()
-	p := poller{ctx: ctx, lg: lg, r: r, w: w, prewarm: prewarm, ceCh: ceCh, stats: stats}
+	p := poller{ctx: ctx, lg: lg, r: r, prewarm: prewarm, ceCh: ceCh, stats: stats}
 	if err := p.init(); err != nil {
 		return err
 	}
@@ -347,11 +351,11 @@ type poll struct {
 }
 
 type reading struct {
-	state gpsio.SerialPinState
-	poll  poll
-	start time.Time
-	sched time.Time // when this poll was scheduled to run
-	slept bool      // whether waiting for the schedule used a timer
+	inPulse bool
+	poll    poll
+	start   time.Time
+	sched   time.Time // when this poll was scheduled to run
+	slept   bool      // whether waiting for the schedule used a timer
 }
 
 func (p *poller) init() error {
@@ -398,7 +402,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	// every period and never acquire; poll through it instead. slept accumulates
 	// over the window's scheduled polls (the wait for the window open is
 	// excluded: it always sleeps).
-	for inPulse(cur.state, p.w) && cur.poll.midpoint().mono.Before(deadline) {
+	for cur.inPulse && cur.poll.midpoint().mono.Before(deadline) {
 		prev := cur
 		cur, err = readState(p.ctx, p.r, cur.start.Add(spacing))
 		if err != nil {
@@ -409,7 +413,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 		p.slept = p.slept || cur.slept
 	}
 	prev := cur
-	missed := inPulse(cur.state, p.w)
+	missed := cur.inPulse
 	var edge clockReading
 	for !missed && edge.stamp.IsZero() {
 		cur, err = readState(p.ctx, p.r, prev.start.Add(spacing))
@@ -419,7 +423,7 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 		p.stats.addPoll(cur.poll, &prev.poll)
 		p.stateReads++
 		p.slept = p.slept || cur.slept
-		edge, missed = classify(prev, cur, p.w, deadline)
+		edge, missed = classify(prev, cur, deadline)
 		if !edge.stamp.IsZero() {
 			p.lastBracket = cur.poll.midpoint().elapsedSince(prev.poll.midpoint())
 		}
@@ -458,18 +462,18 @@ func (p *poller) pollWindow(window, spacing time.Duration, acquired, atFloor boo
 	}
 }
 
-func readState(ctx context.Context, r StateReader, sched time.Time) (reading, error) {
+func readState(ctx context.Context, r PulseReader, sched time.Time) (reading, error) {
 	slept, err := waitUntil(ctx, sched)
 	if err != nil {
 		return reading{}, err
 	}
 	start := now()
-	state, err := r.SerialPinState()
+	inPulse, err := r.InPulse()
 	end := now()
 	if err != nil {
 		return reading{}, err
 	}
-	return reading{state: state, poll: poll{start: start, end: end}, start: start.mono,
+	return reading{inPulse: inPulse, poll: poll{start: start, end: end}, start: start.mono,
 		sched: sched, slept: slept}, nil
 }
 
@@ -503,20 +507,14 @@ func waitUntil(ctx context.Context, t time.Time) (bool, error) {
 // bracket means the measurement clock stepped backward between the reads
 // (its stamps carry no monotonic reading on Windows), so its midpoint is
 // equally meaningless: both are a miss.
-func classify(prev, cur reading, w Wiring, deadline time.Time) (clockReading, bool) {
-	if !inPulse(prev.state, w) && inPulse(cur.state, w) {
+func classify(prev, cur reading, deadline time.Time) (clockReading, bool) {
+	if !prev.inPulse && cur.inPulse {
 		if d := cur.poll.midpoint().elapsedSince(prev.poll.midpoint()); d >= period || d <= 0 {
 			return clockReading{}, true
 		}
 		return prev.poll.midpoint().midpoint(cur.poll.midpoint()), false
 	}
 	return clockReading{}, !cur.poll.midpoint().mono.Before(deadline)
-}
-
-// inPulse reports whether the state was observed during a pulse, as
-// selected by the wiring's polarity.
-func inPulse(s gpsio.SerialPinState, w Wiring) bool {
-	return s.Asserted(w.Pin) == w.Polarity.Asserted()
 }
 
 func halfCeil(d time.Duration) time.Duration {

--- a/gps/app/pps/poll_test.go
+++ b/gps/app/pps/poll_test.go
@@ -152,7 +152,7 @@ func TestPoll(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				candidates := make(chan CandidateEdge)
 				errCh := make(chan error, 1)
-				go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+				go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 				var got []CandidateEdge
 				sawSettling := false
 				for len(got) < 3 {
@@ -504,7 +504,7 @@ func TestPollShortOutageKeepsTracking(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		var first CandidateEdge
 		for pulseIndex(first.Timestamp, f.epoch) <= 15 || first.Timestamp.IsZero() {
 			first = <-candidates
@@ -540,7 +540,7 @@ func TestPollAcquiresWithCoarseStateRefresh(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		deadline := time.After(20 * period)
 		settled := 0
 		timedOut := false
@@ -573,7 +573,7 @@ func TestPollMissedPulseKeepsLatch(t *testing.T) {
 		errCh := make(chan error, 1)
 		var logs bytes.Buffer
 		lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
-		go func() { errCh <- Poll(ctx, lg, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, lg, f, PollParams{}, candidates, nil) }()
 		seen := make(map[int]bool)
 		for pulse := 0; pulse < 18; {
 			pulse = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -606,7 +606,7 @@ func TestPollOutageReacquires(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		var first int
 		for first <= 15 {
 			first = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -634,7 +634,7 @@ func TestPollTrackingConverges(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		for pulseIndex(nextSettled(candidates).Timestamp, f.epoch) < 100 {
 		}
 		start := f.calls.Load()
@@ -661,7 +661,7 @@ func TestPollLearnsDeliveryTail(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		seen := make(map[int]bool)
 		for last := 0; last < 500; {
 			last = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -698,7 +698,7 @@ func TestPollAcquiresDespiteSleepJitter(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, slog.New(capture), f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, slog.New(capture), f, PollParams{}, candidates, nil) }()
 		var got []CandidateEdge
 		for len(got) < 20 {
 			got = append(got, nextSettled(candidates))
@@ -763,7 +763,7 @@ func TestPollConfirmsQueryPacing(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, slog.New(capture), f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, slog.New(capture), f, PollParams{}, candidates, nil) }()
 		for range 3 {
 			nextSettled(candidates)
 		}
@@ -801,7 +801,7 @@ func testPollNarrowPulse(t *testing.T, epochOffset time.Duration) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, PollParams{}, candidates, nil) }()
 		var got []CandidateEdge
 		for len(got) < 3 {
 			got = append(got, nextSettled(candidates))
@@ -926,7 +926,7 @@ func (p errPin) InPulse() (bool, error) { return false, p.err }
 
 func TestPollReaderError(t *testing.T) {
 	e := errors.New("query failed")
-	if err := Poll(context.Background(), testLog, errPin{err: e}, 0, nil, nil); err != e {
+	if err := Poll(context.Background(), testLog, errPin{err: e}, PollParams{}, nil, nil); err != e {
 		t.Fatalf("Poll error = %v, want %v", err, e)
 	}
 }

--- a/gps/app/pps/poll_test.go
+++ b/gps/app/pps/poll_test.go
@@ -1,4 +1,4 @@
-package serialpps
+package pps
 
 import (
 	"bytes"
@@ -11,8 +11,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/jclark/satpulse/gps/app/gpsio"
 )
 
 // acquireCapture records the window attribute of the "serial PPS acquired"
@@ -76,13 +74,13 @@ type fakePulse struct {
 	edgeCallDur    time.Duration
 	stalled        bool
 	haveState      bool
-	lastState      gpsio.SerialPinState
+	lastState      bool
 	lastEnd        time.Time
 	seq            uint32
 	calls          atomic.Int64
 }
 
-func (f *fakePulse) SerialPinState() (gpsio.SerialPinState, error) {
+func (f *fakePulse) InPulse() (bool, error) {
 	f.calls.Add(1)
 	if f.wakeJitter > 0 && !f.lastEnd.IsZero() && time.Since(f.lastEnd) > 0 {
 		if f.seq++; f.seq%2 == 0 {
@@ -101,8 +99,7 @@ func (f *fakePulse) SerialPinState() (gpsio.SerialPinState, error) {
 	if f.slowCallDur > 0 && since >= f.slowFrom && since < f.slowTo {
 		callDur = f.slowCallDur
 	}
-	if state := f.state(since); f.edgeCallDur > 0 && f.haveState &&
-		f.lastState.Asserted(gpsio.SerialPinCTS) && !state.Asserted(gpsio.SerialPinCTS) {
+	if state := f.state(since); f.edgeCallDur > 0 && f.haveState && !f.lastState && state {
 		callDur = f.edgeCallDur
 	}
 	time.Sleep(callDur)
@@ -112,7 +109,7 @@ func (f *fakePulse) SerialPinState() (gpsio.SerialPinState, error) {
 	return state, nil
 }
 
-func (f *fakePulse) state(since time.Duration) gpsio.SerialPinState {
+func (f *fakePulse) state(since time.Duration) bool {
 	if f.stateRefresh > 0 && since >= 0 {
 		since = since.Truncate(f.stateRefresh)
 	}
@@ -121,10 +118,7 @@ func (f *fakePulse) state(since time.Duration) gpsio.SerialPinState {
 	if f.lateEvery > 0 && n%f.lateEvery == 0 {
 		off -= f.late
 	}
-	if since >= 0 && off >= 0 && off < f.width && !(f.offTo > 0 && n >= f.offFrom && n < f.offTo) {
-		return 0
-	}
-	return gpsio.NewSerialPinState(gpsio.SerialPinCTS)
+	return since >= 0 && off >= 0 && off < f.width && !(f.offTo > 0 && n >= f.offFrom && n < f.offTo)
 }
 
 func TestPoll(t *testing.T) {
@@ -158,7 +152,7 @@ func TestPoll(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				candidates := make(chan CandidateEdge)
 				errCh := make(chan error, 1)
-				go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+				go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 				var got []CandidateEdge
 				sawSettling := false
 				for len(got) < 3 {
@@ -510,7 +504,7 @@ func TestPollShortOutageKeepsTracking(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		var first CandidateEdge
 		for pulseIndex(first.Timestamp, f.epoch) <= 15 || first.Timestamp.IsZero() {
 			first = <-candidates
@@ -546,7 +540,7 @@ func TestPollAcquiresWithCoarseStateRefresh(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		deadline := time.After(20 * period)
 		settled := 0
 		timedOut := false
@@ -579,7 +573,7 @@ func TestPollMissedPulseKeepsLatch(t *testing.T) {
 		errCh := make(chan error, 1)
 		var logs bytes.Buffer
 		lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
-		go func() { errCh <- Poll(ctx, lg, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, lg, f, 0, candidates, nil) }()
 		seen := make(map[int]bool)
 		for pulse := 0; pulse < 18; {
 			pulse = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -612,7 +606,7 @@ func TestPollOutageReacquires(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		var first int
 		for first <= 15 {
 			first = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -640,7 +634,7 @@ func TestPollTrackingConverges(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		for pulseIndex(nextSettled(candidates).Timestamp, f.epoch) < 100 {
 		}
 		start := f.calls.Load()
@@ -667,7 +661,7 @@ func TestPollLearnsDeliveryTail(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		seen := make(map[int]bool)
 		for last := 0; last < 500; {
 			last = pulseIndex(nextSettled(candidates).Timestamp, f.epoch)
@@ -704,7 +698,7 @@ func TestPollAcquiresDespiteSleepJitter(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, slog.New(capture), f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, slog.New(capture), f, 0, candidates, nil) }()
 		var got []CandidateEdge
 		for len(got) < 20 {
 			got = append(got, nextSettled(candidates))
@@ -769,7 +763,7 @@ func TestPollConfirmsQueryPacing(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, slog.New(capture), f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, slog.New(capture), f, 0, candidates, nil) }()
 		for range 3 {
 			nextSettled(candidates)
 		}
@@ -807,7 +801,7 @@ func testPollNarrowPulse(t *testing.T, epochOffset time.Duration) {
 		ctx, cancel := context.WithCancel(context.Background())
 		candidates := make(chan CandidateEdge)
 		errCh := make(chan error, 1)
-		go func() { errCh <- Poll(ctx, testLog, f, Wiring{Pin: gpsio.SerialPinCTS}, 0, candidates, nil) }()
+		go func() { errCh <- Poll(ctx, testLog, f, 0, candidates, nil) }()
 		var got []CandidateEdge
 		for len(got) < 3 {
 			got = append(got, nextSettled(candidates))
@@ -830,10 +824,9 @@ func testPollNarrowPulse(t *testing.T, epochOffset time.Duration) {
 
 func TestClassify(t *testing.T) {
 	base := time.Unix(1_000, 0)
-	asserted := gpsio.NewSerialPinState(gpsio.SerialPinCTS)
 	tests := []struct {
 		name       string
-		curState   gpsio.SerialPinState
+		curInPulse bool
 		curAt      time.Duration
 		deadline   time.Duration
 		wantEdgeAt time.Duration
@@ -841,38 +834,38 @@ func TestClassify(t *testing.T) {
 	}{
 		{
 			name:       "transition before deadline",
+			curInPulse: true,
 			curAt:      4 * time.Millisecond,
 			deadline:   5 * time.Millisecond,
 			wantEdgeAt: 2 * time.Millisecond,
 		},
 		{
 			name:       "transition crossing deadline",
+			curInPulse: true,
 			curAt:      12 * time.Millisecond,
 			deadline:   5 * time.Millisecond,
 			wantEdgeAt: 6 * time.Millisecond,
 		},
 		{
 			name:     "no transition before deadline",
-			curState: asserted,
 			curAt:    4 * time.Millisecond,
 			deadline: 5 * time.Millisecond,
 		},
 		{
 			name:       "no transition reaching deadline",
-			curState:   asserted,
 			curAt:      5 * time.Millisecond,
 			deadline:   5 * time.Millisecond,
 			wantMissed: true,
 		},
 		{
 			name:       "no transition crossing deadline",
-			curState:   asserted,
 			curAt:      6 * time.Millisecond,
 			deadline:   5 * time.Millisecond,
 			wantMissed: true,
 		},
 		{
 			name:       "bracket spanning a period",
+			curInPulse: true,
 			curAt:      1100 * time.Millisecond,
 			deadline:   5 * time.Millisecond,
 			wantMissed: true,
@@ -888,9 +881,9 @@ func TestClassify(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			prevAt := clockReading{stamp: base, mono: base.Add(monoSkew)}
 			curAt := clockReading{stamp: base.Add(tc.curAt), mono: base.Add(tc.curAt + monoSkew)}
-			prev := reading{state: asserted, poll: poll{start: prevAt, end: prevAt}}
-			cur := reading{state: tc.curState, poll: poll{start: curAt, end: curAt}}
-			edge, missed := classify(prev, cur, Wiring{Pin: gpsio.SerialPinCTS}, base.Add(tc.deadline+monoSkew))
+			prev := reading{poll: poll{start: prevAt, end: prevAt}}
+			cur := reading{inPulse: tc.curInPulse, poll: poll{start: curAt, end: curAt}}
+			edge, missed := classify(prev, cur, base.Add(tc.deadline+monoSkew))
 			if missed != tc.wantMissed {
 				t.Errorf("missed = %v, want %v", missed, tc.wantMissed)
 			}
@@ -929,11 +922,11 @@ func TestClockReadingElapsedSinceUsesStamp(t *testing.T) {
 
 type errPin struct{ err error }
 
-func (p errPin) SerialPinState() (gpsio.SerialPinState, error) { return 0, p.err }
+func (p errPin) InPulse() (bool, error) { return false, p.err }
 
 func TestPollReaderError(t *testing.T) {
 	e := errors.New("query failed")
-	if err := Poll(context.Background(), testLog, errPin{err: e}, Wiring{Pin: gpsio.SerialPinCTS}, 0, nil, nil); err != e {
+	if err := Poll(context.Background(), testLog, errPin{err: e}, 0, nil, nil); err != e {
 		t.Fatalf("Poll error = %v, want %v", err, e)
 	}
 }

--- a/gps/app/pps/pollstats.go
+++ b/gps/app/pps/pollstats.go
@@ -1,4 +1,4 @@
-package serialpps
+package pps
 
 import (
 	"log/slog"

--- a/gps/app/pps/pps.go
+++ b/gps/app/pps/pps.go
@@ -1,0 +1,158 @@
+// Package pps turns detected PPS edges into refclock samples using UTC time
+// messages from the receiver, and provides the adaptive polling loop that
+// detects edges on a pin whose level can only be read.
+package pps
+
+import (
+	"time"
+
+	"github.com/jclark/satpulse/gps/ptime"
+)
+
+// maxMsgAge is how old the newest receiver time message may be for an edge to
+// still be identified with a UTC second.
+const maxMsgAge = 3 * time.Second
+
+// Edge is a detected leading edge and the time at which the backend read it.
+// Timestamp is the time assigned to the edge: a kernel timestamp, a polling
+// bracket midpoint, or a wait wakeup used as an edge proxy. Its wall reading
+// is always meaningful, and it carries a monotonic reading when the backend
+// can preserve one. TRead is an ordinary time.Now reading captured when the
+// wait or closing poll completed, before subsequent validation.
+type Edge struct {
+	Timestamp time.Time
+	TRead     time.Time
+}
+
+// CandidateEdge is an edge reported by a detection backend. Poll reports
+// every edge it catches so that diagnostic consumers can follow acquisition:
+// Uncertainty is half the width of the polling bracket, and Settled says no
+// improvement in accuracy is to be expected, because the polling schedule did
+// not limit this measurement (its spacing was at the floor or the state
+// queries paced the window) or the window has stopped shrinking. Candidates
+// are unsettled during acquisition, including the catch that completes it
+// (Settled records the state in which the edge was captured, and acquisition
+// succeeds as a consequence of that catch), and unsettled again during
+// tracking while a window grown by misses is still shrinking back. Timing
+// consumers can accept unsettled candidates with sufficiently small
+// Uncertainty, and use Settled to accept the resolution the hardware can
+// achieve. A wait or kernel candidate carries the backend timestamp directly,
+// has no polling uncertainty, and is always settled.
+type CandidateEdge struct {
+	Edge
+	Uncertainty time.Duration
+	Settled     bool
+}
+
+// GeneratorConfig controls how PPS edges are associated with UTC-labelled
+// receiver messages. Durations are expressed in seconds in TOML.
+type GeneratorConfig struct {
+	// DelayUncertainty is the allowed measurement uncertainty when an
+	// inferred post-pulse message delay is slightly negative.
+	DelayUncertainty float64 `toml:"delayUncertainty" check:">=0,<1" comment:"Uncertainty in measured pulse-to-message delay (s)"`
+	// MaxDelay is the maximum accepted inferred post-pulse message delay.
+	MaxDelay float64 `toml:"maxDelay" check:">0,<1" comment:"Maximum post-pulse message delay (s)"`
+}
+
+// DefaultGeneratorConfig returns the default edge-to-message association
+// configuration.
+func DefaultGeneratorConfig() GeneratorConfig {
+	return GeneratorConfig{DelayUncertainty: 0.005, MaxDelay: 0.8}
+}
+
+// Sample is a PPS refclock sample.
+type Sample struct {
+	Ref  time.Time
+	Sys  time.Time
+	Leap ptime.LeapSecondKind
+}
+
+// Generator associates PPS edges with UTC seconds using the latest receiver
+// time message. It is intended to be called from one dispatcher goroutine.
+type Generator struct {
+	msgUTC           time.Time
+	msgRead          time.Time // zero until the first message arrives
+	msgLeap          ptime.LeapSecondKind
+	delayUncertainty time.Duration
+	maxDelay         time.Duration
+}
+
+// NewGenerator creates an empty sample generator using cfg.
+func NewGenerator(cfg GeneratorConfig) *Generator {
+	return &Generator{
+		delayUncertainty: ptime.Seconds(cfg.DelayUncertainty),
+		maxDelay:         ptime.Seconds(cfg.MaxDelay),
+	}
+}
+
+// MsgUTCTime records the newest UTC/system-time pair from a receiver message.
+func (g *Generator) MsgUTCTime(utc, tRead time.Time, leap ptime.LeapSecondKind) {
+	if tRead.Before(g.msgRead) {
+		return
+	}
+	g.msgUTC = utc
+	g.msgRead = tRead
+	g.msgLeap = leap
+}
+
+// Sample turns a precisely detected PPS edge into a sample. It returns false
+// until a time message is available, when the newest message is over three
+// seconds old, when no unique UTC label satisfies the configured
+// pulse-to-message delay bounds, or for the pulse marking an inserted leap
+// second.
+func (g *Generator) Sample(edge Edge) (Sample, bool) {
+	if g.msgRead.IsZero() {
+		return Sample{}, false
+	}
+	// Transfer the timestamp onto the message-read timeline through TRead.
+	// The long message-to-read interval is monotonic; the short correction
+	// back to the edge uses Timestamp's monotonic reading when it has one and
+	// otherwise its wall reading. A wall-clock step during that correction can
+	// still corrupt it, but a step anywhere else in the message-to-edge span
+	// cannot. Use the transferred interval for both age and UTC extrapolation.
+	edgeSinceMsg := edge.TRead.Sub(g.msgRead) - edge.TRead.Sub(edge.Timestamp)
+	if edgeSinceMsg > maxMsgAge {
+		return Sample{}, false
+	}
+	// Select the integral second whose inferred pulse-to-message delay is in
+	// the configured causal interval. The validated interval is narrower than
+	// a second, so the label is unique when it exists.
+	edgeUTC := g.msgUTC.Add(edgeSinceMsg)
+	ref := edgeUTC.Truncate(time.Second)
+	delay := ref.Sub(edgeUTC)
+	if delay < -g.delayUncertainty {
+		ref = ref.Add(time.Second)
+		delay += time.Second
+	}
+	if delay < -g.delayUncertainty || delay >= g.maxDelay {
+		return Sample{}, false
+	}
+	// The message's leap flag announces a leap at the end of the message's
+	// UTC day, which the monotonic extrapolation cannot see: past the
+	// boundary it runs one second ahead of UTC after a positive leap and
+	// one second behind after a negative one. The inserted second itself
+	// has no value on the leap-free timescale of time.Time and the refclock
+	// samples (midnight is the next pulse's label, 23:59:59 the previous
+	// one's), so its pulse yields no sample.
+	midnight := g.msgUTC.Truncate(24 * time.Hour).Add(24 * time.Hour)
+	if g.msgLeap == ptime.LeapSecondPositive && !ref.Before(midnight) {
+		if ref.Equal(midnight) {
+			return Sample{}, false
+		}
+		ref = ref.Add(-time.Second)
+	} else if g.msgLeap == ptime.LeapSecondNegative && !ref.Before(midnight.Add(-time.Second)) {
+		ref = ref.Add(time.Second)
+	}
+	leap := g.msgLeap
+	// If the edge falls in a different day than the message, the
+	// announcement does not apply to it; a retained pre-midnight flag must
+	// not re-announce a leap that has already happened.
+	if !ref.Truncate(24 * time.Hour).Equal(g.msgUTC.Truncate(24 * time.Hour)) {
+		leap = ptime.LeapSecondNone
+	}
+	return Sample{
+		Ref:  ref,
+		Sys:  edge.Timestamp,
+		Leap: leap,
+	}, true
+}

--- a/gps/app/pps/pps.go
+++ b/gps/app/pps/pps.go
@@ -4,8 +4,10 @@
 package pps
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/jclark/satpulse/gps/lib/check"
 	"github.com/jclark/satpulse/gps/ptime"
 )
 
@@ -58,6 +60,17 @@ type GeneratorConfig struct {
 // configuration.
 func DefaultGeneratorConfig() GeneratorConfig {
 	return GeneratorConfig{DelayUncertainty: 0.005, MaxDelay: 0.8}
+}
+
+// Validate checks that the delay interval is narrower than one second, so at
+// most one integral UTC label can satisfy it. The keys' own ranges are
+// expressed by check tags, so a struct embedding GeneratorConfig validates
+// them with check.Validate and calls this for the interval.
+func (cfg GeneratorConfig) Validate() error {
+	if len(check.Validate(cfg)) == 0 && !(cfg.DelayUncertainty+cfg.MaxDelay < 1) {
+		return fmt.Errorf("delayUncertainty + maxDelay: must be < 1, got %g", cfg.DelayUncertainty+cfg.MaxDelay)
+	}
+	return nil
 }
 
 // Sample is a PPS refclock sample.

--- a/gps/app/pps/pps_test.go
+++ b/gps/app/pps/pps_test.go
@@ -1,0 +1,279 @@
+package pps
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jclark/satpulse/gps/ptime"
+)
+
+var testLog = slog.New(slog.DiscardHandler)
+
+func TestGenerator(t *testing.T) {
+	msgUTC := time.Unix(1_000, 0).UTC()
+	msgRead := time.Unix(900, 125_000_000)
+	edge := time.Unix(900, 1_000_000)
+	tests := []struct {
+		name string
+		msg  bool
+		age  time.Duration
+		leap ptime.LeapSecondKind
+		ok   bool
+	}{
+		{name: "identifies second", msg: true, leap: ptime.LeapSecondNone, ok: true},
+		{name: "positive leap passthrough", msg: true, leap: ptime.LeapSecondPositive, ok: true},
+		{name: "negative leap passthrough", msg: true, leap: ptime.LeapSecondNegative, ok: true},
+		{name: "message exactly three seconds old", msg: true, age: 3 * time.Second, ok: true},
+		{name: "stale message", msg: true, age: 3*time.Second + time.Nanosecond},
+		{name: "no message"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGenerator(DefaultGeneratorConfig())
+			tEdge := edge
+			utc := msgUTC
+			read := msgRead
+			if tc.age != 0 {
+				read = tEdge.Add(-tc.age)
+				utc = read.Add(msgUTC.Sub(msgRead))
+			}
+			if tc.msg {
+				g.MsgUTCTime(utc, read, tc.leap)
+			}
+			sample, ok := g.Sample(Edge{Timestamp: tEdge, TRead: tEdge})
+			if ok != tc.ok {
+				t.Fatalf("Edge ok = %v, want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			wantRef := time.Unix(1_000, 0).UTC()
+			if !sample.Ref.Equal(wantRef) {
+				t.Errorf("reference = %v, want %v", sample.Ref, wantRef)
+			}
+			if !sample.Sys.Equal(tEdge) {
+				t.Errorf("system = %v, want %v", sample.Sys, tEdge)
+			}
+			if sample.Leap != tc.leap {
+				t.Errorf("leap = %v, want %v", sample.Leap, tc.leap)
+			}
+		})
+	}
+}
+
+func TestGeneratorTransfersTimestampThroughReadTime(t *testing.T) {
+	tests := []struct {
+		name          string
+		readSinceMsg  time.Duration
+		readAfterEdge time.Duration
+		wantRef       time.Time
+	}{
+		{
+			name:          "delivery correction determines second label",
+			readSinceMsg:  9 * time.Millisecond,
+			readAfterEdge: 10 * time.Millisecond,
+			wantRef:       time.Unix(1_000, 0).UTC(),
+		},
+		{
+			name:          "delivery correction determines message age",
+			readSinceMsg:  3100 * time.Millisecond,
+			readAfterEdge: 100 * time.Millisecond,
+			wantRef:       time.Unix(1_003, 0).UTC(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGenerator(DefaultGeneratorConfig())
+			msgRead := time.Now()
+			g.MsgUTCTime(time.Unix(1_000, 0).UTC(), msgRead, ptime.LeapSecondNone)
+			tRead := msgRead.Add(tc.readSinceMsg)
+			// Reconstruct Timestamp from wall time to model a kernel or
+			// Windows timestamp without a monotonic reading.
+			timestamp := time.Unix(0, tRead.UnixNano()).Add(-tc.readAfterEdge)
+			sample, ok := g.Sample(Edge{Timestamp: timestamp, TRead: tRead})
+			if !ok {
+				t.Fatal("Edge returned no sample")
+			}
+			if !sample.Ref.Equal(tc.wantRef) {
+				t.Errorf("reference = %v, want %v", sample.Ref, tc.wantRef)
+			}
+			if !sample.Sys.Equal(timestamp) {
+				t.Errorf("system = %v, want timestamp %v", sample.Sys, timestamp)
+			}
+		})
+	}
+}
+
+func TestGeneratorKeepsNewestMessage(t *testing.T) {
+	g := NewGenerator(DefaultGeneratorConfig())
+	newRead := time.Unix(100, 100_000_000)
+	g.MsgUTCTime(time.Unix(200, 0), newRead, ptime.LeapSecondPositive)
+	g.MsgUTCTime(time.Unix(300, 0), newRead.Add(-time.Second), ptime.LeapSecondNegative)
+	sample, ok := g.Sample(Edge{Timestamp: time.Unix(100, 0), TRead: time.Unix(100, 0)})
+	if !ok {
+		t.Fatal("Edge returned no sample")
+	}
+	if !sample.Ref.Equal(time.Unix(200, 0)) || sample.Leap != ptime.LeapSecondPositive {
+		t.Fatalf("sample = %+v, want newest message reference and leap", sample)
+	}
+}
+
+func TestGeneratorDelayBounds(t *testing.T) {
+	cfg := DefaultGeneratorConfig()
+	tests := []struct {
+		name  string
+		delay time.Duration
+		ok    bool
+	}{
+		{name: "at negative uncertainty bound", delay: -ptime.Seconds(cfg.DelayUncertainty), ok: true},
+		{name: "below negative uncertainty bound", delay: -ptime.Seconds(cfg.DelayUncertainty) - time.Nanosecond},
+		{name: "zero delay", delay: 0, ok: true},
+		{name: "below maximum delay", delay: ptime.Seconds(cfg.MaxDelay) - time.Nanosecond, ok: true},
+		{name: "at maximum delay", delay: ptime.Seconds(cfg.MaxDelay)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGenerator(cfg)
+			utc := time.Unix(1_000, 0).UTC()
+			tRead := time.Unix(900, 0)
+			g.MsgUTCTime(utc, tRead, ptime.LeapSecondNone)
+			at := tRead.Add(-tc.delay)
+			sample, ok := g.Sample(Edge{Timestamp: at, TRead: at})
+			if ok != tc.ok {
+				t.Fatalf("Edge ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && !sample.Ref.Equal(utc) {
+				t.Errorf("reference = %v, want %v", sample.Ref, utc)
+			}
+		})
+	}
+}
+
+func TestGeneratorLeapCrossing(t *testing.T) {
+	tests := []struct {
+		name       string
+		utc        time.Time
+		leap       ptime.LeapSecondKind
+		elapsed    time.Duration // edge.Timestamp - tRead
+		expectRef  time.Time
+		expectLeap ptime.LeapSecondKind
+		expectOK   bool
+	}{
+		{name: "pulse before positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
+			elapsed: -125 * time.Millisecond, expectRef: time.Unix(86_399, 0), expectLeap: ptime.LeapSecondPositive, expectOK: true},
+		{name: "inserted second pulse yields no sample", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
+			elapsed: 875 * time.Millisecond},
+		{name: "first pulse after positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
+			elapsed: 1875 * time.Millisecond, expectRef: time.Unix(86_400, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
+		{name: "second pulse after positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
+			elapsed: 2875 * time.Millisecond, expectRef: time.Unix(86_401, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
+		{name: "pulse before negative leap", utc: time.Unix(86_398, 0), leap: ptime.LeapSecondNegative,
+			elapsed: -125 * time.Millisecond, expectRef: time.Unix(86_398, 0), expectLeap: ptime.LeapSecondNegative, expectOK: true},
+		{name: "first pulse after negative leap", utc: time.Unix(86_398, 0), leap: ptime.LeapSecondNegative,
+			elapsed: 875 * time.Millisecond, expectRef: time.Unix(86_400, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGenerator(DefaultGeneratorConfig())
+			read := time.Unix(1_000_000, 125_000_000)
+			g.MsgUTCTime(tc.utc, read, tc.leap)
+			at := read.Add(tc.elapsed)
+			sample, ok := g.Sample(Edge{Timestamp: at, TRead: at})
+			if ok != tc.expectOK {
+				t.Fatalf("Edge ok = %v, want %v", ok, tc.expectOK)
+			}
+			if !ok {
+				return
+			}
+			if !sample.Ref.Equal(tc.expectRef) || sample.Leap != tc.expectLeap {
+				t.Errorf("sample = %+v, want reference %v and leap %v", sample, tc.expectRef, tc.expectLeap)
+			}
+		})
+	}
+}
+
+func TestPollStatsSummary(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	newReading := func(offset time.Duration) clockReading {
+		return clockReading{stamp: base.Add(offset), mono: base.Add(offset)}
+	}
+	polls := []poll{
+		{start: newReading(0), end: newReading(time.Millisecond)},
+		{start: newReading(11 * time.Millisecond), end: newReading(13 * time.Millisecond)},
+		{start: newReading(33 * time.Millisecond), end: newReading(36 * time.Millisecond)},
+		{start: newReading(66 * time.Millisecond), end: newReading(70 * time.Millisecond)},
+		{start: newReading(110 * time.Millisecond), end: newReading(115 * time.Millisecond)},
+	}
+	stats := new(PollStats)
+	stats.addPoll(polls[0], nil)
+	for i := 1; i < len(polls); i++ {
+		stats.addPoll(polls[i], &polls[i-1])
+	}
+	stats.addWindow(false, false)
+	stats.addWindow(true, false)
+	stats.addWindow(true, true)
+
+	got := stats.summary()
+	want := pollStatsSummary{
+		PollDuration: durationStats{
+			Count: 5, Sampled: 5, Min: time.Millisecond, Median: 3 * time.Millisecond,
+			Mean: 3 * time.Millisecond, P90: 5 * time.Millisecond, Max: 5 * time.Millisecond,
+		},
+		PollGap: durationStats{
+			Count: 4, Sampled: 4, Min: 10 * time.Millisecond, Median: 30 * time.Millisecond,
+			Mean: 25 * time.Millisecond, P90: 40 * time.Millisecond, Max: 40 * time.Millisecond,
+		},
+	}
+	want.Acquire.Windows, want.Acquire.Edges = 2, 1
+	want.Track.Windows, want.Track.Edges = 1, 1
+	if got != want {
+		t.Errorf("Summary() = %+v, want %+v", got, want)
+	}
+}
+
+func TestPollStatsTimingSamplesAreBounded(t *testing.T) {
+	stats := new(PollStats)
+	base := time.Unix(1_700_000_000, 0)
+	for i := range pollStatsSampleLimit + 1 {
+		start := clockReading{stamp: base, mono: base}
+		end := clockReading{stamp: base.Add(time.Duration(i) + 1), mono: base.Add(time.Duration(i) + 1)}
+		stats.addPoll(poll{start: start, end: end}, nil)
+	}
+	summary := stats.summary().PollDuration
+	if summary.Count != pollStatsSampleLimit+1 || summary.Sampled != pollStatsSampleLimit {
+		t.Errorf("duration counts = %d total, %d sampled; want %d total, %d sampled",
+			summary.Count, summary.Sampled, pollStatsSampleLimit+1, pollStatsSampleLimit)
+	}
+}
+
+func TestPollStatsLog(t *testing.T) {
+	stats := new(PollStats)
+	stats.begin()
+	start := clockReading{stamp: time.Unix(1_700_000_000, 0), mono: time.Unix(1_700_000_000, 0)}
+	end := clockReading{stamp: start.stamp.Add(2 * time.Millisecond), mono: start.mono.Add(2 * time.Millisecond)}
+	stats.addPoll(poll{start: start, end: end}, nil)
+	stats.addWindow(true, false)
+
+	var output bytes.Buffer
+	stats.Log(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	for _, want := range []string{
+		`msg="serial PPS polling statistics" acquire.windows=1 acquire.edges=1 track.windows=0 track.edges=0`,
+		`msg="serial PPS state read times" count=1 min=2ms median=2ms mean=2ms p90=2ms max=2ms`,
+		`msg="serial PPS between-read times" count=0`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("log %q does not contain %q", output.String(), want)
+		}
+	}
+}
+
+func TestPollStatsLogSkipsUnusedStats(t *testing.T) {
+	var output bytes.Buffer
+	new(PollStats).Log(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	if output.Len() != 0 {
+		t.Errorf("unused polling statistics logged %q", output.String())
+	}
+}

--- a/gps/app/pps/readtime.go
+++ b/gps/app/pps/readtime.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package serialpps
+package pps
 
 import "time"
 

--- a/gps/app/pps/readtime_windows.go
+++ b/gps/app/pps/readtime_windows.go
@@ -1,4 +1,4 @@
-package serialpps
+package pps
 
 import (
 	"time"

--- a/gps/app/pps/sleep.go
+++ b/gps/app/pps/sleep.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package serialpps
+package pps
 
 import "time"
 

--- a/gps/app/pps/sleep_linux.go
+++ b/gps/app/pps/sleep_linux.go
@@ -1,4 +1,4 @@
-package serialpps
+package pps
 
 import "time"
 

--- a/gps/app/serialpps/config.go
+++ b/gps/app/serialpps/config.go
@@ -35,9 +35,8 @@ func DefaultConfig() Config {
 // second, so at most one integral UTC label can satisfy it.
 func (cfg Config) Validate() error {
 	msgs := check.Validate(cfg)
-	if cfg.DelayUncertainty >= 0 && cfg.DelayUncertainty < 1 && cfg.MaxDelay > 0 && cfg.MaxDelay < 1 &&
-		!(cfg.DelayUncertainty+cfg.MaxDelay < 1) {
-		msgs = append(msgs, fmt.Sprintf("delayUncertainty + maxDelay: must be < 1, got %g", cfg.DelayUncertainty+cfg.MaxDelay))
+	if err := cfg.GeneratorConfig.Validate(); err != nil {
+		msgs = append(msgs, err.Error())
 	}
 	if cfg.Method < 0 || cfg.Method > gpsio.PPSMethodKernel {
 		msgs = append(msgs, fmt.Sprintf("method: invalid value %d", int(cfg.Method)))

--- a/gps/app/serialpps/config.go
+++ b/gps/app/serialpps/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/lib/check"
 )
 
@@ -13,11 +14,7 @@ import (
 // UTC-labelled receiver messages. Durations are expressed in seconds in
 // TOML.
 type Config struct {
-	// DelayUncertainty is the allowed measurement uncertainty when an
-	// inferred post-pulse message delay is slightly negative.
-	DelayUncertainty float64 `toml:"delayUncertainty" check:">=0,<1" comment:"Uncertainty in measured pulse-to-message delay (s)"`
-	// MaxDelay is the maximum accepted inferred post-pulse message delay.
-	MaxDelay float64 `toml:"maxDelay" check:">0,<1" comment:"Maximum post-pulse message delay (s)"`
+	pps.GeneratorConfig
 	// Method selects how edges are detected; unspecified means automatic.
 	Method gpsio.PPSMethod `toml:"method" comment:"PPS edge detection method: poll, wait, or kernel; omit for automatic selection"`
 	// MaxWakeupLatency optionally limits latency added when a CPU wakes from
@@ -31,10 +28,7 @@ type Config struct {
 
 // DefaultConfig returns the default serial PPS sampling configuration.
 func DefaultConfig() Config {
-	return Config{
-		DelayUncertainty: 0.005,
-		MaxDelay:         0.8,
-	}
+	return Config{GeneratorConfig: pps.DefaultGeneratorConfig()}
 }
 
 // Validate checks that the delay interval is valid and narrower than one

--- a/gps/app/serialpps/config_test.go
+++ b/gps/app/serialpps/config_test.go
@@ -11,32 +11,30 @@ import (
 
 func TestConfig(t *testing.T) {
 	floatPtr := func(v float64) *float64 { return &v }
-	gen := func(delayUncertainty, maxDelay float64) pps.GeneratorConfig {
-		return pps.GeneratorConfig{DelayUncertainty: delayUncertainty, MaxDelay: maxDelay}
-	}
+	base := pps.GeneratorConfig{MaxDelay: 0.8}
 	tests := []struct {
 		name    string
 		cfg     Config
 		errText string
 	}{
 		{name: "defaults", cfg: DefaultConfig()},
-		{name: "zero uncertainty", cfg: Config{GeneratorConfig: gen(0, 0.8)}},
-		{name: "poll method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodPoll}},
-		{name: "wait method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodWait}},
-		{name: "kernel method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodKernel}},
-		{name: "zero wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(0)}},
-		{name: "fractional wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(10.5e-6)}},
-		{name: "invalid method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodKernel + 1}, errText: "method"},
-		{name: "negative wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(-1)}, errText: "maxWakeupLatency"},
-		{name: "NaN wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(math.NaN())}, errText: "maxWakeupLatency"},
-		{name: "infinite wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(math.Inf(1))}, errText: "maxWakeupLatency"},
-		{name: "one-second wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(1)}, errText: "maxWakeupLatency"},
-		{name: "negative uncertainty", cfg: Config{GeneratorConfig: gen(-0.001, 0.8)}, errText: "delayUncertainty"},
-		{name: "zero maximum", cfg: Config{GeneratorConfig: gen(0.005, 0)}, errText: "maxDelay"},
-		{name: "prewarm", cfg: Config{GeneratorConfig: gen(0.005, 0.8), PollPreWarm: 0.05}},
-		{name: "negative prewarm", cfg: Config{GeneratorConfig: gen(0.005, 0.8), PollPreWarm: -0.01}, errText: "pollPreWarm"},
-		{name: "one-second interval", cfg: Config{GeneratorConfig: gen(0.2, 0.8)}, errText: "delayUncertainty + maxDelay"},
-		{name: "interval over one second", cfg: Config{GeneratorConfig: gen(0.3, 0.8)}, errText: "delayUncertainty + maxDelay"},
+		{name: "zero uncertainty", cfg: Config{GeneratorConfig: base}},
+		{name: "poll method", cfg: Config{GeneratorConfig: base, Method: gpsio.PPSMethodPoll}},
+		{name: "wait method", cfg: Config{GeneratorConfig: base, Method: gpsio.PPSMethodWait}},
+		{name: "kernel method", cfg: Config{GeneratorConfig: base, Method: gpsio.PPSMethodKernel}},
+		{name: "zero wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(0)}},
+		{name: "fractional wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(10.5e-6)}},
+		{name: "invalid method", cfg: Config{GeneratorConfig: base, Method: gpsio.PPSMethodKernel + 1}, errText: "method"},
+		{name: "negative wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(-1)}, errText: "maxWakeupLatency"},
+		{name: "NaN wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(math.NaN())}, errText: "maxWakeupLatency"},
+		{name: "infinite wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(math.Inf(1))}, errText: "maxWakeupLatency"},
+		{name: "one-second wakeup latency", cfg: Config{GeneratorConfig: base, MaxWakeupLatency: floatPtr(1)}, errText: "maxWakeupLatency"},
+		{name: "negative uncertainty", cfg: Config{GeneratorConfig: pps.GeneratorConfig{DelayUncertainty: -0.001, MaxDelay: 0.8}}, errText: "delayUncertainty"},
+		{name: "zero maximum", cfg: Config{GeneratorConfig: pps.GeneratorConfig{DelayUncertainty: 0.005}}, errText: "maxDelay"},
+		{name: "prewarm", cfg: Config{GeneratorConfig: pps.DefaultGeneratorConfig(), PollPreWarm: 0.05}},
+		{name: "negative prewarm", cfg: Config{GeneratorConfig: pps.DefaultGeneratorConfig(), PollPreWarm: -0.01}, errText: "pollPreWarm"},
+		{name: "one-second interval", cfg: Config{GeneratorConfig: pps.GeneratorConfig{DelayUncertainty: 0.2, MaxDelay: 0.8}}, errText: "delayUncertainty + maxDelay"},
+		{name: "interval over one second", cfg: Config{GeneratorConfig: pps.GeneratorConfig{DelayUncertainty: 0.3, MaxDelay: 0.8}}, errText: "delayUncertainty + maxDelay"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/gps/app/serialpps/config_test.go
+++ b/gps/app/serialpps/config_test.go
@@ -6,33 +6,37 @@ import (
 	"testing"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 )
 
 func TestConfig(t *testing.T) {
 	floatPtr := func(v float64) *float64 { return &v }
+	gen := func(delayUncertainty, maxDelay float64) pps.GeneratorConfig {
+		return pps.GeneratorConfig{DelayUncertainty: delayUncertainty, MaxDelay: maxDelay}
+	}
 	tests := []struct {
 		name    string
 		cfg     Config
 		errText string
 	}{
 		{name: "defaults", cfg: DefaultConfig()},
-		{name: "zero uncertainty", cfg: Config{MaxDelay: 0.8}},
-		{name: "poll method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodPoll}},
-		{name: "wait method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodWait}},
-		{name: "kernel method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodKernel}},
-		{name: "zero wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(0)}},
-		{name: "fractional wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(10.5e-6)}},
-		{name: "invalid method", cfg: Config{MaxDelay: 0.8, Method: gpsio.PPSMethodKernel + 1}, errText: "method"},
-		{name: "negative wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(-1)}, errText: "maxWakeupLatency"},
-		{name: "NaN wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(math.NaN())}, errText: "maxWakeupLatency"},
-		{name: "infinite wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(math.Inf(1))}, errText: "maxWakeupLatency"},
-		{name: "one-second wakeup latency", cfg: Config{MaxDelay: 0.8, MaxWakeupLatency: floatPtr(1)}, errText: "maxWakeupLatency"},
-		{name: "negative uncertainty", cfg: Config{DelayUncertainty: -0.001, MaxDelay: 0.8}, errText: "delayUncertainty"},
-		{name: "zero maximum", cfg: Config{DelayUncertainty: 0.005}, errText: "maxDelay"},
-		{name: "prewarm", cfg: Config{DelayUncertainty: 0.005, MaxDelay: 0.8, PollPreWarm: 0.05}},
-		{name: "negative prewarm", cfg: Config{DelayUncertainty: 0.005, MaxDelay: 0.8, PollPreWarm: -0.01}, errText: "pollPreWarm"},
-		{name: "one-second interval", cfg: Config{DelayUncertainty: 0.2, MaxDelay: 0.8}, errText: "delayUncertainty + maxDelay"},
-		{name: "interval over one second", cfg: Config{DelayUncertainty: 0.3, MaxDelay: 0.8}, errText: "delayUncertainty + maxDelay"},
+		{name: "zero uncertainty", cfg: Config{GeneratorConfig: gen(0, 0.8)}},
+		{name: "poll method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodPoll}},
+		{name: "wait method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodWait}},
+		{name: "kernel method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodKernel}},
+		{name: "zero wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(0)}},
+		{name: "fractional wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(10.5e-6)}},
+		{name: "invalid method", cfg: Config{GeneratorConfig: gen(0, 0.8), Method: gpsio.PPSMethodKernel + 1}, errText: "method"},
+		{name: "negative wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(-1)}, errText: "maxWakeupLatency"},
+		{name: "NaN wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(math.NaN())}, errText: "maxWakeupLatency"},
+		{name: "infinite wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(math.Inf(1))}, errText: "maxWakeupLatency"},
+		{name: "one-second wakeup latency", cfg: Config{GeneratorConfig: gen(0, 0.8), MaxWakeupLatency: floatPtr(1)}, errText: "maxWakeupLatency"},
+		{name: "negative uncertainty", cfg: Config{GeneratorConfig: gen(-0.001, 0.8)}, errText: "delayUncertainty"},
+		{name: "zero maximum", cfg: Config{GeneratorConfig: gen(0.005, 0)}, errText: "maxDelay"},
+		{name: "prewarm", cfg: Config{GeneratorConfig: gen(0.005, 0.8), PollPreWarm: 0.05}},
+		{name: "negative prewarm", cfg: Config{GeneratorConfig: gen(0.005, 0.8), PollPreWarm: -0.01}, errText: "pollPreWarm"},
+		{name: "one-second interval", cfg: Config{GeneratorConfig: gen(0.2, 0.8)}, errText: "delayUncertainty + maxDelay"},
+		{name: "interval over one second", cfg: Config{GeneratorConfig: gen(0.3, 0.8)}, errText: "delayUncertainty + maxDelay"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/gps/app/serialpps/serialpps.go
+++ b/gps/app/serialpps/serialpps.go
@@ -132,7 +132,7 @@ func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, metho
 	}
 	lg.Info("serial PPS method selected", "method", method)
 	if method == gpsio.PPSMethodPoll {
-		return pps.Poll(ctx, lg, pinReader{r, w}, prewarm, ceCh, stats)
+		return pps.Poll(ctx, lg, pinReader{r, w}, pps.PollParams{PreWarm: prewarm}, ceCh, stats)
 	}
 	cw, ok := r.(ChangeWaiter)
 	if !ok {

--- a/gps/app/serialpps/serialpps.go
+++ b/gps/app/serialpps/serialpps.go
@@ -1,5 +1,5 @@
-// Package serialpps detects PPS edges on serial modem-control pins and turns
-// them into refclock samples using UTC time messages from the receiver.
+// Package serialpps detects PPS edges on serial modem-control pins and
+// reports them as pps candidate edges.
 package serialpps
 
 import (
@@ -10,44 +10,10 @@ import (
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/lib/wakeup"
 	"github.com/jclark/satpulse/gps/ptime"
 )
-
-// maxMsgAge is how old the newest receiver time message may be for an edge to
-// still be identified with a UTC second.
-const maxMsgAge = 3 * time.Second
-
-// Edge is a detected leading edge and the time at which the backend read it.
-// Timestamp is the time assigned to the edge: a kernel timestamp, a polling
-// bracket midpoint, or a wait wakeup used as an edge proxy. Its wall reading
-// is always meaningful, and it carries a monotonic reading when the backend
-// can preserve one. TRead is an ordinary time.Now reading captured when the
-// wait or closing poll completed, before subsequent validation.
-type Edge struct {
-	Timestamp time.Time
-	TRead     time.Time
-}
-
-// CandidateEdge is an edge reported by a detection backend. Poll reports
-// every edge it catches so that diagnostic consumers can follow acquisition:
-// Uncertainty is half the width of the polling bracket, and Settled says no
-// improvement in accuracy is to be expected, because the polling schedule did
-// not limit this measurement (its spacing was at the floor or the state
-// queries paced the window) or the window has stopped shrinking. Candidates
-// are unsettled during acquisition, including the catch that completes it
-// (Settled records the state in which the edge was captured, and acquisition
-// succeeds as a consequence of that catch), and unsettled again during
-// tracking while a window grown by misses is still shrinking back. Timing
-// consumers can accept unsettled candidates with sufficiently small
-// Uncertainty, and use Settled to accept the resolution the hardware can
-// achieve. A wait or kernel candidate carries the backend timestamp directly,
-// has no polling uncertainty, and is always settled.
-type CandidateEdge struct {
-	Edge
-	Uncertainty time.Duration
-	Settled     bool
-}
 
 // StateReader is implemented by a TTY-backed gpsio.SerialConn.
 type StateReader interface {
@@ -108,7 +74,7 @@ type Wiring struct {
 // speed sets. If stats is non-nil, it records timings only when polling is
 // selected. cfg.MaxWakeupLatency, if set, limits CPU wakeup latency for as
 // long as detection runs.
-func Detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, cfg Config, ceCh chan<- CandidateEdge, stats *PollStats) error {
+func Detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, cfg Config, ceCh chan<- pps.CandidateEdge, stats *pps.PollStats) error {
 	if cfg.MaxWakeupLatency != nil {
 		max := ptime.Seconds(*cfg.MaxWakeupLatency)
 		if req, err := wakeup.RequestLatencyLimit(max); err != nil {
@@ -145,7 +111,20 @@ func Detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, cfg C
 	return detect(ctx, lg, r, w, gpsio.PPSMethodPoll, prewarm, ceCh, stats)
 }
 
-func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, method gpsio.PPSMethod, prewarm time.Duration, ceCh chan<- CandidateEdge, stats *PollStats) error {
+// pinReader reads a modem-control input as a pulse state for pps.Poll.
+type pinReader struct {
+	r StateReader
+	w Wiring
+}
+
+// InPulse reports whether the pin was observed during a pulse, as selected
+// by the wiring's polarity.
+func (p pinReader) InPulse() (bool, error) {
+	s, err := p.r.SerialPinState()
+	return s.Asserted(p.w.Pin) == p.w.Polarity.Asserted(), err
+}
+
+func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, method gpsio.PPSMethod, prewarm time.Duration, ceCh chan<- pps.CandidateEdge, stats *pps.PollStats) error {
 	switch method {
 	case gpsio.PPSMethodPoll, gpsio.PPSMethodWait, gpsio.PPSMethodKernel:
 	default:
@@ -153,7 +132,7 @@ func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, metho
 	}
 	lg.Info("serial PPS method selected", "method", method)
 	if method == gpsio.PPSMethodPoll {
-		return Poll(ctx, lg, r, w, prewarm, ceCh, stats)
+		return pps.Poll(ctx, lg, pinReader{r, w}, prewarm, ceCh, stats)
 	}
 	cw, ok := r.(ChangeWaiter)
 	if !ok {
@@ -166,7 +145,7 @@ func detect(ctx context.Context, lg *slog.Logger, r StateReader, w Wiring, metho
 // using the wait or kernel method. The backend timestamps each unambiguous
 // transition, so these candidates have no polling uncertainty. The leading
 // edge is the transition into the pulse, as selected by w.Polarity.
-func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method gpsio.PPSMethod, ceCh chan<- CandidateEdge) error {
+func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method gpsio.PPSMethod, ceCh chan<- pps.CandidateEdge) error {
 	for {
 		change, missed, err := r.WaitSerialPinChange(ctx, w.Pin, method)
 		if err != nil {
@@ -179,8 +158,8 @@ func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method
 			lg.Debug("serial PPS transitions not observed", "atLeast", missed)
 		}
 		if change.Asserted == w.Polarity.Asserted() {
-			ce := CandidateEdge{
-				Edge:    Edge{Timestamp: change.Timestamp, TRead: change.TRead},
+			ce := pps.CandidateEdge{
+				Edge:    pps.Edge{Timestamp: change.Timestamp, TRead: change.TRead},
 				Settled: true,
 			}
 			select {
@@ -190,101 +169,4 @@ func Wait(ctx context.Context, lg *slog.Logger, r ChangeWaiter, w Wiring, method
 			}
 		}
 	}
-}
-
-// Sample is a serial-PPS refclock sample.
-type Sample struct {
-	Ref  time.Time
-	Sys  time.Time
-	Leap ptime.LeapSecondKind
-}
-
-// Generator associates PPS edges with UTC seconds using the latest receiver
-// time message. It is intended to be called from one dispatcher goroutine.
-type Generator struct {
-	msgUTC           time.Time
-	msgRead          time.Time // zero until the first message arrives
-	msgLeap          ptime.LeapSecondKind
-	delayUncertainty time.Duration
-	maxDelay         time.Duration
-}
-
-// NewGenerator creates an empty sample generator using cfg.
-func NewGenerator(cfg Config) *Generator {
-	return &Generator{
-		delayUncertainty: ptime.Seconds(cfg.DelayUncertainty),
-		maxDelay:         ptime.Seconds(cfg.MaxDelay),
-	}
-}
-
-// MsgUTCTime records the newest UTC/system-time pair from a receiver message.
-func (g *Generator) MsgUTCTime(utc, tRead time.Time, leap ptime.LeapSecondKind) {
-	if tRead.Before(g.msgRead) {
-		return
-	}
-	g.msgUTC = utc
-	g.msgRead = tRead
-	g.msgLeap = leap
-}
-
-// Sample turns a precisely detected PPS edge into a sample. It returns false
-// until a time message is available, when the newest message is over three
-// seconds old, when no unique UTC label satisfies the configured
-// pulse-to-message delay bounds, or for the pulse marking an inserted leap
-// second.
-func (g *Generator) Sample(edge Edge) (Sample, bool) {
-	if g.msgRead.IsZero() {
-		return Sample{}, false
-	}
-	// Transfer the timestamp onto the message-read timeline through TRead.
-	// The long message-to-read interval is monotonic; the short correction
-	// back to the edge uses Timestamp's monotonic reading when it has one and
-	// otherwise its wall reading. A wall-clock step during that correction can
-	// still corrupt it, but a step anywhere else in the message-to-edge span
-	// cannot. Use the transferred interval for both age and UTC extrapolation.
-	edgeSinceMsg := edge.TRead.Sub(g.msgRead) - edge.TRead.Sub(edge.Timestamp)
-	if edgeSinceMsg > maxMsgAge {
-		return Sample{}, false
-	}
-	// Select the integral second whose inferred pulse-to-message delay is in
-	// the configured causal interval. The validated interval is narrower than
-	// a second, so the label is unique when it exists.
-	edgeUTC := g.msgUTC.Add(edgeSinceMsg)
-	ref := edgeUTC.Truncate(time.Second)
-	delay := ref.Sub(edgeUTC)
-	if delay < -g.delayUncertainty {
-		ref = ref.Add(time.Second)
-		delay += time.Second
-	}
-	if delay < -g.delayUncertainty || delay >= g.maxDelay {
-		return Sample{}, false
-	}
-	// The message's leap flag announces a leap at the end of the message's
-	// UTC day, which the monotonic extrapolation cannot see: past the
-	// boundary it runs one second ahead of UTC after a positive leap and
-	// one second behind after a negative one. The inserted second itself
-	// has no value on the leap-free timescale of time.Time and the refclock
-	// samples (midnight is the next pulse's label, 23:59:59 the previous
-	// one's), so its pulse yields no sample.
-	midnight := g.msgUTC.Truncate(24 * time.Hour).Add(24 * time.Hour)
-	if g.msgLeap == ptime.LeapSecondPositive && !ref.Before(midnight) {
-		if ref.Equal(midnight) {
-			return Sample{}, false
-		}
-		ref = ref.Add(-time.Second)
-	} else if g.msgLeap == ptime.LeapSecondNegative && !ref.Before(midnight.Add(-time.Second)) {
-		ref = ref.Add(time.Second)
-	}
-	leap := g.msgLeap
-	// If the edge falls in a different day than the message, the
-	// announcement does not apply to it; a retained pre-midnight flag must
-	// not re-announce a leap that has already happened.
-	if !ref.Truncate(24 * time.Hour).Equal(g.msgUTC.Truncate(24 * time.Hour)) {
-		leap = ptime.LeapSecondNone
-	}
-	return Sample{
-		Ref:  ref,
-		Sys:  edge.Timestamp,
-		Leap: leap,
-	}, true
 }

--- a/gps/app/serialpps/serialpps_test.go
+++ b/gps/app/serialpps/serialpps_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
-	"github.com/jclark/satpulse/gps/ptime"
+	"github.com/jclark/satpulse/gps/app/pps"
 )
 
 var testLog = slog.New(slog.DiscardHandler)
@@ -55,7 +55,7 @@ func TestWait(t *testing.T) {
 	// the backend reports missed transitions.
 	w.next <- testWaitResult{change: gpsio.SerialPinChange{Timestamp: timestamp.Add(-time.Second), TRead: tRead.Add(-time.Second), Asserted: true}}
 	w.next <- testWaitResult{change: gpsio.SerialPinChange{Timestamp: timestamp, TRead: tRead}, missed: 2}
-	candidates := make(chan CandidateEdge, 1)
+	candidates := make(chan pps.CandidateEdge, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	var logs bytes.Buffer
@@ -92,7 +92,7 @@ func TestWaitInvertedPolarity(t *testing.T) {
 	// transition is a trailing edge and the asserted one is published.
 	w.next <- testWaitResult{change: gpsio.SerialPinChange{Timestamp: timestamp.Add(-time.Second), TRead: tRead.Add(-time.Second)}}
 	w.next <- testWaitResult{change: gpsio.SerialPinChange{Timestamp: timestamp, TRead: tRead, Asserted: true}}
-	candidates := make(chan CandidateEdge, 1)
+	candidates := make(chan pps.CandidateEdge, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
@@ -114,7 +114,7 @@ func TestWaitInvertedPolarity(t *testing.T) {
 
 func TestWaitContextCancellation(t *testing.T) {
 	w := &testChangeWaiter{next: make(chan testWaitResult), entered: make(chan struct{}, 1)}
-	candidates := make(chan CandidateEdge, 1)
+	candidates := make(chan pps.CandidateEdge, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() { errCh <- Wait(ctx, testLog, w, Wiring{Pin: gpsio.SerialPinCTS}, gpsio.PPSMethodWait, candidates) }()
@@ -135,10 +135,12 @@ type testFallbackWaiter struct {
 	err             error
 	successfulWaits int
 	methods         []gpsio.PPSMethod
+	polled          bool
 	cancel          context.CancelFunc
 }
 
 func (w *testFallbackWaiter) SerialPinState() (gpsio.SerialPinState, error) {
+	w.polled = true
 	w.cancel()
 	return 0, nil
 }
@@ -154,10 +156,12 @@ func (w *testFallbackWaiter) WaitSerialPinChange(_ context.Context, _ gpsio.Seri
 
 // testPoller is a StateReader without the wait capability.
 type testPoller struct {
+	polled bool
 	cancel context.CancelFunc
 }
 
 func (p *testPoller) SerialPinState() (gpsio.SerialPinState, error) {
+	p.polled = true
 	p.cancel()
 	return 0, nil
 }
@@ -228,18 +232,17 @@ func TestDetectMethodSelection(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			w := &testFallbackWaiter{err: tc.waitErr, successfulWaits: tc.successfulWaits, cancel: cancel}
-			stats := new(PollStats)
 			var logs bytes.Buffer
 			lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-			err := Detect(ctx, lg, w, Wiring{Pin: gpsio.SerialPinCTS}, Config{Method: tc.method}, make(chan CandidateEdge, 1), stats)
+			err := Detect(ctx, lg, w, Wiring{Pin: gpsio.SerialPinCTS}, Config{Method: tc.method}, make(chan pps.CandidateEdge, 1), nil)
 			if !errors.Is(err, tc.expectErr) {
 				t.Errorf("Detect error = %v, want %v", err, tc.expectErr)
 			}
 			if !reflect.DeepEqual(w.methods, tc.expectMethods) {
 				t.Errorf("methods tried = %v, want %v", w.methods, tc.expectMethods)
 			}
-			if stats.started != tc.expectPolled {
-				t.Errorf("polled = %v, want %v", stats.started, tc.expectPolled)
+			if w.polled != tc.expectPolled {
+				t.Errorf("polled = %v, want %v", w.polled, tc.expectPolled)
 			}
 			selectionCount := strings.Count(logs.String(), `msg="serial PPS method selected"`)
 			if selectionCount != len(tc.expectSelected) {
@@ -264,14 +267,14 @@ func TestDetectMethodSelection(t *testing.T) {
 func TestDetectWithoutWaiterPolls(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	stats := new(PollStats)
+	p := &testPoller{cancel: cancel}
 	var logs bytes.Buffer
 	lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	err := Detect(ctx, lg, &testPoller{cancel: cancel}, Wiring{Pin: gpsio.SerialPinCTS}, Config{}, make(chan CandidateEdge, 1), stats)
+	err := Detect(ctx, lg, p, Wiring{Pin: gpsio.SerialPinCTS}, Config{}, make(chan pps.CandidateEdge, 1), nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Detect error = %v, want context.Canceled", err)
 	}
-	if !stats.started {
+	if !p.polled {
 		t.Error("Detect did not fall through to polling")
 	}
 	if got := strings.Count(logs.String(), `msg="serial PPS method selected" method=poll`); got != 1 {
@@ -287,276 +290,10 @@ func TestDetectForcedWaitWithoutWaiter(t *testing.T) {
 		t.Run(method.String(), func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			err := Detect(ctx, testLog, &testPoller{cancel: cancel}, Wiring{Pin: gpsio.SerialPinCTS}, Config{Method: method}, make(chan CandidateEdge, 1), nil)
+			err := Detect(ctx, testLog, &testPoller{cancel: cancel}, Wiring{Pin: gpsio.SerialPinCTS}, Config{Method: method}, make(chan pps.CandidateEdge, 1), nil)
 			if !errors.Is(err, errors.ErrUnsupported) {
 				t.Errorf("Detect error = %v, want errors.ErrUnsupported", err)
 			}
 		})
-	}
-}
-
-func TestGenerator(t *testing.T) {
-	msgUTC := time.Unix(1_000, 0).UTC()
-	msgRead := time.Unix(900, 125_000_000)
-	edge := time.Unix(900, 1_000_000)
-	tests := []struct {
-		name string
-		msg  bool
-		age  time.Duration
-		leap ptime.LeapSecondKind
-		ok   bool
-	}{
-		{name: "identifies second", msg: true, leap: ptime.LeapSecondNone, ok: true},
-		{name: "positive leap passthrough", msg: true, leap: ptime.LeapSecondPositive, ok: true},
-		{name: "negative leap passthrough", msg: true, leap: ptime.LeapSecondNegative, ok: true},
-		{name: "message exactly three seconds old", msg: true, age: 3 * time.Second, ok: true},
-		{name: "stale message", msg: true, age: 3*time.Second + time.Nanosecond},
-		{name: "no message"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(DefaultConfig())
-			tEdge := edge
-			utc := msgUTC
-			read := msgRead
-			if tc.age != 0 {
-				read = tEdge.Add(-tc.age)
-				utc = read.Add(msgUTC.Sub(msgRead))
-			}
-			if tc.msg {
-				g.MsgUTCTime(utc, read, tc.leap)
-			}
-			sample, ok := g.Sample(Edge{Timestamp: tEdge, TRead: tEdge})
-			if ok != tc.ok {
-				t.Fatalf("Edge ok = %v, want %v", ok, tc.ok)
-			}
-			if !ok {
-				return
-			}
-			wantRef := time.Unix(1_000, 0).UTC()
-			if !sample.Ref.Equal(wantRef) {
-				t.Errorf("reference = %v, want %v", sample.Ref, wantRef)
-			}
-			if !sample.Sys.Equal(tEdge) {
-				t.Errorf("system = %v, want %v", sample.Sys, tEdge)
-			}
-			if sample.Leap != tc.leap {
-				t.Errorf("leap = %v, want %v", sample.Leap, tc.leap)
-			}
-		})
-	}
-}
-
-func TestGeneratorTransfersTimestampThroughReadTime(t *testing.T) {
-	tests := []struct {
-		name          string
-		readSinceMsg  time.Duration
-		readAfterEdge time.Duration
-		wantRef       time.Time
-	}{
-		{
-			name:          "delivery correction determines second label",
-			readSinceMsg:  9 * time.Millisecond,
-			readAfterEdge: 10 * time.Millisecond,
-			wantRef:       time.Unix(1_000, 0).UTC(),
-		},
-		{
-			name:          "delivery correction determines message age",
-			readSinceMsg:  3100 * time.Millisecond,
-			readAfterEdge: 100 * time.Millisecond,
-			wantRef:       time.Unix(1_003, 0).UTC(),
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(DefaultConfig())
-			msgRead := time.Now()
-			g.MsgUTCTime(time.Unix(1_000, 0).UTC(), msgRead, ptime.LeapSecondNone)
-			tRead := msgRead.Add(tc.readSinceMsg)
-			// Reconstruct Timestamp from wall time to model a kernel or
-			// Windows timestamp without a monotonic reading.
-			timestamp := time.Unix(0, tRead.UnixNano()).Add(-tc.readAfterEdge)
-			sample, ok := g.Sample(Edge{Timestamp: timestamp, TRead: tRead})
-			if !ok {
-				t.Fatal("Edge returned no sample")
-			}
-			if !sample.Ref.Equal(tc.wantRef) {
-				t.Errorf("reference = %v, want %v", sample.Ref, tc.wantRef)
-			}
-			if !sample.Sys.Equal(timestamp) {
-				t.Errorf("system = %v, want timestamp %v", sample.Sys, timestamp)
-			}
-		})
-	}
-}
-
-func TestGeneratorKeepsNewestMessage(t *testing.T) {
-	g := NewGenerator(DefaultConfig())
-	newRead := time.Unix(100, 100_000_000)
-	g.MsgUTCTime(time.Unix(200, 0), newRead, ptime.LeapSecondPositive)
-	g.MsgUTCTime(time.Unix(300, 0), newRead.Add(-time.Second), ptime.LeapSecondNegative)
-	sample, ok := g.Sample(Edge{Timestamp: time.Unix(100, 0), TRead: time.Unix(100, 0)})
-	if !ok {
-		t.Fatal("Edge returned no sample")
-	}
-	if !sample.Ref.Equal(time.Unix(200, 0)) || sample.Leap != ptime.LeapSecondPositive {
-		t.Fatalf("sample = %+v, want newest message reference and leap", sample)
-	}
-}
-
-func TestGeneratorDelayBounds(t *testing.T) {
-	cfg := DefaultConfig()
-	tests := []struct {
-		name  string
-		delay time.Duration
-		ok    bool
-	}{
-		{name: "at negative uncertainty bound", delay: -ptime.Seconds(cfg.DelayUncertainty), ok: true},
-		{name: "below negative uncertainty bound", delay: -ptime.Seconds(cfg.DelayUncertainty) - time.Nanosecond},
-		{name: "zero delay", delay: 0, ok: true},
-		{name: "below maximum delay", delay: ptime.Seconds(cfg.MaxDelay) - time.Nanosecond, ok: true},
-		{name: "at maximum delay", delay: ptime.Seconds(cfg.MaxDelay)},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(cfg)
-			utc := time.Unix(1_000, 0).UTC()
-			tRead := time.Unix(900, 0)
-			g.MsgUTCTime(utc, tRead, ptime.LeapSecondNone)
-			at := tRead.Add(-tc.delay)
-			sample, ok := g.Sample(Edge{Timestamp: at, TRead: at})
-			if ok != tc.ok {
-				t.Fatalf("Edge ok = %v, want %v", ok, tc.ok)
-			}
-			if ok && !sample.Ref.Equal(utc) {
-				t.Errorf("reference = %v, want %v", sample.Ref, utc)
-			}
-		})
-	}
-}
-
-func TestGeneratorLeapCrossing(t *testing.T) {
-	tests := []struct {
-		name       string
-		utc        time.Time
-		leap       ptime.LeapSecondKind
-		elapsed    time.Duration // edge.Timestamp - tRead
-		expectRef  time.Time
-		expectLeap ptime.LeapSecondKind
-		expectOK   bool
-	}{
-		{name: "pulse before positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
-			elapsed: -125 * time.Millisecond, expectRef: time.Unix(86_399, 0), expectLeap: ptime.LeapSecondPositive, expectOK: true},
-		{name: "inserted second pulse yields no sample", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
-			elapsed: 875 * time.Millisecond},
-		{name: "first pulse after positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
-			elapsed: 1875 * time.Millisecond, expectRef: time.Unix(86_400, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
-		{name: "second pulse after positive leap", utc: time.Unix(86_399, 0), leap: ptime.LeapSecondPositive,
-			elapsed: 2875 * time.Millisecond, expectRef: time.Unix(86_401, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
-		{name: "pulse before negative leap", utc: time.Unix(86_398, 0), leap: ptime.LeapSecondNegative,
-			elapsed: -125 * time.Millisecond, expectRef: time.Unix(86_398, 0), expectLeap: ptime.LeapSecondNegative, expectOK: true},
-		{name: "first pulse after negative leap", utc: time.Unix(86_398, 0), leap: ptime.LeapSecondNegative,
-			elapsed: 875 * time.Millisecond, expectRef: time.Unix(86_400, 0), expectLeap: ptime.LeapSecondNone, expectOK: true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGenerator(DefaultConfig())
-			read := time.Unix(1_000_000, 125_000_000)
-			g.MsgUTCTime(tc.utc, read, tc.leap)
-			at := read.Add(tc.elapsed)
-			sample, ok := g.Sample(Edge{Timestamp: at, TRead: at})
-			if ok != tc.expectOK {
-				t.Fatalf("Edge ok = %v, want %v", ok, tc.expectOK)
-			}
-			if !ok {
-				return
-			}
-			if !sample.Ref.Equal(tc.expectRef) || sample.Leap != tc.expectLeap {
-				t.Errorf("sample = %+v, want reference %v and leap %v", sample, tc.expectRef, tc.expectLeap)
-			}
-		})
-	}
-}
-
-func TestPollStatsSummary(t *testing.T) {
-	base := time.Unix(1_700_000_000, 0)
-	newReading := func(offset time.Duration) clockReading {
-		return clockReading{stamp: base.Add(offset), mono: base.Add(offset)}
-	}
-	polls := []poll{
-		{start: newReading(0), end: newReading(time.Millisecond)},
-		{start: newReading(11 * time.Millisecond), end: newReading(13 * time.Millisecond)},
-		{start: newReading(33 * time.Millisecond), end: newReading(36 * time.Millisecond)},
-		{start: newReading(66 * time.Millisecond), end: newReading(70 * time.Millisecond)},
-		{start: newReading(110 * time.Millisecond), end: newReading(115 * time.Millisecond)},
-	}
-	stats := new(PollStats)
-	stats.addPoll(polls[0], nil)
-	for i := 1; i < len(polls); i++ {
-		stats.addPoll(polls[i], &polls[i-1])
-	}
-	stats.addWindow(false, false)
-	stats.addWindow(true, false)
-	stats.addWindow(true, true)
-
-	got := stats.summary()
-	want := pollStatsSummary{
-		PollDuration: durationStats{
-			Count: 5, Sampled: 5, Min: time.Millisecond, Median: 3 * time.Millisecond,
-			Mean: 3 * time.Millisecond, P90: 5 * time.Millisecond, Max: 5 * time.Millisecond,
-		},
-		PollGap: durationStats{
-			Count: 4, Sampled: 4, Min: 10 * time.Millisecond, Median: 30 * time.Millisecond,
-			Mean: 25 * time.Millisecond, P90: 40 * time.Millisecond, Max: 40 * time.Millisecond,
-		},
-	}
-	want.Acquire.Windows, want.Acquire.Edges = 2, 1
-	want.Track.Windows, want.Track.Edges = 1, 1
-	if got != want {
-		t.Errorf("Summary() = %+v, want %+v", got, want)
-	}
-}
-
-func TestPollStatsTimingSamplesAreBounded(t *testing.T) {
-	stats := new(PollStats)
-	base := time.Unix(1_700_000_000, 0)
-	for i := range pollStatsSampleLimit + 1 {
-		start := clockReading{stamp: base, mono: base}
-		end := clockReading{stamp: base.Add(time.Duration(i) + 1), mono: base.Add(time.Duration(i) + 1)}
-		stats.addPoll(poll{start: start, end: end}, nil)
-	}
-	summary := stats.summary().PollDuration
-	if summary.Count != pollStatsSampleLimit+1 || summary.Sampled != pollStatsSampleLimit {
-		t.Errorf("duration counts = %d total, %d sampled; want %d total, %d sampled",
-			summary.Count, summary.Sampled, pollStatsSampleLimit+1, pollStatsSampleLimit)
-	}
-}
-
-func TestPollStatsLog(t *testing.T) {
-	stats := new(PollStats)
-	stats.begin()
-	start := clockReading{stamp: time.Unix(1_700_000_000, 0), mono: time.Unix(1_700_000_000, 0)}
-	end := clockReading{stamp: start.stamp.Add(2 * time.Millisecond), mono: start.mono.Add(2 * time.Millisecond)}
-	stats.addPoll(poll{start: start, end: end}, nil)
-	stats.addWindow(true, false)
-
-	var output bytes.Buffer
-	stats.Log(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	for _, want := range []string{
-		`msg="serial PPS polling statistics" acquire.windows=1 acquire.edges=1 track.windows=0 track.edges=0`,
-		`msg="serial PPS state read times" count=1 min=2ms median=2ms mean=2ms p90=2ms max=2ms`,
-		`msg="serial PPS between-read times" count=0`,
-	} {
-		if !strings.Contains(output.String(), want) {
-			t.Errorf("log %q does not contain %q", output.String(), want)
-		}
-	}
-}
-
-func TestPollStatsLogSkipsUnusedStats(t *testing.T) {
-	var output bytes.Buffer
-	new(PollStats).Log(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	if output.Len() != 0 {
-		t.Errorf("unused polling statistics logged %q", output.String())
 	}
 }

--- a/gps/app/serialpps/serialpps_test.go
+++ b/gps/app/serialpps/serialpps_test.go
@@ -132,17 +132,10 @@ func TestWaitContextCancellation(t *testing.T) {
 // the first poll so that a run that reaches the polling fallback returns
 // promptly.
 type testFallbackWaiter struct {
+	testPoller
 	err             error
 	successfulWaits int
 	methods         []gpsio.PPSMethod
-	polled          bool
-	cancel          context.CancelFunc
-}
-
-func (w *testFallbackWaiter) SerialPinState() (gpsio.SerialPinState, error) {
-	w.polled = true
-	w.cancel()
-	return 0, nil
 }
 
 func (w *testFallbackWaiter) WaitSerialPinChange(_ context.Context, _ gpsio.SerialPin, method gpsio.PPSMethod) (gpsio.SerialPinChange, int, error) {
@@ -231,7 +224,7 @@ func TestDetectMethodSelection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			w := &testFallbackWaiter{err: tc.waitErr, successfulWaits: tc.successfulWaits, cancel: cancel}
+			w := &testFallbackWaiter{testPoller: testPoller{cancel: cancel}, err: tc.waitErr, successfulWaits: tc.successfulWaits}
 			var logs bytes.Buffer
 			lg := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 			err := Detect(ctx, lg, w, Wiring{Pin: gpsio.SerialPinCTS}, Config{Method: tc.method}, make(chan pps.CandidateEdge, 1), nil)

--- a/gps/lib/check/check.go
+++ b/gps/lib/check/check.go
@@ -32,13 +32,19 @@ func validateStruct(val reflect.Value, prefix string) []string {
 		field := typ.Field(i)
 		fval := val.Field(i)
 
-		// Build qualified name using toml tag or field name
+		// Build qualified name using toml tag or field name. An untagged
+		// embedded struct is inlined by the TOML decoder, so its fields
+		// are named as the embedding struct's own.
 		name := field.Tag.Get("toml")
-		if name == "" {
-			name = field.Name
-		}
-		if prefix != "" {
-			name = prefix + "." + name
+		if name == "" && field.Anonymous {
+			name = prefix
+		} else {
+			if name == "" {
+				name = field.Name
+			}
+			if prefix != "" {
+				name = prefix + "." + name
+			}
 		}
 
 		// Check for validation tag

--- a/gps/lib/check/check.go
+++ b/gps/lib/check/check.go
@@ -33,10 +33,11 @@ func validateStruct(val reflect.Value, prefix string) []string {
 		fval := val.Field(i)
 
 		// Build qualified name using toml tag or field name. An untagged
-		// embedded struct is inlined by the TOML decoder, so its fields
-		// are named as the embedding struct's own.
+		// embedded struct, or pointer to one, is inlined by the TOML
+		// decoder, so its fields are named as the embedding struct's own;
+		// any other embedded field is decoded under its type name.
 		name := field.Tag.Get("toml")
-		if name == "" && field.Anonymous {
+		if ftyp := field.Type; name == "" && field.Anonymous && derefKind(ftyp) == reflect.Struct {
 			name = prefix
 		} else {
 			if name == "" {
@@ -149,4 +150,11 @@ func checkRule(val reflect.Value, op, limit string) bool {
 		panic(fmt.Sprintf("unsupported type %s for check tag", val.Kind()))
 	}
 	panic(fmt.Sprintf("unknown operator %q", op))
+}
+
+func derefKind(t reflect.Type) reflect.Kind {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Kind()
 }

--- a/gps/lib/check/check_test.go
+++ b/gps/lib/check/check_test.go
@@ -463,3 +463,26 @@ func TestValidate_PointerField(t *testing.T) {
 		t.Fatal("expected error for power > 10")
 	}
 }
+
+func TestValidate_EmbeddedStruct(t *testing.T) {
+	type Inner struct {
+		Field float64 `toml:"field" check:">0"`
+	}
+	type Named struct {
+		Inner `toml:"inner"`
+	}
+	type Outer struct {
+		Inner
+		Named Named `toml:"named"`
+	}
+	errs := Validate(Outer{})
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %v", errs)
+	}
+	if !strings.HasPrefix(errs[0], "field:") {
+		t.Errorf("embedded field named %q, want it named as the outer struct's own", errs[0])
+	}
+	if !strings.HasPrefix(errs[1], "named.inner.field:") {
+		t.Errorf("tagged embedded field named %q, want named.inner.field", errs[1])
+	}
+}

--- a/gps/lib/check/check_test.go
+++ b/gps/lib/check/check_test.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -484,5 +485,20 @@ func TestValidate_EmbeddedStruct(t *testing.T) {
 	}
 	if !strings.HasPrefix(errs[1], "named.inner.field:") {
 		t.Errorf("tagged embedded field named %q, want named.inner.field", errs[1])
+	}
+}
+
+func TestValidate_Embedded(t *testing.T) {
+	type Inner struct {
+		Level int `check:">0"`
+	}
+	type Count int
+	type Outer struct {
+		Inner
+		Count `check:">0"`
+	}
+	errs := Validate(Outer{})
+	if want := []string{"Level: must be > 0, got 0", "Count: must be > 0, got 0"}; !reflect.DeepEqual(errs, want) {
+		t.Errorf("Validate(Outer{}) = %q, want %q", errs, want)
 	}
 }

--- a/time/app/daemon/daemon.go
+++ b/time/app/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jclark/satpulse/gps/app/cmd"
 	"github.com/jclark/satpulse/gps/app/gpscfg"
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/app/serialpps"
 	"github.com/jclark/satpulse/gps/app/stream"
 	"github.com/jclark/satpulse/gps/gpsprot"
@@ -321,11 +322,11 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 			return err
 		}
 	}
-	var spCh <-chan serialpps.CandidateEdge
-	var spGen *serialpps.Generator
+	var spCh <-chan pps.CandidateEdge
+	var spGen *pps.Generator
 	if cfg.Serial.PPS != nil {
-		spGen = serialpps.NewGenerator(cfg.Sample.Serial.PPS)
-		ch := make(chan serialpps.CandidateEdge, 1)
+		spGen = pps.NewGenerator(cfg.Sample.Serial.PPS.GeneratorConfig)
+		ch := make(chan pps.CandidateEdge, 1)
 		spCh = ch
 		wg.Go(func() {
 			defer close(ch)
@@ -395,7 +396,7 @@ func NewDispatcher(
 	gm *ptpgm.Grandmaster,
 	rc *refclock.ProxyRefClock,
 	shm *ntpshm.Writer,
-	spGen *serialpps.Generator,
+	spGen *pps.Generator,
 	obs obs.Observer,
 	tStart time.Time,
 	ggaSelector *stream.GGASelector,

--- a/time/app/daemon/daemon.go
+++ b/time/app/daemon/daemon.go
@@ -322,12 +322,12 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 			return err
 		}
 	}
-	var spCh <-chan pps.CandidateEdge
-	var spGen *pps.Generator
+	var ppsCh <-chan pps.CandidateEdge
+	var ppsGen *pps.Generator
 	if cfg.Serial.PPS != nil {
-		spGen = pps.NewGenerator(cfg.Sample.Serial.PPS.GeneratorConfig)
+		ppsGen = pps.NewGenerator(cfg.Sample.Serial.PPS.GeneratorConfig)
 		ch := make(chan pps.CandidateEdge, 1)
-		spCh = ch
+		ppsCh = ch
 		wg.Go(func() {
 			defer close(ch)
 			lg.Debug("serial PPS goroutine started", "pin", cfg.Serial.PPS.Pin)
@@ -361,7 +361,7 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 	obs.AddObserver(&oc, posObs)
 	observer := oc.Observer()
 
-	d, err := NewDispatcher(lg, pktProcs, clk, cfg, gm, rcProxy, shm, spGen, observer, tStart, ggaSelector)
+	d, err := NewDispatcher(lg, pktProcs, clk, cfg, gm, rcProxy, shm, ppsGen, observer, tStart, ggaSelector)
 	if err != nil {
 		return err
 	}
@@ -381,7 +381,7 @@ func run(ctx context.Context, lg *slog.Logger, cancel context.CancelCauseFunc, c
 			d.LeapSecond(ls, time.Time{})
 		}
 		// Dispatcher is responsible for closing rcProxy via defer in Run()
-		d.Run(tsCh, spCh, pCh, pullPktCh)
+		d.Run(tsCh, ppsCh, pCh, pullPktCh)
 	})
 
 	return nil
@@ -396,7 +396,7 @@ func NewDispatcher(
 	gm *ptpgm.Grandmaster,
 	rc *refclock.ProxyRefClock,
 	shm *ntpshm.Writer,
-	spGen *pps.Generator,
+	ppsGen *pps.Generator,
 	obs obs.Observer,
 	tStart time.Time,
 	ggaSelector *stream.GGASelector,
@@ -426,7 +426,7 @@ func NewDispatcher(
 	if ggaSelector != nil {
 		gs = ggaSelector
 	}
-	return gpsevent.NewDispatcher(lg, pktProcs, controller, rc, shmWriter, spGen, ls, obs, eventLogPath, tStart, gs)
+	return gpsevent.NewDispatcher(lg, pktProcs, controller, rc, shmWriter, ppsGen, ls, obs, eventLogPath, tStart, gs)
 }
 
 // newSSEObserver creates SSE observer if any HTTP endpoint needs GUI

--- a/time/app/serialcmd/serialpps.go
+++ b/time/app/serialcmd/serialpps.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/app/serialpps"
 	"github.com/jclark/satpulse/gps/gpsreg"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
@@ -212,9 +213,9 @@ func detectEdges(parent context.Context, lg *slog.Logger, conn ppsConn, w serial
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
-	edges := make(chan serialpps.CandidateEdge)
+	edges := make(chan pps.CandidateEdge)
 	errCh := make(chan error, 1)
-	stats := new(serialpps.PollStats)
+	stats := new(pps.PollStats)
 	if !lg.Enabled(ctx, slog.LevelInfo) {
 		stats = nil
 	}
@@ -265,7 +266,7 @@ func (e *ppsOutputError) Unwrap() error {
 	return e.err
 }
 
-func (p *edgePrinter) print(device string, edge serialpps.CandidateEdge) error {
+func (p *edgePrinter) print(device string, edge pps.CandidateEdge) error {
 	t := edge.Timestamp.UTC().Round(time.Microsecond)
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/time/app/serialcmd/serialpps_test.go
+++ b/time/app/serialcmd/serialpps_test.go
@@ -12,28 +12,29 @@ import (
 	"time"
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/app/serialpps"
 	"github.com/jclark/satpulse/gps/lib/serialenum"
 )
 
 func TestEdgePrinter(t *testing.T) {
-	edge := serialpps.Edge{
+	edge := pps.Edge{
 		Timestamp: time.Date(2026, time.August, 12, 21, 23, 5, 123_456_499, time.FixedZone("ICT", 7*60*60)),
 	}
 	for _, tc := range []struct {
 		name       string
-		edge       serialpps.CandidateEdge
+		edge       pps.CandidateEdge
 		jsonl      bool
 		withDevice bool
 		want       string
 	}{
-		{name: "human", edge: serialpps.CandidateEdge{Edge: edge}, want: "14:23:05.123456\n"},
-		{name: "human with device", edge: serialpps.CandidateEdge{Edge: edge}, withDevice: true, want: "/dev/ttyS0 14:23:05.123456\n"},
-		{name: "wait JSONL", edge: serialpps.CandidateEdge{Edge: edge, Settled: true}, jsonl: true,
+		{name: "human", edge: pps.CandidateEdge{Edge: edge}, want: "14:23:05.123456\n"},
+		{name: "human with device", edge: pps.CandidateEdge{Edge: edge}, withDevice: true, want: "/dev/ttyS0 14:23:05.123456\n"},
+		{name: "wait JSONL", edge: pps.CandidateEdge{Edge: edge, Settled: true}, jsonl: true,
 			want: "{\"device\":\"/dev/ttyS0\",\"t\":\"2026-08-12T14:23:05.123456Z\"}\n"},
-		{name: "settling poll JSONL", edge: serialpps.CandidateEdge{Edge: edge, Uncertainty: 16 * time.Microsecond}, jsonl: true,
+		{name: "settling poll JSONL", edge: pps.CandidateEdge{Edge: edge, Uncertainty: 16 * time.Microsecond}, jsonl: true,
 			want: "{\"device\":\"/dev/ttyS0\",\"t\":\"2026-08-12T14:23:05.123456Z\",\"uncertainty\":0.000016,\"settling\":true}\n"},
-		{name: "settled poll JSONL", edge: serialpps.CandidateEdge{Edge: edge, Uncertainty: 16 * time.Microsecond, Settled: true}, jsonl: true,
+		{name: "settled poll JSONL", edge: pps.CandidateEdge{Edge: edge, Uncertainty: 16 * time.Microsecond, Settled: true}, jsonl: true,
 			want: "{\"device\":\"/dev/ttyS0\",\"t\":\"2026-08-12T14:23:05.123456Z\",\"uncertainty\":0.000016}\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -236,7 +237,7 @@ func TestMonitorPortListOutputFailure(t *testing.T) {
 	ports := []serialenum.Port{{Device: "writer"}, {Device: "waiting"}}
 	monitor := func(ctx context.Context, _ *slog.Logger, device string) ppsResult {
 		if device == "writer" {
-			err := pr.print(device, serialpps.CandidateEdge{})
+			err := pr.print(device, pps.CandidateEdge{})
 			return ppsResult{device: device, failure: err.Error()}
 		}
 		<-ctx.Done()

--- a/time/internal/gpsevent/dispatcher.go
+++ b/time/internal/gpsevent/dispatcher.go
@@ -107,7 +107,7 @@ type Dispatcher struct {
 	shm                   SHMWriter
 	sps                   samplePrecisionSetter
 	timeMsgBuffer         *timemsg.Buffer
-	spGen                 *pps.Generator
+	ppsGen                 *pps.Generator
 	timeTicker            gpsprot.TimeTicker
 	pvAccum               gpsprot.PVMsgAccum
 	ls                    ptime.LeapSecond
@@ -127,7 +127,7 @@ func NewDispatcher(
 	controller *phcsync.Controller,
 	rc *refclock.ProxyRefClock,
 	shm SHMWriter,
-	spGen *pps.Generator,
+	ppsGen *pps.Generator,
 	ls ptime.LeapSecond,
 	obs obs.Observer,
 	eventLogPath string,
@@ -173,9 +173,9 @@ func NewDispatcher(
 		pp.SetMsgHandler(multiHandler)
 		pp.SetNativeMsgHandler(&d)
 	}
-	if spGen != nil {
-		d.spGen = spGen
-		timeMsgBuffer.SetMsgUTCTimer(spGen)
+	if ppsGen != nil {
+		d.ppsGen = ppsGen
+		timeMsgBuffer.SetMsgUTCTimer(ppsGen)
 	} else if controller == nil && (rc != nil || shm != nil) {
 		// In serial timing mode (no PHC, but refclock configured), feed
 		// NTP samples directly from time messages.
@@ -194,7 +194,7 @@ const (
 	sysPulseMaxUncertainty   = time.Millisecond
 )
 
-func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pktCh <-chan scan.Packet, pullPktCh <-chan scan.Packet) {
+func (d *Dispatcher) Run(tsCh <-chan ts.Event, ppsCh <-chan pps.CandidateEdge, pktCh <-chan scan.Packet, pullPktCh <-chan scan.Packet) {
 	// loop until all input channels are closed
 	defer d.obs.Release()
 	if d.rc != nil {
@@ -224,7 +224,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 		// give a warning if we haven't received a timestamp by the time this fires
 		firstTsDeadline = time.After(time.Second * 2)
 	}
-	if spCh != nil {
+	if ppsCh != nil {
 		// Adaptive polling can take several seconds to acquire a narrow pulse.
 		// Allow comfortably more before warning.
 		firstSysPulseDeadline = time.After(sysPulseFirstEdgeTimeout)
@@ -239,7 +239,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 	staleEra := ts.StaleEra
 	nSkipped := 0
 
-	for tsCh != nil || spCh != nil || pktCh != nil || pullPktCh != nil {
+	for tsCh != nil || ppsCh != nil || pktCh != nil || pullPktCh != nil {
 		select {
 		case e, ok := <-tsCh:
 			if !ok {
@@ -271,7 +271,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 				}
 				d.timestamp(e)
 			}
-		case ce, ok := <-spCh:
+		case ce, ok := <-ppsCh:
 			if ok {
 				// Any candidate, settled or not, proves the pin is wired and
 				// pulsing, which is all this warning is about.
@@ -279,7 +279,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 				d.sysPulseCandidateEdge(ce)
 			} else {
 				lg.Debug("serial PPS channel of event dispatcher goroutine was closed")
-				spCh = nil
+				ppsCh = nil
 				firstSysPulseDeadline = nil
 			}
 
@@ -328,10 +328,10 @@ func (d *Dispatcher) sysPulseCandidateEdge(ce pps.CandidateEdge) {
 }
 
 func (d *Dispatcher) sysPulseSample(edge pps.Edge) {
-	if d.spGen == nil {
+	if d.ppsGen == nil {
 		panic("serial PPS edge channel wired without a Generator")
 	}
-	sample, ok := d.spGen.Sample(edge)
+	sample, ok := d.ppsGen.Sample(edge)
 	if !ok {
 		return
 	}

--- a/time/internal/gpsevent/dispatcher.go
+++ b/time/internal/gpsevent/dispatcher.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/jclark/satpulse/gps/app/gpsio"
 	"github.com/jclark/satpulse/gps/app/logfile"
-	"github.com/jclark/satpulse/gps/app/serialpps"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/app/stream"
 	"github.com/jclark/satpulse/gps/gpsprot"
 	"github.com/jclark/satpulse/gps/nmeasyn"
@@ -107,7 +107,7 @@ type Dispatcher struct {
 	shm                   SHMWriter
 	sps                   samplePrecisionSetter
 	timeMsgBuffer         *timemsg.Buffer
-	spGen                 *serialpps.Generator
+	spGen                 *pps.Generator
 	timeTicker            gpsprot.TimeTicker
 	pvAccum               gpsprot.PVMsgAccum
 	ls                    ptime.LeapSecond
@@ -127,7 +127,7 @@ func NewDispatcher(
 	controller *phcsync.Controller,
 	rc *refclock.ProxyRefClock,
 	shm SHMWriter,
-	spGen *serialpps.Generator,
+	spGen *pps.Generator,
 	ls ptime.LeapSecond,
 	obs obs.Observer,
 	eventLogPath string,
@@ -194,7 +194,7 @@ const (
 	serialPPSMaxUncertainty   = time.Millisecond
 )
 
-func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan serialpps.CandidateEdge, pktCh <-chan scan.Packet, pullPktCh <-chan scan.Packet) {
+func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pktCh <-chan scan.Packet, pullPktCh <-chan scan.Packet) {
 	// loop until all input channels are closed
 	defer d.obs.Release()
 	if d.rc != nil {
@@ -312,7 +312,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan serialpps.CandidateEd
 	}
 }
 
-func (d *Dispatcher) serialPPSCandidateEdge(ce serialpps.CandidateEdge) {
+func (d *Dispatcher) serialPPSCandidateEdge(ce pps.CandidateEdge) {
 	d.logEvent(LogEvent{
 		Type: sysPulseEdgeType,
 		T:    ce.TRead,
@@ -327,7 +327,7 @@ func (d *Dispatcher) serialPPSCandidateEdge(ce serialpps.CandidateEdge) {
 	}
 }
 
-func (d *Dispatcher) serialPPSEdge(edge serialpps.Edge) {
+func (d *Dispatcher) serialPPSEdge(edge pps.Edge) {
 	if d.spGen == nil {
 		panic("serial PPS edge channel wired without a Generator")
 	}

--- a/time/internal/gpsevent/dispatcher.go
+++ b/time/internal/gpsevent/dispatcher.go
@@ -189,9 +189,9 @@ func NewDispatcher(
 }
 
 const (
-	tickPeriod                = time.Second / 4
-	serialPPSFirstEdgeTimeout = 30 * time.Second
-	serialPPSMaxUncertainty   = time.Millisecond
+	tickPeriod               = time.Second / 4
+	sysPulseFirstEdgeTimeout = 30 * time.Second
+	sysPulseMaxUncertainty   = time.Millisecond
 )
 
 func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pktCh <-chan scan.Packet, pullPktCh <-chan scan.Packet) {
@@ -214,7 +214,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 	var ticker *time.Ticker
 	var tickerCh <-chan time.Time
 	var firstTsDeadline <-chan time.Time
-	var firstSerialPPSDeadline <-chan time.Time
+	var firstSysPulseDeadline <-chan time.Time
 	if d.controller != nil {
 		ticker = time.NewTicker(tickPeriod)
 		defer ticker.Stop()
@@ -227,7 +227,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 	if spCh != nil {
 		// Adaptive polling can take several seconds to acquire a narrow pulse.
 		// Allow comfortably more before warning.
-		firstSerialPPSDeadline = time.After(serialPPSFirstEdgeTimeout)
+		firstSysPulseDeadline = time.After(sysPulseFirstEdgeTimeout)
 	}
 	// Use SIGHUP as a signal to reopen the log file (e.g. after log rotation)
 	sig := make(chan os.Signal, 1)
@@ -275,12 +275,12 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 			if ok {
 				// Any candidate, settled or not, proves the pin is wired and
 				// pulsing, which is all this warning is about.
-				firstSerialPPSDeadline = nil
-				d.serialPPSCandidateEdge(ce)
+				firstSysPulseDeadline = nil
+				d.sysPulseCandidateEdge(ce)
 			} else {
 				lg.Debug("serial PPS channel of event dispatcher goroutine was closed")
 				spCh = nil
-				firstSerialPPSDeadline = nil
+				firstSysPulseDeadline = nil
 			}
 
 		case pkt, ok := <-pktCh:
@@ -302,9 +302,9 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 		case <-firstTsDeadline:
 			lg.Warn("no PTP hardware clock external timestamps being received")
 			firstTsDeadline = nil
-		case <-firstSerialPPSDeadline:
+		case <-firstSysPulseDeadline:
 			lg.Warn("no serial PPS edges are being received; check pps.pin in the [serial] table, PPS wiring, and receiver pulse width")
-			firstSerialPPSDeadline = nil
+			firstSysPulseDeadline = nil
 		case <-sig:
 			d.obs.ReopenLog()
 			d.lf.Reopen(d.lg)
@@ -312,7 +312,7 @@ func (d *Dispatcher) Run(tsCh <-chan ts.Event, spCh <-chan pps.CandidateEdge, pk
 	}
 }
 
-func (d *Dispatcher) serialPPSCandidateEdge(ce pps.CandidateEdge) {
+func (d *Dispatcher) sysPulseCandidateEdge(ce pps.CandidateEdge) {
 	d.logEvent(LogEvent{
 		Type: sysPulseEdgeType,
 		T:    ce.TRead,
@@ -322,12 +322,12 @@ func (d *Dispatcher) serialPPSCandidateEdge(ce pps.CandidateEdge) {
 			Settled:     ce.Settled,
 		},
 	})
-	if ce.Uncertainty <= serialPPSMaxUncertainty || ce.Settled {
-		d.serialPPSEdge(ce.Edge)
+	if ce.Uncertainty <= sysPulseMaxUncertainty || ce.Settled {
+		d.sysPulseSample(ce.Edge)
 	}
 }
 
-func (d *Dispatcher) serialPPSEdge(edge pps.Edge) {
+func (d *Dispatcher) sysPulseSample(edge pps.Edge) {
 	if d.spGen == nil {
 		panic("serial PPS edge channel wired without a Generator")
 	}

--- a/time/internal/gpsevent/dispatcher_test.go
+++ b/time/internal/gpsevent/dispatcher_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jclark/satpulse/gps/app/serialpps"
+	"github.com/jclark/satpulse/gps/app/pps"
 	"github.com/jclark/satpulse/gps/app/stream"
 	"github.com/jclark/satpulse/gps/gpsprot"
 	"github.com/jclark/satpulse/gps/gpsreg"
@@ -283,7 +283,7 @@ func TestDispatcherMsgUTCTimeWritesBothSinks(t *testing.T) {
 func TestDispatcherSerialPPSCandidateWritesAcceptableSamples(t *testing.T) {
 	shm := &fakeSHM{precision: -9}
 	observer := &ntpSampleObserver{}
-	g := serialpps.NewGenerator(serialpps.DefaultConfig())
+	g := pps.NewGenerator(pps.DefaultGeneratorConfig())
 	d := &Dispatcher{
 		spGen: g,
 		shm:   shm,
@@ -294,19 +294,19 @@ func TestDispatcherSerialPPSCandidateWritesAcceptableSamples(t *testing.T) {
 	msgRead := time.Unix(900, 125_000_000)
 	g.MsgUTCTime(msgUTC, msgRead, ptime.LeapSecondPositive)
 	edge := time.Unix(900, 1_000_000)
-	d.serialPPSCandidateEdge(serialpps.CandidateEdge{
-		Edge:        serialpps.Edge{Timestamp: edge, TRead: edge},
+	d.serialPPSCandidateEdge(pps.CandidateEdge{
+		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
 		Uncertainty: serialPPSMaxUncertainty + time.Nanosecond,
 	})
 	if len(shm.writes) != 0 {
 		t.Fatalf("inaccurate unsettled candidate produced %d SHM writes, want none", len(shm.writes))
 	}
-	d.serialPPSCandidateEdge(serialpps.CandidateEdge{
-		Edge:        serialpps.Edge{Timestamp: edge, TRead: edge},
+	d.serialPPSCandidateEdge(pps.CandidateEdge{
+		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
 		Uncertainty: serialPPSMaxUncertainty,
 	})
-	d.serialPPSCandidateEdge(serialpps.CandidateEdge{
-		Edge:        serialpps.Edge{Timestamp: edge, TRead: edge},
+	d.serialPPSCandidateEdge(pps.CandidateEdge{
+		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
 		Uncertainty: serialPPSMaxUncertainty + time.Nanosecond,
 		Settled:     true,
 	})

--- a/time/internal/gpsevent/dispatcher_test.go
+++ b/time/internal/gpsevent/dispatcher_test.go
@@ -280,7 +280,7 @@ func TestDispatcherMsgUTCTimeWritesBothSinks(t *testing.T) {
 	}
 }
 
-func TestDispatcherSerialPPSCandidateWritesAcceptableSamples(t *testing.T) {
+func TestDispatcherSysPulseCandidateWritesAcceptableSamples(t *testing.T) {
 	shm := &fakeSHM{precision: -9}
 	observer := &ntpSampleObserver{}
 	g := pps.NewGenerator(pps.DefaultGeneratorConfig())
@@ -294,20 +294,20 @@ func TestDispatcherSerialPPSCandidateWritesAcceptableSamples(t *testing.T) {
 	msgRead := time.Unix(900, 125_000_000)
 	g.MsgUTCTime(msgUTC, msgRead, ptime.LeapSecondPositive)
 	edge := time.Unix(900, 1_000_000)
-	d.serialPPSCandidateEdge(pps.CandidateEdge{
+	d.sysPulseCandidateEdge(pps.CandidateEdge{
 		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
-		Uncertainty: serialPPSMaxUncertainty + time.Nanosecond,
+		Uncertainty: sysPulseMaxUncertainty + time.Nanosecond,
 	})
 	if len(shm.writes) != 0 {
 		t.Fatalf("inaccurate unsettled candidate produced %d SHM writes, want none", len(shm.writes))
 	}
-	d.serialPPSCandidateEdge(pps.CandidateEdge{
+	d.sysPulseCandidateEdge(pps.CandidateEdge{
 		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
-		Uncertainty: serialPPSMaxUncertainty,
+		Uncertainty: sysPulseMaxUncertainty,
 	})
-	d.serialPPSCandidateEdge(pps.CandidateEdge{
+	d.sysPulseCandidateEdge(pps.CandidateEdge{
 		Edge:        pps.Edge{Timestamp: edge, TRead: edge},
-		Uncertainty: serialPPSMaxUncertainty + time.Nanosecond,
+		Uncertainty: sysPulseMaxUncertainty + time.Nanosecond,
 		Settled:     true,
 	})
 

--- a/time/internal/gpsevent/dispatcher_test.go
+++ b/time/internal/gpsevent/dispatcher_test.go
@@ -285,7 +285,7 @@ func TestDispatcherSysPulseCandidateWritesAcceptableSamples(t *testing.T) {
 	observer := &ntpSampleObserver{}
 	g := pps.NewGenerator(pps.DefaultGeneratorConfig())
 	d := &Dispatcher{
-		spGen: g,
+		ppsGen: g,
 		shm:   shm,
 		obs:   observer,
 		lg:    slog.New(slog.NewTextHandler(io.Discard, nil)),


### PR DESCRIPTION
serialpps mixed two things: reading a serial port's modem-control pins, and the parts that do not care where a pulse comes from, namely the edge types, the adaptive polling loop that finds a pulse on a pin whose level can only be read, and the generator that labels an edge with a UTC second from the receiver's time messages. A GPIO pulse source (#460, plan/gpio-poll.md) needs the second group but not the first.

This moves the source-neutral parts into a new package `gps/app/pps`: `Edge`, `CandidateEdge`, `Sample`, `Generator`, `PollStats`, and the poller, exported as `Poll`. `Poll` takes an in-pulse reader and a `PollParams` struct for the number of polls per window, the minimum spacing and the sleep mechanism, which were fixed at values suited to serial modem-status queries; the zero value selects those values. `GeneratorConfig` holds `delayUncertainty` and `maxDelay` and validates the `delayUncertainty + maxDelay < 1` rule that `Generator.Sample` relies on.

serialpps keeps `Config`, `Detect`, `Wait`, `Wiring`, `Polarity` and its reader interfaces under their current names, embeds `GeneratorConfig` in `Config` so the `[sample.serial.pps]` keys are unchanged, and passes a zero `PollParams` with its pre-warm. To keep the embedded struct's fields named as before in validation messages, `check.Validate` names the fields of an untagged embedded struct as the embedding struct's own, as the TOML decoder does. The daemon, the dispatcher and serialcmd use the new package; the dispatcher's Generator field, candidate channel, acceptance gate and first-edge warning, previously named for serial PPS, are named `ppsGen`, `ppsCh` and `sysPulse*` after the `sysPulseEdge` event they produce.

No log, error or output text changes. No behaviour change. This prepares for #460; the GPIO source follows in a PR stacked on this one.